### PR TITLE
Added `streamflow ext` subcommand

### DIFF
--- a/streamflow/ext/utils.py
+++ b/streamflow/ext/utils.py
@@ -10,7 +10,7 @@ from importlib_metadata import entry_points
 
 from streamflow.core.exception import InvalidPluginException
 from streamflow.core.utils import get_class_fullname
-from streamflow.ext.plugin import StreamFlowPlugin
+from streamflow.ext.plugin import StreamFlowPlugin, extension_points
 from streamflow.log_handler import logger
 
 PLUGIN_ENTRY_POINT = "unito.streamflow.plugin"
@@ -49,7 +49,88 @@ def _get_type_repr(obj: MutableMapping[str, Any]) -> str | None:
         return None
 
 
-def list_extensions():
+def list_extensions(name: str | None, type_: str | None):
+    extensions = {}
+    max_sizes = {
+        "name": 0,
+        "class": 0,
+        "plugin": 0,
+    }
+    for ext, classes in extension_points.items():
+        if type_ is None or ext == type_:
+            for n, v in classes.items():
+                if name is None or name == n:
+                    extensions.setdefault(ext, {})[n] = {
+                        "name": n,
+                        "class": get_class_fullname(v),
+                        "plugin": "-",
+                    }
+                    for k in max_sizes:
+                        max_sizes[k] = max(max_sizes[k], len(extensions[ext][n][k]))
+    if plugins := entry_points(group=PLUGIN_ENTRY_POINT):
+        for plugin in plugins:
+            plugin_class = (plugin.load())()
+            plugin_class.register()
+            if isinstance(plugin_class, StreamFlowPlugin):
+                plugin_classes = (
+                    {k: v for k, v in plugin_class.classes_.items() if k == type_}
+                    if type_ is not None
+                    else plugin_class.classes_
+                )
+                if name is not None:
+                    plugin_classes = _filter_by_name(plugin_classes, name)
+                for ext, items in plugin_classes.items():
+                    for item in items:
+                        extensions.setdefault(ext, {})[item["name"]] = {
+                            "name": item["name"],
+                            "class": get_class_fullname(item["class"]),
+                            "plugin": plugin.name,
+                        }
+                        for k in max_sizes:
+                            max_sizes[k] = max(
+                                max_sizes[k], len(extensions[ext][item["name"]][k])
+                            )
+    format_string = (
+        "{:<"
+        + str(max(max_sizes["name"] + 2, 6))
+        + "}"
+        + "{:<"
+        + str(max(max_sizes["class"] + 2, 12))
+        + "}"
+        + "{:<"
+        + str(max(max_sizes["plugin"], 8))
+        + "}"
+    )
+    if extensions:
+        for ext, items in extensions.items():
+            if type_ is None:
+                print(
+                    f"There {'are' if len(items) > 1 else 'is'} "
+                    f"{len(items)} available extension{'s' if len(items) > 1 else ''} "
+                    f"for the `{ext}` extension point:"
+                )
+            print(format_string.format("NAME", "CLASS_NAME", "PLUGIN"))
+            for item in items.values():
+                print(
+                    format_string.format(
+                        item["name"],
+                        item["class"],
+                        item["plugin"],
+                    )
+                )
+            print("")
+    else:
+        print(
+            "There are no available StreamFlow extensions{type}{sep}{name}.".format(
+                type=f" of type `{type_}`" if type_ is not None else "",
+                sep=" and" if type_ is not None and name is not None else "",
+                name=f" with name `{name}`" if name is not None else "",
+            ),
+            file=sys.stderr,
+        )
+
+
+def list_plugins():
     if plugins := entry_points(group=PLUGIN_ENTRY_POINT):
         plugin_objs = []
         max_sizes = {
@@ -115,44 +196,83 @@ def load_extensions():
             )
 
 
-def show_extension(
-    plugin: str, name: str | None, type_: str | None, show_schema: bool = False
-):
+def show_extension(name: str, type_: str):
+    plugin = "-"
+    if name in extension_points[type_]:
+        class_ = extension_points[type_][name]
+    else:
+        class_ = None
+        for plugin_obj in entry_points(group=PLUGIN_ENTRY_POINT):
+            plugin_class = (plugin_obj.load())()
+            if isinstance(plugin_class, StreamFlowPlugin):
+                plugin_class.register()
+                plugin_classes = _filter_by_name(
+                    {k: v for k, v in plugin_class.classes_.items() if k == type_}, name
+                )
+                for item in plugin_classes.get(type_, []):
+                    if item["name"] == name:
+                        class_ = item["class"]
+                        plugin = plugin_obj.name
+    if class_ is not None:
+        class_name = get_class_fullname(class_)
+        entity_schema = class_.get_schema()
+        with open(entity_schema) as f:
+            entity_schema = jsonref.loads(
+                f.read(),
+                base_uri=f"file://{os.path.dirname(entity_schema)}/",
+                jsonschema=True,
+            )
+        format_string = (
+            "{:<"
+            + str(max(len(name) + 2, 6))
+            + "}"
+            + "{:<"
+            + str(max(len(class_name) + 2, 10))
+            + "}"
+            + "{:<"
+            + str(max(len(plugin), 8))
+            + "}"
+        )
+        print(format_string.format("NAME", "CLASS_NAME", "PLUGIN"))
+        print(format_string.format(name, class_name, plugin))
+        property_descs = []
+        for k, v in entity_schema.get("properties", {}).items():
+            if k in entity_schema.get("required", []):
+                property_descs.append(_get_property_desc(k, v))
+        if property_descs:
+            print("\nREQUIRED\n")
+            print("\n---\n".join(property_descs))
+            property_descs = []
+        for k, v in entity_schema.get("properties", {}).items():
+            if k not in entity_schema.get("required", []):
+                property_descs.append(_get_property_desc(k, v))
+        if property_descs:
+            print("\nOPTIONAL\n")
+            print("\n---\n".join(property_descs))
+    else:
+        print(
+            f"No StreamFlow extension `{name}` of type `{type_}` detected.",
+            file=sys.stderr,
+        )
+
+
+def show_plugin(plugin: str):
     if plugins := entry_points(name=plugin, group=PLUGIN_ENTRY_POINT):
-        plugin = plugins[plugin]
-        plugin_class = (plugin.load())()
+        plugin_obj = plugins[plugin]
+        plugin_class = (plugin_obj.load())()
         if isinstance(plugin_class, StreamFlowPlugin):
             plugin_class.register()
-            print(f"NAME: {plugin.name}")
-            print(f"PACKAGE: {plugin.dist.name}")
-            print(f"VERSION: {plugin.dist.version}")
+            print(f"NAME: {plugin_obj.name}")
+            print(f"PACKAGE: {plugin_obj.dist.name}")
+            print(f"VERSION: {plugin_obj.dist.version}")
             print(f"CLASS_NAME: {get_class_fullname(type(plugin_class))}\n")
-            plugin_classes = plugin_class.classes_
-            if type_ is not None:
-                plugin_classes = {k: v for k, v in plugin_classes.items() if k == type_}
-                if len(plugin_classes) == 0:
-                    print(
-                        f"It does not provide any StreamFlow extension of type `{type_}`"
-                    )
-                else:
-                    if name is not None:
-                        plugin_classes = _filter_by_name(plugin_classes, name)
-                        if len(plugin_classes) == 0:
-                            print(
-                                f"It does not provide any StreamFlow extension of type `{type_}` with name `{name}`"
-                            )
-            elif name is not None:
-                plugin_classes = _filter_by_name(plugin_classes, name)
-                if len(plugin_classes) == 0:
-                    print(
-                        f"It does not provide any StreamFlow extension with name `{name}`"
-                    )
-            elif len(plugin_classes) == 0:
+            classes = plugin_class.classes_
+            if len(classes) == 0:
                 print("It does not provide any StreamFlow extension")
-            if len(plugin_classes) > 0:
+            else:
                 ext_objs = {}
                 max_sizes = {"name": 0, "class": 0}
-                for extension_point, items in plugin_classes.items():
+                for extension_point, items in classes.items():
                     for item in items:
                         ext_objs.setdefault(extension_point, []).append(
                             {
@@ -164,14 +284,6 @@ def show_extension(
                             max_sizes[k] = max(
                                 max_sizes[k], len(ext_objs[extension_point][-1][k])
                             )
-                        if show_schema:
-                            entity_schema = item["class"].get_schema()
-                            with open(entity_schema) as f:
-                                ext_objs[extension_point][-1]["schema"] = jsonref.loads(
-                                    f.read(),
-                                    base_uri=f"file://{os.path.dirname(entity_schema)}/",
-                                    jsonschema=True,
-                                )
                 format_string = (
                     "{:<"
                     + str(max(max_sizes["name"] + 2, 6))
@@ -194,31 +306,6 @@ def show_extension(
                                 ext_point["class"],
                             )
                         )
-                if show_schema:
-                    print("\nSCHEMAS:")
-                    for extension_point, ext_obj in ext_objs.items():
-                        for ext_point in ext_obj:
-                            title = f"`{ext_point['name']}` {extension_point} ({ext_point['class']})"
-                            print(f"\n{title}")
-                            print("-" * len(title))
-                            property_descs = []
-                            for k, v in (
-                                ext_point["schema"].get("properties", {}).items()
-                            ):
-                                if k in ext_point["schema"].get("required", []):
-                                    property_descs.append(_get_property_desc(k, v))
-                            if property_descs:
-                                print("\nREQUIRED\n")
-                                print("\n---\n".join(property_descs))
-                                property_descs = []
-                            for k, v in (
-                                ext_point["schema"].get("properties", {}).items()
-                            ):
-                                if k not in ext_point["schema"].get("required", []):
-                                    property_descs.append(_get_property_desc(k, v))
-                            if property_descs:
-                                print("\nOPTIONAL\n")
-                                print("\n---\n".join(property_descs))
         else:
             print(
                 "Invalid plugin: it does not extend the streamflow.ext.StreamFlowPlugin class"

--- a/streamflow/main.py
+++ b/streamflow/main.py
@@ -18,7 +18,13 @@ from streamflow.core.workflow import Workflow
 from streamflow.cwl.main import main as cwl_main
 from streamflow.data import data_manager_classes
 from streamflow.deployment import deployment_manager_classes
-from streamflow.ext.utils import list_extensions, load_extensions, show_extension
+from streamflow.ext.utils import (
+    list_extensions,
+    list_plugins,
+    load_extensions,
+    show_extension,
+    show_plugin,
+)
 from streamflow.log_handler import CustomFormatter, HighlitingFilter, logger
 from streamflow.parser import parser
 from streamflow.persistence import database_classes
@@ -26,6 +32,13 @@ from streamflow.persistence.loading_context import DefaultDatabaseLoadingContext
 from streamflow.provenance import prov_classes
 from streamflow.recovery import checkpoint_manager_classes, failure_manager_classes
 from streamflow.scheduling import scheduler_classes
+
+
+async def _async_ext(args: argparse.Namespace):
+    if args.ext_context == "list":
+        list_extensions(args.name, args.type)
+    elif args.ext_context == "show":
+        show_extension(args.name, args.type)
 
 
 async def _async_list(args: argparse.Namespace):
@@ -80,9 +93,9 @@ async def _async_list(args: argparse.Namespace):
 
 async def _async_plugin(args: argparse.Namespace):
     if args.plugin_context == "list":
-        list_extensions()
+        list_plugins()
     elif args.plugin_context == "show":
-        show_extension(args.plugin, args.name, args.type, args.show_schema)
+        show_plugin(args.plugin)
 
 
 async def _async_prov(args: argparse.Namespace):
@@ -234,6 +247,8 @@ def main(args):
             from streamflow.version import VERSION
 
             print(f"StreamFlow version {VERSION}")
+        elif args.context == "ext":
+            asyncio.run(_async_ext(args))
         elif args.context == "list":
             asyncio.run(_async_list(args))
         elif args.context == "plugin":

--- a/streamflow/parser.py
+++ b/streamflow/parser.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import re
 
+import streamflow.ext.plugin
 
 UNESCAPED_COMMA = re.compile(r"(?<!\\),")
 UNESCAPED_EQUAL = re.compile(r"(?<!\\)=")
@@ -25,6 +26,40 @@ class _KeyValueAction(argparse.Action):
 parser = argparse.ArgumentParser(description="StreamFlow Command Line")
 subparsers = parser.add_subparsers(dest="context")
 
+
+# streamflow ext
+ext_parser = subparsers.add_parser(
+    "ext", help="Retrieve information on the available StreamFlow extensions"
+)
+ext_subparsers = ext_parser.add_subparsers(dest="ext_context")
+
+# streamflow ext list
+ext_list_parser = ext_subparsers.add_parser(
+    "list", help="List the available StreamFlow extensions"
+)
+ext_list_parser.add_argument("--name", "-n", type=str, help="Filter extensions by name")
+ext_list_parser.add_argument(
+    "--type",
+    "-t",
+    type=str,
+    choices=streamflow.ext.plugin.extension_points,
+    help="Filter extensions by type",
+)
+
+# streamflow ext show
+ext_show_parser = ext_subparsers.add_parser(
+    "show", help="Show the details of a StreamFlow extension"
+)
+ext_show_parser.add_argument(
+    "type",
+    metavar="TYPE",
+    type=str,
+    choices=streamflow.ext.plugin.extension_points,
+    help="Type of the extension to show",
+)
+ext_show_parser.add_argument(
+    "name", metavar="NAME", type=str, help="Name of the extension to show"
+)
 
 # streamflow list
 list_parser = subparsers.add_parser("list", help="List the executed workflows")
@@ -59,32 +94,6 @@ plugin_show_parser = plugin_subparsers.add_parser(
 )
 plugin_show_parser.add_argument(
     "plugin", metavar="PLUGIN", type=str, help="Name of the plugin to show"
-)
-plugin_show_parser.add_argument(
-    "--name", "-n", type=str, help="Filter extensions by name"
-)
-plugin_show_parser.add_argument(
-    "--type",
-    "-t",
-    type=str,
-    choices=[
-        "binding_filter",
-        "checkpoint_manager",
-        "cwl_docker_translator",
-        "connector",
-        "data_manager",
-        "database",
-        "deployment_manager",
-        "failure_manager",
-        "policy",
-        "scheduler",
-    ],
-    help="Filter extensions by type",
-)
-plugin_show_parser.add_argument(
-    "--show-schema",
-    action="store_true",
-    help="Print property schemas for selected extension points",
 )
 
 # streamflow prov


### PR DESCRIPTION
This commit modifies the CLI interface to query StreamFlow plugins and extensions. The `streamflow plugin show` subcommand now just gives general information about the extensions provided by a plugin. The details of each extension, together with the schema documentation, are now available through the `streamflow ext show` subcommand.

In addition, the `streamflow ext list` subcommand shows all extensions provided by StreamFlow and the installed plugins.