### PR TITLE
Fix scheduler validation path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         "streamflow.deployment.filter": ["schemas/*.json"],
         "streamflow.persistence": ["schemas/*.sql", "schemas/*.json"],
         "streamflow.recovery": ["schemas/*.json"],
+        "streamflow.scheduling": ["schemas/*.json"],
         "streamflow.scheduling.policy": ["schemas/*.json"],
     },
     include_package_data=True,

--- a/streamflow/config/validator.py
+++ b/streamflow/config/validator.py
@@ -16,6 +16,7 @@ from streamflow.deployment.connector import connector_classes
 from streamflow.deployment.filter import binding_filter_classes
 from streamflow.persistence import database_classes
 from streamflow.recovery import checkpoint_manager_classes, failure_manager_classes
+from streamflow.scheduling import scheduler_classes
 from streamflow.scheduling.policy import policy_classes
 
 if TYPE_CHECKING:
@@ -67,6 +68,7 @@ class SfValidator:
         utils.inject_schema(schema, deployment_manager_classes, "deploymentManager")
         utils.inject_schema(schema, failure_manager_classes, "failureManager")
         utils.inject_schema(schema, policy_classes, "policy")
+        utils.inject_schema(schema, scheduler_classes, "scheduler")
         validator = Draft7Validator(schema)
         handle_errors(validator.iter_errors(streamflow_config))
         return streamflow_config


### PR DESCRIPTION
Static validation of scheduler classes was not working for two reasons. First, the `schemas` folder in the `scheduling` package was not loaded in the release archive. Plus, scheduler config files were not loader by the validator prior to check the configuration. This commit fixes both issues.