### PR TITLE
Fix CWL map processors behaviour

### DIFF
--- a/streamflow/cwl/command.py
+++ b/streamflow/cwl/command.py
@@ -146,7 +146,10 @@ def _check_command_token(command_token: CWLCommandToken, input_value: Any) -> bo
     # CWLMapCommandToken is suitable for input lists
     if isinstance(command_token, CWLMapCommandToken):
         if isinstance(input_value, MutableSequence):
-            return _check_command_token(command_token.value, input_value[0])
+            if len(input_value) > 0:
+                return _check_command_token(command_token.value, input_value[0])
+            else:
+                return True
         else:
             return False
     # At least one command token in a CWLUnionCommandToken must be suitable for the input value

--- a/streamflow/cwl/processor.py
+++ b/streamflow/cwl/processor.py
@@ -1080,9 +1080,15 @@ class CWLUnionTokenProcessor(TokenProcessor):
             return False
 
     def _check_map_processor(self, processor: CWLMapTokenProcessor, token_value: Any):
-        return isinstance(token_value, MutableSequence) and self.check_processor[
-            type(processor.processor)
-        ](processor.processor, token_value[0])
+        if isinstance(token_value, MutableSequence):
+            if len(token_value) > 0:
+                return self.check_processor[type(processor.processor)](
+                    processor.processor, token_value[0]
+                )
+            else:
+                return True
+        else:
+            return False
 
     def _check_object_processor(
         self, processor: CWLObjectTokenProcessor, token_value: Any
@@ -1173,9 +1179,15 @@ class CWLUnionCommandOutputProcessor(CommandOutputProcessor):
     def _check_map_processor(
         self, processor: CWLMapCommandOutputProcessor, token_value: Any
     ):
-        return isinstance(token_value, MutableSequence) and self.check_processor[
-            type(processor.processor)
-        ](processor.processor, token_value[0])
+        if isinstance(token_value, MutableSequence):
+            if len(token_value) > 0:
+                return self.check_processor[type(processor.processor)](
+                    processor.processor, token_value[0]
+                )
+            else:
+                return True
+        else:
+            return False
 
     def _check_object_processor(
         self, processor: CWLObjectCommandOutputProcessor, token_value: Any


### PR DESCRIPTION
In CWL, an empty list is always considered valid for an `ArraySchema` type. However, in StreamFlow empty lists caused an `IndexError` because of the previous implementation of the map processors check. This commit fixesthis behaviour, always returning success when checking an empty list from inside a map processor.