### PR TITLE
Added explicit version check for DockerCompose

### DIFF
--- a/streamflow/deployment/connector/kubernetes.py
+++ b/streamflow/deployment/connector/kubernetes.py
@@ -622,6 +622,8 @@ class Helm3Connector(BaseKubernetesConnector):
                 raise WorkflowExecutionException(
                     f"Helm {version} is not compatible with Helm3Connector"
                 )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(f"Using Helm {version}.")
             # Deploy Helm charts
             deploy_command = self._get_base_command() + "".join(
                 [


### PR DESCRIPTION
StreamFlow is not compatible with DockerCompose 1.x. Howeverm prior to this commit there was no explicit check for DockerCompose version. Now, if the installed version of DockerCompose is too old (1.x), the DockerCompose connector throws an explicit error at deployment time.