### PR TITLE
Fix StreamFlow MPI example

### DIFF
--- a/examples/mpi/streamflow.yml
+++ b/examples/mpi/streamflow.yml
@@ -28,5 +28,6 @@ deployments:
     type: helm
     config:
       chart: environment/helm/openmpi
-      kubeconfig: /home/glassofwhiskey/.kube/config-streamflow
+      kubeconfig: ~/.kube/config-streamflow
       releaseName: openmpi-rel
+    workdir: /tmp

--- a/streamflow/core/scheduling.py
+++ b/streamflow/core/scheduling.py
@@ -129,13 +129,13 @@ class JobAllocation:
         self,
         job: str,
         target: Target,
-        locations: MutableSequence[Location],
+        locations: MutableSequence[AvailableLocation],
         status: Status,
         hardware: Hardware,
     ):
         self.job: str = job
         self.target: Target = target
-        self.locations: MutableSequence[Location] = locations
+        self.locations: MutableSequence[AvailableLocation] = locations
         self.status: Status = status
         self.hardware: Hardware = hardware
 
@@ -232,7 +232,7 @@ class Scheduler(SchemaEntity):
 
     def get_locations(
         self, job_name: str, statuses: MutableSequence[Status] | None = None
-    ) -> MutableSequence[Location]:
+    ) -> MutableSequence[AvailableLocation]:
         allocation = self.get_allocation(job_name)
         return (
             allocation.locations

--- a/streamflow/cwl/command.py
+++ b/streamflow/cwl/command.py
@@ -778,14 +778,9 @@ class CWLCommand(CWLBaseCommand):
             ]
         # If step is assigned to multiple locations, add the STREAMFLOW_HOSTS environment variable
         if len(locations) > 1:
-            service = self.step.workflow.context.scheduler.get_service(job.name)
-            available_locations = await connector.get_available_locations(
-                service=service
+            parsed_env["STREAMFLOW_HOSTS"] = ",".join(
+                [loc.hostname for loc in locations]
             )
-            hosts = {
-                k: v.hostname for k, v in available_locations.items() if k in locations
-            }
-            parsed_env["STREAMFLOW_HOSTS"] = ",".join(hosts.values())
         # Process streams
         stdin = utils.eval_expression(
             expression=self.stdin,

--- a/streamflow/cwl/main.py
+++ b/streamflow/cwl/main.py
@@ -20,7 +20,7 @@ from streamflow.workflow.executor import StreamFlowExecutor
 def _parse_arg(path: str, context: StreamFlowContext):
     if "://" in path:
         return path
-    elif os.path.isabs(path):
+    elif not os.path.isabs(path):
         return os.path.join(os.path.dirname(context.config["path"]), path)
     else:
         return path

--- a/streamflow/cwl/utils.py
+++ b/streamflow/cwl/utils.py
@@ -189,7 +189,7 @@ async def _register_path(
                 ):
                     data_location = data_locations[0]
                 else:
-                    raise WorkflowExecutionException(f"Error registering path {path}")
+                    return None
             link_location = context.data_manager.register_path(
                 location=location,
                 path=path,

--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -78,7 +78,7 @@ class DefaultScheduler(Scheduler):
             else:
                 logger.debug(
                     f"Job {job.name} allocated on locations "
-                    ", ".join([str(loc) for loc in selected_locations])
+                    f"{', '.join([str(loc) for loc in selected_locations])}"
                 )
         self.job_allocations[job.name] = JobAllocation(
             job=job.name,


### PR DESCRIPTION
Prior to this commit, the MPI example was not working for these reasons:
 - When scheduling a job on multiple locations the `STREAMFLOW_HOSTS` variable was not correctly populated;
 - Helm connector had some issues with file transfers and tar streaming;
 - DockerCompose connector had issues with parsing available locations. All these issues are solved by this fix, which also fixes #82.