### PR TITLE
Prepend `isEnabledFor` to logger calls

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -14,6 +14,8 @@ exclude_lines =
     if __name__ == .__main__.:
     # Exclude type checking lines
     if TYPE_CHECKING:
+    # Exclude log messages
+    if logger.isEnabledFor
 ignore_errors = True
 omit =
     streamflow/__main__.py

--- a/streamflow/config/config.py
+++ b/streamflow/config/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from pathlib import PurePosixPath
 from typing import MutableSequence, TYPE_CHECKING
 
@@ -40,10 +41,11 @@ class WorkflowConfig(Config):
         if not self.deplyoments:
             self.deplyoments = config.get("models", {})
             if self.deplyoments:
-                logger.warn(
-                    "The `models` keyword is deprecated and will be removed in StreamFlow 0.3.0. "
-                    "Use `deployments` instead."
-                )
+                if logger.isEnabledFor(logging.WARN):
+                    logger.warn(
+                        "The `models` keyword is deprecated and will be removed in StreamFlow 0.3.0. "
+                        "Use `deployments` instead."
+                    )
         self.scheduling_groups: MutableMapping[str, MutableSequence[str]] = {}
         for name, deployment in self.deplyoments.items():
             deployment["name"] = name

--- a/streamflow/cwl/command.py
+++ b/streamflow/cwl/command.py
@@ -765,8 +765,9 @@ class CWLCommand(CWLBaseCommand):
             status = Status.FAILED
         elif (self.success_codes and exit_code in self.success_codes) or exit_code == 0:
             status = Status.COMPLETED
-            if result:
-                logger.info(result)
+            if logger.isEnabledFor(logging.INFO):
+                if result:
+                    logger.info(result)
         else:
             status = Status.FAILED
         # Update command persistence
@@ -1042,11 +1043,12 @@ class CWLExpressionCommand(CWLBaseCommand):
         )
         if self.initial_work_dir is not None:
             await self._prepare_work_dir(job, context, self.initial_work_dir)
-        logger.info(
-            "Evaluating expression for step {step} (job {job})".format(
-                step=self.step.name, job=job.name
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(
+                "Evaluating expression for step {step} (job {job})".format(
+                    step=self.step.name, job=job.name
+                )
             )
-        )
         # Persist command
         command_id = await self.step.workflow.context.database.add_command(
             self.step.persistent_id, self.expression
@@ -1103,7 +1105,8 @@ class CWLStepCommand(CWLBaseCommand):
             tmp_directory=job.tmp_directory,
             hardware=self.step.workflow.context.scheduler.get_hardware(job.name),
         )
-        logger.info("EXECUTING job {job}".format(job=job.name))
+        if logger.isEnabledFor(logging.INFO):
+            logger.info("EXECUTING job {job}".format(job=job.name))
         # Process expressions
         processed_inputs = {}
         for k, v in self.input_expressions.items():

--- a/streamflow/cwl/main.py
+++ b/streamflow/cwl/main.py
@@ -74,7 +74,8 @@ async def main(
     else:
         cwl_inputs = {}
     # Transpile CWL workflow to the StreamFlow representation
-    logger.info("Processing workflow {}".format(args.name))
+    if logger.isEnabledFor(logging.INFO):
+        logger.info("Processing workflow {}".format(args.name))
     translator = CWLTranslator(
         context=context,
         name=args.name,
@@ -84,14 +85,18 @@ async def main(
         workflow_config=workflow_config,
         loading_context=loading_context,
     )
-    logger.info("Building workflow execution plan")
+    if logger.isEnabledFor(logging.INFO):
+        logger.info("Building workflow execution plan")
     workflow = translator.translate()
     if getattr(args, "validate", False):
         return
     await workflow.save(context)
-    logger.info("COMPLETED Building of workflow execution plan")
+    if logger.isEnabledFor(logging.INFO):
+        logger.info("COMPLETED Building of workflow execution plan")
     executor = StreamFlowExecutor(workflow)
-    logger.info("Running workflow {}".format(args.name))
+    if logger.isEnabledFor(logging.INFO):
+        logger.info("Running workflow {}".format(args.name))
     output_tokens = await executor.run()
-    logger.info("COMPLETED Workflow execution")
+    if logger.isEnabledFor(logging.INFO):
+        logger.info("COMPLETED Workflow execution")
     print(json.dumps(output_tokens, sort_keys=True, indent=4))

--- a/streamflow/cwl/step.py
+++ b/streamflow/cwl/step.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import urllib.parse
 from abc import ABC
 from typing import Any, MutableMapping, MutableSequence, Optional
@@ -132,22 +133,24 @@ class CWLLoopConditionalStep(CWLConditionalStep):
                 "Conditional 'when' must evaluate to 'true' or 'false'"
             )
 
-    async def _on_true(self, inputs: MutableMapping[str, Token]):
-        logger.debug(
-            "Step {} condition evaluated true on inputs {}".format(
-                self.name, [t.tag for t in inputs.values()]
+    async def _on_true(self, inputs: MutableMapping[str, Token]) -> None:
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "Step {} condition evaluated true on inputs {}".format(
+                    self.name, [t.tag for t in inputs.values()]
+                )
             )
-        )
         # Next iteration: propagate outputs to the loop
         for port_name, port in self.get_output_ports().items():
             port.put(inputs[port_name])
 
-    async def _on_false(self, inputs: MutableMapping[str, Token]):
-        logger.debug(
-            "Step {} condition evaluated false on inputs {}".format(
-                self.name, [t.tag for t in inputs.values()]
+    async def _on_false(self, inputs: MutableMapping[str, Token]) -> None:
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "Step {} condition evaluated false on inputs {}".format(
+                    self.name, [t.tag for t in inputs.values()]
+                )
             )
-        )
         # Loop termination: propagate outputs outside the loop
         for port_name, port in self.get_skip_ports().items():
             port.put(IterationTerminationToken(tag=get_tag(inputs.values())))

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import logging
 import os
 import posixpath
 import tempfile
@@ -1299,18 +1300,20 @@ class CWLTranslator(object):
                     target_deployment = self.workflow_config.deplyoments[
                         target["model"]
                     ]
-                    logger.warn(
-                        "The `model` keyword is deprecated and will be removed in StreamFlow 0.3.0. "
-                        "Use `deployment` instead."
-                    )
+                    if logger.isEnabledFor(logging.WARN):
+                        logger.warn(
+                            "The `model` keyword is deprecated and will be removed in StreamFlow 0.3.0. "
+                            "Use `deployment` instead."
+                        )
                 locations = target.get("locations", None)
                 if locations is None:
                     locations = target.get("resources")
                     if locations is not None:
-                        logger.warn(
-                            "The `resources` keyword is deprecated and will be removed in StreamFlow 0.3.0. "
-                            "Use `locations` instead."
-                        )
+                        if logger.isEnabledFor(logging.WARN):
+                            logger.warn(
+                                "The `resources` keyword is deprecated and will be removed in StreamFlow 0.3.0. "
+                                "Use `locations` instead."
+                            )
                     else:
                         locations = 1
                 deployment = DeploymentConfig(
@@ -1522,9 +1525,10 @@ class CWLTranslator(object):
         name_prefix: str,
         cwl_name_prefix: str,
     ):
-        logger.debug(
-            "Translating {} {}".format(cwl_element.__class__.__name__, name_prefix)
-        )
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "Translating {} {}".format(cwl_element.__class__.__name__, name_prefix)
+            )
         # Extract custom types if present
         requirements = {**context["hints"], **context["requirements"]}
         schema_def_types = _get_schema_def_types(requirements)
@@ -1706,7 +1710,8 @@ class CWLTranslator(object):
         cwl_name_prefix: str,
     ):
         step_name = name_prefix
-        logger.debug("Translating Workflow {}".format(step_name))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("Translating Workflow {}".format(step_name))
         # Extract custom types if present
         requirements = {**context["hints"], **context["requirements"]}
         schema_def_types = _get_schema_def_types(requirements)
@@ -1865,7 +1870,8 @@ class CWLTranslator(object):
     ):
         # Process content
         step_name = _get_name(name_prefix, cwl_name_prefix, cwl_element.id)
-        logger.debug("Translating WorkflowStep {}".format(step_name))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("Translating WorkflowStep {}".format(step_name))
         cwl_step_name = _get_name(
             name_prefix, cwl_name_prefix, cwl_element.id, preserve_cwl_prefix=True
         )

--- a/streamflow/cwl/utils.py
+++ b/streamflow/cwl/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import urllib.parse
 from enum import Enum
 from types import ModuleType
@@ -987,16 +988,17 @@ async def write_remote_file(
         connector = context.deployment_manager.get_connector(location.deployment)
         path_processor = get_path_processor(connector)
         if not await remotepath.exists(connector, location, path):
-            logger.info(
-                "Creating {path} {location}".format(
-                    path=path,
-                    location=(
-                        "on local file-system"
-                        if isinstance(connector, LocalConnector)
-                        else "on location {res}".format(res=location)
-                    ),
+            if logger.isEnabledFor(logging.INFO):
+                logger.info(
+                    "Creating {path} {location}".format(
+                        path=path,
+                        location=(
+                            "on local file-system"
+                            if isinstance(connector, LocalConnector)
+                            else "on location {res}".format(res=location)
+                        ),
+                    )
                 )
-            )
             await remotepath.write(connector, location, path, content)
             context.data_manager.register_path(
                 location=location,

--- a/streamflow/deployment/connector/container.py
+++ b/streamflow/deployment/connector/container.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import os
 import posixpath
 import shlex
@@ -55,20 +56,22 @@ class ContainerConnector(BaseConnector, ABC):
         if cacheSize is None:
             cacheSize = resourcesCacheSize
             if cacheSize is not None:
-                logger.warn(
-                    "The `resourcesCacheSize` keyword is deprecated and will be removed in StreamFlow 0.3.0. "
-                    "Use `locationsCacheSize` instead."
-                )
+                if logger.isEnabledFor(logging.WARN):
+                    logger.warn(
+                        "The `resourcesCacheSize` keyword is deprecated and will be removed in StreamFlow 0.3.0. "
+                        "Use `locationsCacheSize` instead."
+                    )
             else:
                 cacheSize = 10
         cacheTTL = locationsCacheTTL
         if cacheTTL is None:
             cacheTTL = resourcesCacheTTL
             if cacheTTL is not None:
-                logger.warn(
-                    "The `resourcesCacheTTL` keyword is deprecated and will be removed in StreamFlow 0.3.0. "
-                    "Use `locationsCacheTTL` instead."
-                )
+                if logger.isEnabledFor(logging.WARN):
+                    logger.warn(
+                        "The `resourcesCacheTTL` keyword is deprecated and will be removed in StreamFlow 0.3.0. "
+                        "Use `locationsCacheTTL` instead."
+                    )
             else:
                 cacheTTL = 10
         self.locationsCache: Cache = TTLCache(maxsize=cacheSize, ttl=cacheTTL)
@@ -594,7 +597,8 @@ class DockerConnector(DockerBaseConnector):
                         self.image,
                     ]
                 )
-                logger.debug("EXECUTING command {}".format(deploy_command))
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug("EXECUTING command {}".format(deploy_command))
                 proc = await asyncio.create_subprocess_exec(
                     *shlex.split(deploy_command),
                     stdout=asyncio.subprocess.PIPE,
@@ -629,9 +633,10 @@ class DockerConnector(DockerBaseConnector):
         if not external and self.containerIds:
             for container_id in self.containerIds:
                 undeploy_command = "".join(["docker ", "stop ", container_id])
-                logger.debug(
-                    "EXECUTING command {command}".format(command=undeploy_command)
-                )
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        "EXECUTING command {command}".format(command=undeploy_command)
+                    )
                 proc = await asyncio.create_subprocess_exec(
                     *shlex.split(undeploy_command),
                     stdout=asyncio.subprocess.PIPE,
@@ -747,7 +752,8 @@ class DockerComposeConnector(DockerBaseConnector):
                     self.get_option("no-start", self.noStart),
                 ]
             )
-            logger.debug("EXECUTING command {}".format(deploy_command))
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug("EXECUTING command {}".format(deploy_command))
             proc = await asyncio.create_subprocess_exec(*shlex.split(deploy_command))
             await proc.wait()
 
@@ -760,7 +766,8 @@ class DockerComposeConnector(DockerBaseConnector):
         tmp_directory: Optional[str] = None,
     ) -> MutableMapping[str, AvailableLocation]:
         ps_command = self.base_command() + "".join(["ps ", service or ""])
-        logger.debug("EXECUTING command {command}".format(command=ps_command))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("EXECUTING command {command}".format(command=ps_command))
         proc = await asyncio.create_subprocess_exec(
             *shlex.split(ps_command),
             stdout=asyncio.subprocess.PIPE,
@@ -788,7 +795,10 @@ class DockerComposeConnector(DockerBaseConnector):
             undeploy_command = self.base_command() + "".join(
                 ["down ", "{removeVolumes}"]
             ).format(removeVolumes=self.get_option("volumes", self.removeVolumes))
-            logger.debug("EXECUTING command {command}".format(command=undeploy_command))
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "EXECUTING command {command}".format(command=undeploy_command)
+                )
             proc = await asyncio.create_subprocess_exec(*shlex.split(undeploy_command))
             await proc.wait()
 
@@ -1004,7 +1014,8 @@ class SingularityConnector(SingularityBaseConnector):
                         instance_name,
                     ]
                 )
-                logger.debug("EXECUTING command {}".format(deploy_command))
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug("EXECUTING command {}".format(deploy_command))
                 proc = await asyncio.create_subprocess_exec(
                     *shlex.split(deploy_command),
                     stdout=asyncio.subprocess.PIPE,
@@ -1049,9 +1060,10 @@ class SingularityConnector(SingularityBaseConnector):
                 undeploy_command = "".join(
                     ["singularity ", "instance ", "stop ", instance_name]
                 )
-                logger.debug(
-                    "EXECUTING command {command}".format(command=undeploy_command)
-                )
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        "EXECUTING command {command}".format(command=undeploy_command)
+                    )
                 proc = await asyncio.create_subprocess_exec(
                     *shlex.split(undeploy_command),
                     stdout=asyncio.subprocess.PIPE,

--- a/streamflow/deployment/connector/occam.py
+++ b/streamflow/deployment/connector/occam.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 import posixpath
 import re
@@ -289,7 +290,8 @@ class OccamConnector(SSHConnector):
                 " ".join(service.get("command", "")),
             ]
         )
-        logger.debug("EXECUTING {command}".format(command=deploy_command))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("EXECUTING {command}".format(command=deploy_command))
         async with self._get_ssh_client(name) as ssh_client:
             result = await ssh_client.run(deploy_command)
         output = result.stdout
@@ -300,20 +302,23 @@ class OccamConnector(SSHConnector):
             if name not in self.jobs_table:
                 self.jobs_table[name] = []
             self.jobs_table[name].append(search_result[0])
-            logger.info(
-                "Deployed {name} on {location}".format(
-                    name=name, location=search_result[0]
+            if logger.isEnabledFor(logging.INFO):
+                logger.info(
+                    "Deployed {name} on {location}".format(
+                        name=name, location=search_result[0]
+                    )
                 )
-            )
         else:
             raise Exception
 
     async def _undeploy_node(self, name: str, job_id: str):
         undeploy_command = "".join(["occam-kill ", "{job_id}"]).format(job_id=job_id)
-        logger.debug("EXECUTING {command}".format(command=undeploy_command))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("EXECUTING {command}".format(command=undeploy_command))
         async with self._get_ssh_client(name) as ssh_client:
             await ssh_client.run(undeploy_command)
-        logger.info("Killed {location}".format(location=job_id))
+        if logger.isEnabledFor(logging.INFO):
+            logger.info("Killed {location}".format(location=job_id))
 
     async def deploy(self, external: bool) -> None:
         await super().deploy(external)

--- a/streamflow/deployment/connector/queue_manager.py
+++ b/streamflow/deployment/connector/queue_manager.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import logging
 import os
 import shlex
 from abc import ABC, abstractmethod
@@ -142,13 +143,14 @@ class QueueManagerConnector(SSHConnector, ABC):
             command = utils.create_command(
                 command=command, environment=environment, workdir=workdir
             )
-            logger.debug(
-                "EXECUTING command {command} on {location} {job}".format(
-                    command=command,
-                    location=location,
-                    job="for job {job}".format(job=job_name) if job_name else "",
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "EXECUTING command {command} on {location} {job}".format(
+                        command=command,
+                        location=location,
+                        job="for job {job}".format(job=job_name) if job_name else "",
+                    )
                 )
-            )
             command = utils.encode_command(command)
             command = self._get_command_from_template(
                 command=command,
@@ -166,11 +168,12 @@ class QueueManagerConnector(SSHConnector, ABC):
                 stderr=stderr,
                 timeout=timeout,
             )
-            logger.info(
-                "Scheduled job {job} with job id {job_id}".format(
-                    job=job_name, job_id=job_id
+            if logger.isEnabledFor(logging.INFO):
+                logger.info(
+                    "Scheduled job {job} with job id {job_id}".format(
+                        job=job_name, job_id=job_id
+                    )
                 )
-            )
             self.scheduledJobs.append(job_id)
             async with self.jobsCacheLock:
                 self.jobsCache.clear()

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import logging
 import os
 import posixpath
 import tarfile
@@ -239,13 +240,14 @@ class SSHConnector(BaseConnector):
             stdout=stdout,
             stderr=stderr,
         )
-        logger.debug(
-            "EXECUTING command {command} on {location} {job}".format(
-                command=command,
-                location=location,
-                job="for job {job}".format(job=job_name) if job_name else "",
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "EXECUTING command {command} on {location} {job}".format(
+                    command=command,
+                    location=location,
+                    job="for job {job}".format(job=job_name) if job_name else "",
+                )
             )
-        )
         return utils.encode_command(command)
 
     def __init__(
@@ -274,10 +276,11 @@ class SSHConnector(BaseConnector):
         )
         self.templates: MutableMapping[str, Template] = {}
         if file is not None:
-            logger.warn(
-                "The `file` keyword is deprecated and will be removed in StreamFlow 0.3.0. "
-                "Use `services` instead."
-            )
+            if logger.isEnabledFor(logging.WARN):
+                logger.warn(
+                    "The `file` keyword is deprecated and will be removed in StreamFlow 0.3.0. "
+                    "Use `services` instead."
+                )
             with open(os.path.join(self.config_dir, file)) as f:
                 self.templates["__DEFAULT__"] = Template(f.read())
         else:

--- a/streamflow/deployment/deployment_manager.py
+++ b/streamflow/deployment/deployment_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 from typing import TYPE_CHECKING
 
@@ -49,13 +50,15 @@ class DefaultDeploymentManager(DeploymentManager):
                         deployment_name, self.context, **deployment_config.config
                     )
                     self.deployments_map[deployment_name] = connector
-                    if not deployment_config.external:
-                        logger.info("DEPLOYING {}".format(deployment_name))
+                    if logger.isEnabledFor(logging.INFO):
+                        if not deployment_config.external:
+                            logger.info("DEPLOYING {}".format(deployment_name))
                     await connector.deploy(deployment_config.external)
-                    if not deployment_config.external:
-                        logger.info(
-                            "COMPLETED Deployment of {}".format(deployment_name)
-                        )
+                    if logger.isEnabledFor(logging.INFO):
+                        if not deployment_config.external:
+                            logger.info(
+                                "COMPLETED Deployment of {}".format(deployment_name)
+                            )
                     self.events_map[deployment_name].set()
                     break
             else:
@@ -81,13 +84,15 @@ class DefaultDeploymentManager(DeploymentManager):
             self.events_map[deployment_name].clear()
             connector = self.deployments_map[deployment_name]
             config = self.config_map[deployment_name]
-            if not config.external:
-                logger.info(
-                    "UNDEPLOYING {deployment}".format(deployment=deployment_name)
-                )
+            if logger.isEnabledFor(logging.INFO):
+                if not config.external:
+                    logger.info(
+                        "UNDEPLOYING {deployment}".format(deployment=deployment_name)
+                    )
             await connector.undeploy(config.external)
-            if not config.external:
-                logger.info("COMPLETED Undeployment of {}".format(deployment_name))
+            if logger.isEnabledFor(logging.INFO):
+                if not config.external:
+                    logger.info("COMPLETED Undeployment of {}".format(deployment_name))
             del self.deployments_map[deployment_name]
             del self.config_map[deployment_name]
             self.events_map[deployment_name].set()

--- a/streamflow/deployment/future.py
+++ b/streamflow/deployment/future.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from typing import Any, MutableMapping, MutableSequence, Optional, Tuple, Type, Union
 
 from streamflow.core.deployment import Connector, ConnectorCopyKind, Location
@@ -54,11 +55,13 @@ class FutureConnector(Connector):
     async def deploy(self, external: bool) -> None:
         # noinspection PyArgumentList
         connector = self.type(self.deployment_name, self.config_dir, **self.parameters)
-        if not external:
-            logger.info("DEPLOYING {}".format(self.deployment_name))
+        if logger.isEnabledFor(logging.INFO):
+            if not external:
+                logger.info("DEPLOYING {}".format(self.deployment_name))
         await connector.deploy(external)
-        if not external:
-            logger.info("COMPLETED Deployment of {}".format(self.deployment_name))
+        if logger.isEnabledFor(logging.INFO):
+            if not external:
+                logger.info("COMPLETED Deployment of {}".format(self.deployment_name))
         self.connector = connector
         self.deploy_event.set()
 

--- a/streamflow/ext/plugin.py
+++ b/streamflow/ext/plugin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from typing import MutableMapping, Type
 
@@ -15,11 +16,12 @@ from streamflow.scheduling.policy import policy_classes
 class StreamFlowPlugin(ABC):
     def _register(self, name: str, cls: Type, classes: MutableMapping[str, Type]):
         if name in classes:
-            logger.warning(
-                "{} is already installed and will be overridden by {}".format(
-                    name, self.__class__.__module__ + "." + self.__class__.__name__
+            if logger.isEnabledFor(logging.WARN):
+                logger.warn(
+                    "{} is already installed and will be overridden by {}".format(
+                        name, self.__class__.__module__ + "." + self.__class__.__name__
+                    )
                 )
-            )
         classes[name] = cls
 
     @abstractmethod

--- a/streamflow/ext/utils.py
+++ b/streamflow/ext/utils.py
@@ -1,3 +1,5 @@
+import logging
+
 from importlib_metadata import entry_points
 
 from streamflow.core.exception import InvalidPluginException
@@ -12,11 +14,12 @@ def load_extensions():
         plugin = (plugin.load())()
         if isinstance(plugin, StreamFlowPlugin):
             plugin.register()
-            logger.info(
-                "Successfully registered plugin {}".format(
-                    get_class_fullname(type(plugin))
+            if logger.isEnabledFor(logging.INFO):
+                logger.info(
+                    "Successfully registered plugin {}".format(
+                        get_class_fullname(type(plugin))
+                    )
                 )
-            )
         else:
             raise InvalidPluginException(
                 "StreamFlow plugins must extend the streamflow.ext.StreamFlowPlugin class"

--- a/streamflow/recovery/failure_manager.py
+++ b/streamflow/recovery/failure_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 from typing import MutableMapping, Optional, cast
 
@@ -175,17 +176,19 @@ class DefaultFailureManager(FailureManager):
     async def handle_exception(
         self, job: Job, step: Step, exception: BaseException
     ) -> CommandOutput:
-        logger.info(
-            "Handling {exception} failure for job {job}".format(
-                job=job.name, exception=type(exception).__name__
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(
+                "Handling {exception} failure for job {job}".format(
+                    job=job.name, exception=type(exception).__name__
+                )
             )
-        )
         return await self._do_handle_failure(job, step)
 
     async def handle_failure(
         self, job: Job, step: Step, command_output: CommandOutput
     ) -> CommandOutput:
-        logger.info("Handling command failure for job {job}".format(job=job.name))
+        if logger.isEnabledFor(logging.INFO):
+            logger.info("Handling command failure for job {job}".format(job=job.name))
         return await self._do_handle_failure(job, step)
 
     async def replay_job(self, replay_request: ReplayRequest) -> ReplayResponse:
@@ -200,7 +203,8 @@ class DefaultFailureManager(FailureManager):
                 or self.replay_cache[target_job].version < replay_request.version
             ):
                 # Reschedule job
-                logger.info("Rescheduling job {job}".format(job=target_job))
+                if logger.isEnabledFor(logging.INFO):
+                    logger.info("Rescheduling job {job}".format(job=target_job))
                 command_output = CommandOutput(value=None, status=Status.FAILED)
                 self.replay_cache[target_job] = ReplayResponse(
                     job=target_job,

--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -323,15 +323,16 @@ class DefaultScheduler(Scheduler):
                                 )
                                 job_context.scheduled = True
                                 return
-                    elif logger.isEnabledFor(logging.DEBUG):
-                        logger.debug(
-                            "No location available for job {} on deployment {}.".format(
-                                job_context.job.name,
-                                posixpath.join(deployment, target.service)
-                                if target.service
-                                else deployment,
+                    else:
+                        if logger.isEnabledFor(logging.DEBUG):
+                            logger.debug(
+                                "No location available for job {} on deployment {}.".format(
+                                    job_context.job.name,
+                                    posixpath.join(deployment, target.service)
+                                    if target.service
+                                    else deployment,
+                                )
                             )
-                        )
                 await asyncio.wait_for(
                     self.wait_queues[deployment].wait(), timeout=self.retry_interval
                 )
@@ -353,11 +354,12 @@ class DefaultScheduler(Scheduler):
                     if job_name in self.job_allocations:
                         if status != self.job_allocations[job_name].status:
                             self.job_allocations[job_name].status = status
-                            logger.debug(
-                                "Job {name} changed status to {status}".format(
-                                    name=job_name, status=status.name
+                            if logger.isEnabledFor(logging.DEBUG):
+                                logger.debug(
+                                    "Job {name} changed status to {status}".format(
+                                        name=job_name, status=status.name
+                                    )
                                 )
-                            )
                         if status in [Status.COMPLETED, Status.FAILED]:
                             self.wait_queues[connector.deployment_name].notify_all()
 


### PR DESCRIPTION
This commit always evaluates if a given log level is enabled before evaluating the log string. This can lead to performance improvements when running with the `--quiet` flag, as useless strings are not constructed. Also, test coverage metrics have been disabled for the debug log messages, as tests are never executed in DEBUG mode.