### PR TITLE
Stricter type checking for CWL outputs 

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -36,13 +36,13 @@ jobs:
           - commit: "6397014050177074c9ccd0d771577f7fa9f728a3"
             exclude: "docker_entrypoint,stdin_shorcut,inplace_update_on_file_content"
             version: "v1.1"
-          - commit: "ad6f77c648ae9f0eaa2fd53ba7032b0523e12de8"
+          - commit: "5411b8cad173121641b23ba9a0da2cf36e6df2d6"
             exclude: "docker_entrypoint,modify_file_content"
             version: "v1.2"
           - on: "macos-12"
             python: "3.11"
-            commit: "ad6f77c648ae9f0eaa2fd53ba7032b0523e12de8"
-            exclude: "docker_entrypoint,modify_file_content,step_input_default_value_noexp,step_input_default_value_overriden_noexp,nested_workflow_noexp,step_input_default_value_overriden_2nd_step_noexp,step_input_default_value_overriden_2nd_step_null_noexp"
+            commit: "5411b8cad173121641b23ba9a0da2cf36e6df2d6"
+            exclude: "docker_entrypoint,modify_file_content"
             version: "v1.2"
     runs-on: ${{ matrix.on }}
     steps:

--- a/streamflow/cwl/utils.py
+++ b/streamflow/cwl/utils.py
@@ -387,39 +387,6 @@ async def build_token_value(
     return token_value
 
 
-def check_token_type(
-    name: str,
-    token_value: Any,
-    token_type: str,
-    enum_symbols: MutableSequence[str] | None,
-    optional: bool,
-):
-    if isinstance(token_value, Token):
-        check_token_type(name, token_value.value, token_type, enum_symbols, optional)
-    elif token_type == "Any":  # nosec
-        if token_value is None:
-            raise WorkflowExecutionException(
-                f"Token {name} is of type `Any`: it cannot be null."
-            )
-    elif token_type == "null":  # nosec
-        if token_value is not None:
-            raise WorkflowExecutionException(f"Token {name} should be null.")
-    elif token_value is None:
-        if not optional:
-            raise WorkflowExecutionException(f"Token {name} is not optional.")
-    elif token_type == "enum":  # nosec
-        if token_value not in enum_symbols:
-            raise WorkflowExecutionException(
-                f"Value {token_value} is not valid for token {name}."
-            )
-    elif (inferred_type := infer_type_from_token(token_value)) != token_type:
-        # In CWL, long is considered as a subtype of double
-        if inferred_type != "long" or token_type != "double":  # nosec
-            raise WorkflowExecutionException(
-                f"Expected {name} token of type {token_type}, got {inferred_type}."
-            )
-
-
 def eval_expression(
     expression: str,
     context: MutableMapping[str, Any],


### PR DESCRIPTION
This commit enforces a stricter type checking on `ExecuteStep` output, as required by the CWL standard. Plus, it reduces the number of generated `CommandOutputProcessor` objects, avoiding redundancy.