### PR TITLE
Avoid Sqlite race conditions during tests

### DIFF
--- a/cwl-conformance-test.sh
+++ b/cwl-conformance-test.sh
@@ -70,7 +70,8 @@ TEST_COMMAND="${TEST_COMMAND} --cov --cov-config ${SCRIPT_DIRECTORY}/.coveragerc
 rm -rf "${SCRIPT_DIRECTORY}/.coverage" "${SCRIPT_DIRECTORY}/coverage.xml"
 
 # Run test
-cp "${SCRIPT_DIRECTORY}/tests/cwl-conformance/conftest.py" "$(dirname "${CONFORMANCE_TEST}")/conftest.py"
+cp "${SCRIPT_DIRECTORY}/tests/cwl-conformance/conftest.py" "$(dirname "${CONFORMANCE_TEST}")/"
+cp "${SCRIPT_DIRECTORY}/tests/cwl-conformance/streamflow.yml" "$(dirname "${CONFORMANCE_TEST}")/"
 bash -c "${TEST_COMMAND}"
 RETURN_CODE=$?
 

--- a/streamflow/persistence/sqlite.py
+++ b/streamflow/persistence/sqlite.py
@@ -72,7 +72,8 @@ class SqliteDatabase(CachedDatabase):
     def __init__(self, context: StreamFlowContext, connection: str, timeout: int = 20):
         super().__init__(context)
         # Open connection to database
-        os.makedirs(os.path.dirname(connection), exist_ok=True)
+        if connection != ":memory:":
+            os.makedirs(os.path.dirname(connection), exist_ok=True)
         self.connection: SqliteConnection = SqliteConnection(
             connection=connection,
             timeout=timeout,

--- a/tests/cwl-conformance/conftest.py
+++ b/tests/cwl-conformance/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import json
+import os
 from contextlib import redirect_stdout
 from typing import Any
 
@@ -14,7 +15,14 @@ def pytest_cwl_execute_test(
     from streamflow.core.exception import WorkflowException
     from streamflow.cwl.runner import main
 
-    args = ["--outdir", config.outdir, processfile]
+    this_directory = os.path.abspath(os.path.dirname(__file__))
+    args = [
+        "--streamflow-file",
+        os.path.join(this_directory, "streamflow.yml"),
+        "--outdir",
+        config.outdir,
+        processfile,
+    ]
     if jobfile is not None:
         args.append(jobfile)
 

--- a/tests/cwl-conformance/streamflow.yml
+++ b/tests/cwl-conformance/streamflow.yml
@@ -1,0 +1,5 @@
+version: v1.0
+database:
+  type: default
+  config:
+    connection: ":memory:"


### PR DESCRIPTION
Parallel CWL conformance tests often fail due to a `Database is locked` exception thrown by Sqlite. Indeed, concurrent access to a single Sqlite file is not well supported by the library.

This commit uses a dedicated in-memory Sqlite instance for each test, in order to speed up the overall execution and to avoid race conditions.