### PR TITLE
Fix `list` and `report` subcommands

### DIFF
--- a/report-requirements.txt
+++ b/report-requirements.txt
@@ -1,3 +1,3 @@
 pandas==2.0.1
 plotly==5.14.1
-kaleido==0.2.1.post1
+kaleido==0.2.1

--- a/streamflow/main.py
+++ b/streamflow/main.py
@@ -137,7 +137,7 @@ async def _async_prov(args: argparse.Namespace):
 
 
 async def _async_report(args: argparse.Namespace):
-    context = _get_context_from_config(args.streamflow_file, args.outdir)
+    context = _get_context_from_config(args.file)
     try:
         await report.create_report(context, args)
     finally:
@@ -165,6 +165,7 @@ async def _async_run(args: argparse.Namespace):
 
 def _get_context_from_config(streamflow_file: str | None) -> StreamFlowContext:
     if os.path.exists(streamflow_file):
+        load_extensions()
         streamflow_config = SfValidator().validate_file(streamflow_file)
         streamflow_config["path"] = streamflow_file
         return build_context(streamflow_config)

--- a/streamflow/parser.py
+++ b/streamflow/parser.py
@@ -38,6 +38,7 @@ list_parser.add_argument(
 list_parser.add_argument(
     "name",
     metavar="NAME",
+    nargs="?",
     type=str,
     help="List all executions for the given workflow",
 )


### PR DESCRIPTION
This commit fixes some issues with `streamflow list` and `streamflow report` commands. In detail:

- It changes the required version of the `kaleido` library to `0.2.1`, because version `0.2.1.post1` no longer exists;
- It corrects a bug with the argument names of the `streamflow report` command, closing PR #83;
- It makes optional the `NAME` metavar in the `streamflow list` command, which had erroneously been marked as required;
- It loads StreamFlow plugins also when executing secondary commands, in order to allow for custom database extensions.