### PR TITLE
Fix additional files in RunCrate provenance

### DIFF
--- a/streamflow/provenance/run_crate.py
+++ b/streamflow/provenance/run_crate.py
@@ -571,8 +571,8 @@ class RunCrateProvenanceManager(ProvenanceManager, ABC):
         src = file["src"]
         dst = file.get("dst", posixpath.sep)
         dst_parent = posixpath.dirname(posixpath.normpath(dst))
-        if logger.isEnabledFor(logging.WARN):
-            if src in self.files_map:
+        if src in self.files_map:
+            if logger.isEnabledFor(logging.WARN):
                 logger.warn(f"File {src} is already present in the archive.")
         else:
             if os.path.isfile(os.path.realpath(src)):


### PR DESCRIPTION
A bug prevented users to correctly add files to a RunCrate archive through the `--add-file` option. This commit fixes the bug.