### PR TITLE
Added support for nested connectors

### DIFF
--- a/streamflow/config/schemas/v1.0/config_schema.json
+++ b/streamflow/config/schemas/v1.0/config_schema.json
@@ -161,6 +161,10 @@
           "type": "string",
           "description": "Path to the working directory.",
           "default": "${TMPDIR}/streamflow"
+        },
+        "wraps": {
+          "type": "string",
+          "description": "The name of the deployment wrapped by this configuration."
         }
       },
       "$comment": "The `config` property is injected by each Connector extension",

--- a/streamflow/core/context.py
+++ b/streamflow/core/context.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from abc import ABC, abstractmethod
 from concurrent.futures import ProcessPoolExecutor
-from typing import TYPE_CHECKING
+from typing import Any, MutableMapping, TYPE_CHECKING
 
 from streamflow.log_handler import logger
 
@@ -23,8 +23,8 @@ class SchemaEntity(ABC):
 
 
 class StreamFlowContext:
-    def __init__(self, streamflow_config_dir: str):
-        self.config_dir = streamflow_config_dir
+    def __init__(self, config: MutableMapping[str, Any]):
+        self.config: MutableMapping[str, Any] = config
         self.checkpoint_manager: CheckpointManager | None = None
         self.database: Database | None = None
         self.data_manager: DataManager | None = None

--- a/streamflow/core/deployment.py
+++ b/streamflow/core/deployment.py
@@ -155,7 +155,7 @@ class DeploymentManager(SchemaEntity):
 
 
 class DeploymentConfig(Config):
-    __slots__ = ("name", "type", "config", "external", "lazy", "workdir")
+    __slots__ = ("name", "type", "config", "external", "lazy", "workdir", "wraps")
 
     def __init__(
         self,
@@ -165,11 +165,13 @@ class DeploymentConfig(Config):
         external: bool = False,
         lazy: bool = True,
         workdir: str | None = None,
+        wraps: str | None = None,
     ) -> None:
         super().__init__(name, type, config)
-        self.external = external
+        self.external: bool = external
         self.lazy: bool = lazy
         self.workdir: str | None = workdir
+        self.wraps: str | None = wraps
 
     @classmethod
     async def load(

--- a/streamflow/cwl/antlr/ECMAScriptLexer.py
+++ b/streamflow/cwl/antlr/ECMAScriptLexer.py
@@ -1,7 +1,8 @@
 # Generated from ECMAScript.g4 by ANTLR 4.12.0
-from antlr4 import *
-from io import StringIO
 import sys
+
+from antlr4 import *
+
 if sys.version_info[1] > 5:
     from typing import TextIO
 else:

--- a/streamflow/cwl/antlr/ECMAScriptParser.py
+++ b/streamflow/cwl/antlr/ECMAScriptParser.py
@@ -1,8 +1,9 @@
 # Generated from ECMAScript.g4 by ANTLR 4.12.0
 # encoding: utf-8
-from antlr4 import *
-from io import StringIO
 import sys
+
+from antlr4 import *
+
 if sys.version_info[1] > 5:
 	from typing import TextIO
 else:

--- a/streamflow/cwl/command.py
+++ b/streamflow/cwl/command.py
@@ -11,15 +11,7 @@ import time
 from abc import ABC
 from asyncio.subprocess import STDOUT
 from types import ModuleType
-from typing import (
-    Any,
-    IO,
-    Iterable,
-    MutableMapping,
-    MutableSequence,
-    cast,
-    Type,
-)
+from typing import Any, IO, Iterable, MutableMapping, MutableSequence, Type, cast
 
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.data import DataLocation
@@ -31,9 +23,9 @@ from streamflow.core.exception import (
 from streamflow.core.persistence import DatabaseLoadingContext
 from streamflow.core.utils import (
     flatten_list,
-    get_tag,
-    get_class_fullname,
     get_class_from_name,
+    get_class_fullname,
+    get_tag,
 )
 from streamflow.core.workflow import (
     Command,
@@ -658,13 +650,18 @@ class CWLCommand(CWLBaseCommand):
             step=step,
             absolute_initial_workdir_allowed=row["absolute_initial_workdir_allowed"],
             base_command=row["base_command"],
-            command_tokens=await asyncio.gather(
-                *(
-                    asyncio.create_task(
-                        CWLCommandToken.load(context, command_token, loading_context)
+            command_tokens=cast(
+                MutableSequence[CWLCommandToken],
+                await asyncio.gather(
+                    *(
+                        asyncio.create_task(
+                            CWLCommandToken.load(
+                                context, command_token, loading_context
+                            )
+                        )
+                        for command_token in row["command_tokens"]
                     )
-                    for command_token in row["command_tokens"]
-                )
+                ),
             ),
             expression_lib=row["expression_lib"],
             failure_codes=row["failure_codes"],

--- a/streamflow/cwl/main.py
+++ b/streamflow/cwl/main.py
@@ -18,7 +18,12 @@ from streamflow.workflow.executor import StreamFlowExecutor
 
 
 def _parse_arg(path: str, context: StreamFlowContext):
-    return os.path.join(context.config_dir, path) if not os.path.isabs(path) else path
+    if "://" in path:
+        return path
+    elif os.path.isabs(path):
+        return os.path.join(os.path.dirname(context.config["path"]), path)
+    else:
+        return path
 
 
 def _parse_args(workflow_config: WorkflowConfig, context: StreamFlowContext):

--- a/streamflow/cwl/runner.py
+++ b/streamflow/cwl/runner.py
@@ -56,13 +56,11 @@ parser.add_argument(
 
 async def _async_main(args: argparse.Namespace):
     validator = SfValidator()
-    config_dir = os.getcwd()
     args.name = args.name or str(uuid.uuid4())
     if args.streamflow_file:
         load_extensions()
         with open(args.streamflow_file) as f:
             streamflow_config = validator.yaml.load(f)
-        config_dir = os.path.dirname(args.streamflow_file)
         workflows = streamflow_config.get("workflows", {})
         if len(workflows) == 1:
             workflow_name = list(workflows.keys())[0]
@@ -85,8 +83,11 @@ async def _async_main(args: argparse.Namespace):
             "settings"
         ] = os.path.abspath(args.jobfile)
     validator.validate(streamflow_config)
+    streamflow_config["path"] = (
+        args.streamflow_file if args.streamflow_file is not None else os.getcwd()
+    )
     workflow_config = WorkflowConfig(workflow_name, streamflow_config)
-    context = build_context(config_dir, streamflow_config)
+    context = build_context(streamflow_config)
     try:
         await streamflow.cwl.main.main(
             workflow_config=workflow_config, context=context, args=args

--- a/streamflow/deployment/connector/base.py
+++ b/streamflow/deployment/connector/base.py
@@ -20,12 +20,12 @@ from streamflow.core.deployment import (
 )
 from streamflow.core.exception import WorkflowExecutionException
 from streamflow.deployment import aiotarstream
+from streamflow.deployment.future import FutureConnector
 from streamflow.deployment.stream import (
     StreamReaderWrapper,
     StreamWriterWrapper,
     SubprocessStreamReaderWrapperContext,
 )
-from streamflow.deployment.future import FutureConnector
 from streamflow.log_handler import logger
 
 if TYPE_CHECKING:

--- a/streamflow/deployment/connector/container.py
+++ b/streamflow/deployment/connector/container.py
@@ -301,6 +301,7 @@ class DockerConnector(DockerBaseConnector):
         capAdd: MutableSequence[str] | None = None,
         capDrop: MutableSequence[str] | None = None,
         cgroupParent: str | None = None,
+        cgroupns: str | None = None,
         cidfile: str | None = None,
         command: MutableSequence[str] | None = None,
         containerIds: MutableSequence | None = None,
@@ -407,6 +408,7 @@ class DockerConnector(DockerBaseConnector):
         self.capAdd: MutableSequence[str] | None = capAdd
         self.capDrop: MutableSequence[str] | None = capDrop
         self.cgroupParent: str | None = cgroupParent
+        self.cgroupns: str | None = cgroupns
         self.cidfile: str | None = cidfile
         self.containerIds: MutableSequence[str] = containerIds or []
         self.command: MutableSequence[str] = command
@@ -511,6 +513,7 @@ class DockerConnector(DockerBaseConnector):
                         self.get_option("cap-add", self.capAdd),
                         self.get_option("cap-drop", self.capDrop),
                         self.get_option("cgroup-parent", self.cgroupParent),
+                        self.get_option("cgroupns", self.cgroupns),
                         self.get_option("cidfile", self.cidfile),
                         self.get_option("cpu-period", self.cpuPeriod),
                         self.get_option("cpu-quota", self.cpuQuota),

--- a/streamflow/deployment/connector/schemas/docker.json
+++ b/streamflow/deployment/connector/schemas/docker.json
@@ -47,6 +47,14 @@
       "type": "string",
       "description": "Optional parent cgroup for the container"
     },
+    "cgroupns": {
+      "type": "string",
+      "enum": [
+        "host",
+        "private"
+      ],
+      "description": "Cgroup namespace to use. `host` runs the container in the Docker host's cgroup namespace, `private` runs the container in its own private cgroup namespace. By default, DOcker uses the cgroup namespace as configured by the `default-cgroupns-mode` option on the daemon"
+    },
     "cidfile": {
       "type": "string",
       "description": "Write the container ID to the file"

--- a/streamflow/deployment/connector/schemas/queue_manager.json
+++ b/streamflow/deployment/connector/schemas/queue_manager.json
@@ -5,7 +5,7 @@
   "properties": {
     "checkHostKey": {
       "type": "boolean",
-      "description": "Perform a strict validation of the host SSH keys (and return exception if key is not recognized as valid)",
+      "description": "(**Deprecated.** Use the `wraps` directive to wrap a standalone SSH connector.) Perform a strict validation of the host SSH keys (and return exception if key is not recognized as valid)",
       "default": true
     },
     "dataTransferConnection": {
@@ -18,7 +18,7 @@
           "$ref": "ssh.json#/definitions/connection"
         }
       ],
-      "description": "Sometimes HPC clusters provide dedicated hostnames for large data transfers, which guarantee a higher efficiency for data movements"
+      "description": "(**Deprecated.** Use the `wraps` directive to wrap a standalone SSH connector.) Sometimes HPC clusters provide dedicated hostnames for large data transfers, which guarantee a higher efficiency for data movements"
     },
     "file": {
       "type": "string",
@@ -26,7 +26,7 @@
     },
     "hostname": {
       "type": "string",
-      "description": "Hostname of the HPC facility"
+      "description": "(**Deprecated.** Use the `wraps` directive to wrap a standalone SSH connector.) Hostname of the HPC facility"
     },
     "maxConcurrentJobs": {
       "type": "integer",
@@ -35,7 +35,7 @@
     },
     "maxConcurrentSessions": {
       "type": "integer",
-      "description": "Maximum number of concurrent session to open for a single SSH client connection",
+      "description": "(**Deprecated.** Use the `wraps` directive to wrap a standalone SSH connector.) Maximum number of concurrent session to open for a single SSH client connection",
       "default": 10
     },
     "maxConnections": {
@@ -45,7 +45,7 @@
     },
     "passwordFile": {
       "type": "string",
-      "description": "Path to a file containing the password to use for authentication"
+      "description": "(**Deprecated.** Use the `wraps` directive to wrap a standalone SSH connector.) Path to a file containing the password to use for authentication"
     },
     "pollingInterval": {
       "type": "integer",
@@ -63,11 +63,11 @@
     },
     "sshKey": {
       "type": "string",
-      "description": "Path to the SSH key needed to connect with Slurm environment"
+      "description": "(**Deprecated.** Use the `wraps` directive to wrap a standalone SSH connector.) Path to the SSH key needed to connect with Slurm environment"
     },
     "sshKeyPassphraseFile": {
       "type": "string",
-      "description": "Path to a file containing the passphrase protecting the SSH key"
+      "description": "(**Deprecated.** Use the `wraps` directive to wrap a standalone SSH connector.) Path to a file containing the passphrase protecting the SSH key"
     },
     "transferBufferSize": {
       "type": "integer",
@@ -76,17 +76,13 @@
     },
     "tunnel": {
       "type": "object",
-      "description": "External SSH connection parameters for tunneling",
+      "description": "(**Deprecated.** Use the `wraps` directive to wrap a standalone SSH connector.) External SSH connection parameters for tunneling",
       "$ref": "ssh.json#/definitions/connection"
     },
     "username": {
       "type": "string",
-      "description": "Username needed to connect with the SSH environment"
+      "description": "(**Deprecated.** Use the `wraps` directive to wrap a standalone SSH connector.) Username needed to connect with the SSH environment"
     }
   },
-  "required": [
-    "hostname",
-    "username"
-  ],
   "additionalProperties": false
 }

--- a/streamflow/deployment/deployment_manager.py
+++ b/streamflow/deployment/deployment_manager.py
@@ -3,18 +3,26 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from asyncio import Event
 from typing import TYPE_CHECKING
 
 import pkg_resources
 
-from streamflow.core.deployment import Connector, DeploymentManager
+from streamflow.core.deployment import (
+    Connector,
+    DeploymentConfig,
+    DeploymentManager,
+    LOCAL_LOCATION,
+    LocalTarget,
+)
+from streamflow.core.exception import WorkflowDefinitionException
 from streamflow.deployment.connector import connector_classes
 from streamflow.deployment.future import FutureConnector
+from streamflow.deployment.wrapper import ConnectorWrapper
 from streamflow.log_handler import logger
 
 if TYPE_CHECKING:
     from streamflow.core.context import StreamFlowContext
-    from streamflow.core.deployment import DeploymentConfig
     from typing import MutableMapping, Any
 
 
@@ -24,29 +32,35 @@ class DefaultDeploymentManager(DeploymentManager):
         self.config_map: MutableMapping[str, Any] = {}
         self.events_map: MutableMapping[str, asyncio.Event] = {}
         self.deployments_map: MutableMapping[str, Connector] = {}
+        self.dependency_graph: MutableMapping[str, set[str]] = {}
 
-    async def close(self):
-        await self.undeploy_all()
-
-    async def deploy(self, deployment_config: DeploymentConfig):
+    async def _deploy(
+        self, deployment_config: DeploymentConfig, wrappers_stack: set[str]
+    ) -> None:
         deployment_name = deployment_config.name
         while True:
-            if deployment_name not in self.events_map:
-                self.events_map[deployment_name] = asyncio.Event()
             if deployment_name not in self.config_map:
                 self.config_map[deployment_name] = deployment_config
+                self.events_map[deployment_name] = Event()
+                self.dependency_graph[deployment_name] = set()
+                connector_type = connector_classes[deployment_config.type]
+                deployment_config = await self._inner_deploy(
+                    connector_type=connector_type,
+                    deployment_config=deployment_config,
+                    wrappers_stack=wrappers_stack,
+                )
                 if deployment_config.lazy:
                     connector = FutureConnector(
                         name=deployment_name,
-                        config_dir=self.context.config_dir,
-                        connector_type=connector_classes[deployment_config.type],
+                        config_dir=os.path.dirname(self.context.config["path"]),
+                        connector_type=connector_type,
                         external=deployment_config.external,
                         **deployment_config.config,
                     )
                     self.deployments_map[deployment_name] = connector
                     self.events_map[deployment_name].set()
                 else:
-                    connector = connector_classes[deployment_config.type](
+                    connector = connector_type(
                         deployment_name, self.context, **deployment_config.config
                     )
                     self.deployments_map[deployment_name] = connector
@@ -64,6 +78,90 @@ class DefaultDeploymentManager(DeploymentManager):
                 if deployment_name in self.config_map:
                     break
 
+    async def _inner_deploy(
+        self,
+        connector_type: type[Connector],
+        deployment_config: DeploymentConfig,
+        wrappers_stack: set[str],
+    ) -> DeploymentConfig:
+        # If it is a ConnectorWrapper
+        if issubclass(connector_type, ConnectorWrapper):
+            # Retrieve the inner connector's config
+            if deployment_config.wraps is None:
+                deployment_name = LOCAL_LOCATION
+                if deployment_name not in self.config_map:
+                    local_target = LocalTarget()
+                    await self._deploy(local_target.deployment, wrappers_stack)
+            else:
+                deployment_name = deployment_config.wraps
+            # If it has already been processed, there is a recursive definition
+            if deployment_name in wrappers_stack:
+                raise WorkflowDefinitionException(
+                    "Recursive connector definitions are not allowed."
+                )
+            # If it has already been processed by the DeploymentManager
+            if deployment_name in self.config_map:
+                # If the DeploymentManager is creating the environment, wait for it to finish
+                if not self.is_deployed(deployment_name):
+                    await self.events_map[deployment_name].wait()
+                # Check for recursive definitions
+                wrappers_stack.update(deployment_name)
+                await self._inner_deploy(
+                    connector_type=type(self.deployments_map[deployment_name]),
+                    deployment_config=self.config_map[deployment_name],
+                    wrappers_stack=wrappers_stack,
+                )
+            # Otherwise, if it exists and it points to a new connector, deploy it
+            elif deployment_name in self.context.config["deployments"]:
+                wrappers_stack.update(deployment_name)
+                inner_config = self.context.config["deployments"][deployment_name]
+                inner_config = DeploymentConfig(
+                    name=deployment_name,
+                    type=inner_config["type"],
+                    config=inner_config["config"],
+                    external=inner_config.get("external", False),
+                    lazy=inner_config.get("lazy", True),
+                    workdir=inner_config.get("workdir"),
+                    wraps=inner_config.get("wraps"),
+                )
+                await self._deploy(inner_config, wrappers_stack)
+            # Otherwise, the workflow is badly specified
+            else:
+                raise WorkflowDefinitionException(
+                    f"No valid deployment configuration for {deployment_name}."
+                )
+            # Update dependency graph
+            self.dependency_graph[deployment_name].add(deployment_config.name)
+            # Then, inject the connector into the DeploymentConfig
+            return DeploymentConfig(
+                name=deployment_config.name,
+                type=deployment_config.type,
+                config={
+                    **deployment_config.config,
+                    **{"connector": self.deployments_map[deployment_name]},
+                },
+                external=deployment_config.external,
+                lazy=deployment_config.lazy,
+                wraps=deployment_config.wraps,
+            )
+        # If it is not a ConnectorWrapper, do nothing
+        else:
+            if deployment_config.wraps is not None:
+                if logger.isEnabledFor(logging.WARN):
+                    logger.warn(
+                        f"The `wraps` directive has no effect on deployment {deployment_config.name}, "
+                        f"as the `{deployment_config.type}` connector does not inherit from the ConnectorWrapper class."
+                    )
+            return deployment_config
+
+    async def close(self):
+        await self.undeploy_all()
+
+    async def deploy(self, deployment_config: DeploymentConfig):
+        deployment_name = deployment_config.name
+        await self._deploy(deployment_config, {deployment_name})
+        self.dependency_graph[deployment_name].add(deployment_name)
+
     def get_connector(self, deployment_name: str) -> Connector | None:
         return self.deployments_map.get(deployment_name, None)
 
@@ -79,19 +177,32 @@ class DefaultDeploymentManager(DeploymentManager):
     async def undeploy(self, deployment_name: str):
         if deployment_name in dict(self.deployments_map):
             await self.events_map[deployment_name].wait()
-            self.events_map[deployment_name].clear()
-            connector = self.deployments_map[deployment_name]
-            config = self.config_map[deployment_name]
-            if logger.isEnabledFor(logging.INFO):
-                if not config.external:
-                    logger.info(f"UNDEPLOYING {deployment_name}")
-            await connector.undeploy(config.external)
-            if logger.isEnabledFor(logging.INFO):
-                if not config.external:
-                    logger.info(f"COMPLETED Undeployment of {deployment_name}")
-            del self.deployments_map[deployment_name]
-            del self.config_map[deployment_name]
-            self.events_map[deployment_name].set()
+            # Remove the deployment from the dependency graph
+            self.dependency_graph[deployment_name].discard(deployment_name)
+            # If there are no more inner deployments, undeploy the environment and clear the related data structures
+            if len(self.dependency_graph[deployment_name]) == 0:
+                self.events_map[deployment_name].clear()
+                connector = self.deployments_map[deployment_name]
+                config = self.config_map[deployment_name]
+                if logger.isEnabledFor(logging.INFO):
+                    if not config.external:
+                        logger.info(f"UNDEPLOYING {deployment_name}")
+                del self.deployments_map[deployment_name]
+                del self.config_map[deployment_name]
+                del self.dependency_graph[deployment_name]
+                await connector.undeploy(config.external)
+                if logger.isEnabledFor(logging.INFO):
+                    if not config.external:
+                        logger.info(f"COMPLETED Undeployment of {deployment_name}")
+                self.events_map[deployment_name].set()
+            # Remove the current environment from all the other dependency graphs
+            for name, deps in {
+                k: v for k, v in self.dependency_graph.items() if k != deployment_name
+            }.items():
+                deps.discard(deployment_name)
+                # If there are no more dependencies, undeploy the environment
+                if len(deps) == 0:
+                    await self.undeploy(name)
 
     async def undeploy_all(self):
         undeployments = []

--- a/streamflow/deployment/template.py
+++ b/streamflow/deployment/template.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import MutableMapping
+
+from jinja2 import Template
+
+
+class CommandTemplateMap:
+    def __init__(
+        self,
+        default: str,
+        template_map: MutableMapping[str, str] | None = None,
+    ):
+        self.templates: MutableMapping[str, Template] = {
+            "__DEFAULT__": Template(default)
+        }
+        if template_map:
+            for name, template in template_map.items():
+                self.templates[name] = Template(template)
+
+    def get_command(
+        self,
+        command: str,
+        template: str | None = None,
+        environment: MutableMapping[str, str] = None,
+        workdir: str = None,
+        **kwargs,
+    ) -> str:
+        return self.templates[template or "__DEFAULT__"].render(
+            streamflow_command=command,
+            streamflow_environment=environment,
+            streamflow_workdir=workdir,
+            **kwargs,
+        )

--- a/streamflow/deployment/utils.py
+++ b/streamflow/deployment/utils.py
@@ -53,6 +53,7 @@ def get_binding_config(
                 external=target_deployment.get("external", False),
                 lazy=target_deployment.get("lazy", True),
                 workdir=target_deployment.get("workdir"),
+                wraps=target_deployment.get("wraps"),
             )
             targets.append(
                 Target(

--- a/streamflow/deployment/wrapper.py
+++ b/streamflow/deployment/wrapper.py
@@ -1,0 +1,78 @@
+import asyncio
+from abc import ABC
+from typing import Any, MutableMapping, MutableSequence, Optional, Tuple, Union
+
+from streamflow.core.deployment import Connector, ConnectorCopyKind, Location
+from streamflow.core.scheduling import AvailableLocation
+
+
+class ConnectorWrapper(Connector, ABC):
+    def __init__(self, deployment_name: str, config_dir: str, connector: Connector):
+        super().__init__(deployment_name, config_dir)
+        self.connector: Connector = connector
+
+    async def copy(
+        self,
+        src: str,
+        dst: str,
+        locations: MutableSequence[Location],
+        kind: ConnectorCopyKind,
+        source_connector: Optional[Connector] = None,
+        source_location: Optional[Location] = None,
+        read_only: bool = False,
+    ) -> None:
+        await self.connector.copy(
+            src=src,
+            dst=dst,
+            locations=locations,
+            kind=kind,
+            source_connector=source_connector,
+            source_location=source_location,
+            read_only=read_only,
+        )
+
+    async def deploy(self, external: bool) -> None:
+        return None
+
+    async def get_available_locations(
+        self,
+        service: Optional[str] = None,
+        input_directory: Optional[str] = None,
+        output_directory: Optional[str] = None,
+        tmp_directory: Optional[str] = None,
+    ) -> MutableMapping[str, AvailableLocation]:
+        return await self.connector.get_available_locations(
+            service=service,
+            input_directory=input_directory,
+            output_directory=output_directory,
+            tmp_directory=tmp_directory,
+        )
+
+    async def run(
+        self,
+        location: Location,
+        command: MutableSequence[str],
+        environment: MutableMapping[str, str] = None,
+        workdir: Optional[str] = None,
+        stdin: Optional[Union[int, str]] = None,
+        stdout: Union[int, str] = asyncio.subprocess.STDOUT,
+        stderr: Union[int, str] = asyncio.subprocess.STDOUT,
+        capture_output: bool = False,
+        timeout: Optional[int] = None,
+        job_name: Optional[str] = None,
+    ) -> Optional[Tuple[Optional[Any], int]]:
+        return await self.connector.run(
+            location=location,
+            command=command,
+            environment=environment,
+            workdir=workdir,
+            stdin=stdin,
+            stdout=stdout,
+            stderr=stderr,
+            capture_output=capture_output,
+            timeout=timeout,
+            job_name=job_name,
+        )
+
+    async def undeploy(self, external: bool) -> None:
+        return None

--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -370,4 +370,11 @@ class DefaultScheduler(Scheduler):
             )
             for target in targets
         ]
-        await asyncio.wait(wait_tasks, return_when=asyncio.FIRST_COMPLETED)
+        # Capture finished tasks and call result() to check for exceptions
+        finished, _ = await asyncio.wait(
+            wait_tasks, return_when=asyncio.FIRST_COMPLETED
+        )
+        for task in finished:
+            if task.cancelled():
+                continue
+            task.result()

--- a/streamflow/workflow/token.py
+++ b/streamflow/workflow/token.py
@@ -7,7 +7,7 @@ from typing import Any, MutableMapping, MutableSequence
 
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.persistence import DatabaseLoadingContext
-from streamflow.core.workflow import Token, Job
+from streamflow.core.workflow import Job, Token
 
 
 class IterationTerminationToken(Token):

--- a/tests/test_remotepath.py
+++ b/tests/test_remotepath.py
@@ -136,18 +136,25 @@ async def test_directory(context, connector, location):
 async def test_file(context, connector, location):
     """Test file creation, size, checksum and deletion."""
     path = utils.random_name()
+    path2 = utils.random_name()
     try:
         await remotepath.write(connector, location, path, "StreamFlow")
         assert await remotepath.exists(connector, location, path)
         assert await remotepath.isfile(connector, location, path)
         assert await remotepath.size(connector, location, path) == 10
+        await remotepath.write(connector, location, path2, "CWL")
+        assert await remotepath.exists(connector, location, path2)
+        assert await remotepath.size(connector, location, [path, path2]) == 13
         digest = await remotepath.checksum(context, connector, location, path)
         assert digest == "e8abb7445e1c4061c3ef39a0e1690159b094d3b5"
-        await remotepath.rm(connector, location, path)
+        await remotepath.rm(connector, location, [path, path2])
         assert not await remotepath.exists(connector, location, path)
+        assert not await remotepath.exists(connector, location, path2)
     finally:
         if await remotepath.exists(connector, location, path):
             await remotepath.rm(connector, location, path)
+        if await remotepath.exists(connector, location, path2):
+            await remotepath.rm(connector, location, path2)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This commit adds support for nested Connector classes through the `ConnectorWrapper` interface. The `QueueManagerConnector` is now implemented as a connector wrapper, automatically creating an inner SSH connector to maintain compatibility with the (deprecated) previous version, which inherited from the `SSHConnector` class.

A new `wraps` property in the `deployment` configuration allows to define connector wrappers for other connectors. A single connector can be wrapped from multiple connector wrappers, but each wrapper can wrap a single inner connector.

The `deploy` and `undeploy` actions are not automatically propagated to the inner connector to avoid spurious creations and deletions of connectors when multiple wrappers wrap the same object. Instead, the correct order of deployment and undeployment actions is in charge of the `DeploymentManager` class.