### PR TITLE
Adding explicit options to queue connectors

### DIFF
--- a/streamflow/core/utils.py
+++ b/streamflow/core/utils.py
@@ -159,6 +159,24 @@ async def get_local_to_remote_destination(
         return dst
 
 
+def get_option(
+    name: str,
+    value: Any,
+) -> str:
+    if len(name) > 1:
+        name = f"-{name} "
+    if isinstance(value, bool):
+        return f"-{name} " if value else ""
+    elif isinstance(value, str) or isinstance(value, int):
+        return f'-{name} "{value}" '
+    elif isinstance(value, MutableSequence):
+        return "".join([f'-{name} "{item}" ' for item in value])
+    elif value is None:
+        return ""
+    else:
+        raise TypeError("Unsupported value type")
+
+
 async def get_remote_to_remote_write_command(
     src_connector: Connector,
     src_location: Location,

--- a/streamflow/deployment/connector/base.py
+++ b/streamflow/deployment/connector/base.py
@@ -69,24 +69,6 @@ class FutureAware(metaclass=FutureMeta):
 
 
 class BaseConnector(Connector, FutureAware):
-    @staticmethod
-    def get_option(
-        name: str,
-        value: Any,
-    ) -> str:
-        if len(name) > 1:
-            name = f"-{name} "
-        if isinstance(value, bool):
-            return f"-{name} " if value else ""
-        elif isinstance(value, str):
-            return f'-{name} "{value}" '
-        elif isinstance(value, MutableSequence):
-            return "".join([f'-{name} "{item}" ' for item in value])
-        elif value is None:
-            return ""
-        else:
-            raise TypeError("Unsupported value type")
-
     def __init__(self, deployment_name: str, config_dir: str, transferBufferSize: int):
         super().__init__(deployment_name, config_dir)
         self.transferBufferSize: int = transferBufferSize

--- a/streamflow/deployment/connector/container.py
+++ b/streamflow/deployment/connector/container.py
@@ -18,7 +18,7 @@ from streamflow.core.asyncache import cachedmethod
 from streamflow.core.deployment import Connector, Location
 from streamflow.core.exception import WorkflowExecutionException
 from streamflow.core.scheduling import AvailableLocation
-from streamflow.core.utils import get_local_to_remote_destination
+from streamflow.core.utils import get_local_to_remote_destination, get_option
 from streamflow.deployment.connector.base import BaseConnector
 from streamflow.log_handler import logger
 
@@ -563,109 +563,98 @@ class DockerConnector(DockerBaseConnector):
                 await _pull_docker_image(self.image)
             # Deploy the Docker container
             for _ in range(0, self.replicas):
-                deploy_command = "".join(
-                    [
-                        "docker ",
-                        "run ",
-                        "--detach ",
-                        "--interactive ",
-                        self.get_option("add-host", self.addHost),
-                        self.get_option("blkio-weight", self.addHost),
-                        self.get_option("blkio-weight-device", self.blkioWeightDevice),
-                        self.get_option("cap-add", self.capAdd),
-                        self.get_option("cap-drop", self.capDrop),
-                        self.get_option("cgroup-parent", self.cgroupParent),
-                        self.get_option("cgroupns", self.cgroupns),
-                        self.get_option("cidfile", self.cidfile),
-                        self.get_option("cpu-period", self.cpuPeriod),
-                        self.get_option("cpu-quota", self.cpuQuota),
-                        self.get_option("cpu-rt-period", self.cpuRTPeriod),
-                        self.get_option("cpu-rt-runtime", self.cpuRTRuntime),
-                        self.get_option("cpu-shares", self.cpuShares),
-                        self.get_option("cpus", self.cpus),
-                        self.get_option("cpuset-cpus", self.cpusetCpus),
-                        self.get_option("cpuset-mems", self.cpusetMems),
-                        self.get_option("detach-keys", self.detachKeys),
-                        self.get_option("device", self.device),
-                        self.get_option("device-cgroup-rule", self.deviceCgroupRule),
-                        self.get_option("device-read-bps", self.deviceReadBps),
-                        self.get_option("device-read-iops", self.deviceReadIops),
-                        self.get_option("device-write-bps", self.deviceWriteBps),
-                        self.get_option("device-write-iops", self.deviceWriteIops),
-                        "--disable-content-trust={disableContentTrust} ".format(
-                            disableContentTrust="true"
-                            if self.disableContentTrust
-                            else "false"
-                        ),
-                        self.get_option("dns", self.dns),
-                        self.get_option("dns-option", self.dnsOptions),
-                        self.get_option("dns-search", self.dnsSearch),
-                        self.get_option("domainname", self.domainname),
-                        self.get_option("entrypoint", self.entrypoint),
-                        self.get_option("env", self.env),
-                        self.get_option("env-file", self.envFile),
-                        self.get_option("expose", self.expose),
-                        self.get_option("gpus", self.gpus),
-                        self.get_option("group-add", self.groupAdd),
-                        self.get_option("health-cmd", self.healthCmd),
-                        self.get_option("health-interval", self.healthInterval),
-                        self.get_option("health-retries", self.healthRetries),
-                        self.get_option("health-start-period", self.healthStartPeriod),
-                        self.get_option("health-timeout", self.healthTimeout),
-                        self.get_option("hostname", self.hostname),
-                        self.get_option("init", self.init),
-                        self.get_option("ip", self.ip),
-                        self.get_option("ip6", self.ip6),
-                        self.get_option("ipc", self.ipc),
-                        self.get_option("isolation", self.isolation),
-                        self.get_option("kernel-memory", self.kernelMemory),
-                        self.get_option("label", self.label),
-                        self.get_option("label-file", self.labelFile),
-                        self.get_option("link", self.link),
-                        self.get_option("link-local-ip", self.linkLocalIP),
-                        self.get_option("log-driver", self.logDriver),
-                        self.get_option("log-opt", self.logOpts),
-                        self.get_option("mac-address", self.macAddress),
-                        self.get_option("memory", self.memory),
-                        self.get_option("memory-reservation", self.memoryReservation),
-                        self.get_option("memory-swap", self.memorySwap),
-                        self.get_option("memory-swappiness", self.memorySwappiness),
-                        self.get_option("mount", self.mount),
-                        self.get_option("network", self.network),
-                        self.get_option("network-alias", self.networkAlias),
-                        self.get_option("no-healthcheck", self.noHealthcheck),
-                        self.get_option("oom-kill-disable", self.oomKillDisable),
-                        self.get_option("oom-score-adj", self.oomScoreAdj),
-                        self.get_option("pid", self.pid),
-                        self.get_option("pids-limit", self.pidsLimit),
-                        self.get_option("privileged", self.privileged),
-                        self.get_option("publish", self.publish),
-                        self.get_option("publish-all", self.publishAll),
-                        self.get_option("read-only", self.readOnly),
-                        self.get_option("restart", self.restart),
-                        self.get_option("rm", self.rm),
-                        self.get_option("runtime", self.runtime),
-                        self.get_option("security-opt", self.securityOpts),
-                        self.get_option("shm-size", self.shmSize),
-                        "--sig-proxy={sigProxy} ".format(
-                            sigProxy="true" if self.sigProxy else "false"
-                        ),
-                        self.get_option("stop-signal", self.stopSignal),
-                        self.get_option("stop-timeout", self.stopTimeout),
-                        self.get_option("storage-opt", self.storageOpts),
-                        self.get_option("sysctl", self.sysctl),
-                        self.get_option("tmpfs", self.tmpfs),
-                        self.get_option("ulimit", self.ulimit),
-                        self.get_option("user", self.user),
-                        self.get_option("userns", self.userns),
-                        self.get_option("uts", self.uts),
-                        self.get_option("volume", self.volume),
-                        self.get_option("volume-driver", self.volumeDriver),
-                        self.get_option("volumes-from", self.volumesFrom),
-                        self.get_option("workdir", self.workdir),
-                        f"{self.image} ",
-                        " ".join(self.command) if self.command else "",
-                    ]
+                deploy_command = (
+                    f"docker run --detach --interactive "
+                    f"{get_option('add-host', self.addHost)}"
+                    f"{get_option('blkio-weight', self.addHost)}"
+                    f"{get_option('blkio-weight-device', self.blkioWeightDevice)}"
+                    f"{get_option('cap-add', self.capAdd)}"
+                    f"{get_option('cap-drop', self.capDrop)}"
+                    f"{get_option('cgroup-parent', self.cgroupParent)}"
+                    f"{get_option('cgroupns', self.cgroupns)}"
+                    f"{get_option('cidfile', self.cidfile)}"
+                    f"{get_option('cpu-period', self.cpuPeriod)}"
+                    f"{get_option('cpu-quota', self.cpuQuota)}"
+                    f"{get_option('cpu-rt-period', self.cpuRTPeriod)}"
+                    f"{get_option('cpu-rt-runtime', self.cpuRTRuntime)}"
+                    f"{get_option('cpu-shares', self.cpuShares)}"
+                    f"{get_option('cpus', self.cpus)}"
+                    f"{get_option('cpuset-cpus', self.cpusetCpus)}"
+                    f"{get_option('cpuset-mems', self.cpusetMems)}"
+                    f"{get_option('detach-keys', self.detachKeys)}"
+                    f"{get_option('device', self.device)}"
+                    f"{get_option('device-cgroup-rule', self.deviceCgroupRule)}"
+                    f"{get_option('device-read-bps', self.deviceReadBps)}"
+                    f"{get_option('device-read-iops', self.deviceReadIops)}"
+                    f"{get_option('device-write-bps', self.deviceWriteBps)}"
+                    f"{get_option('device-write-iops', self.deviceWriteIops)}"
+                    f"--disable-content-trust={'true' if self.disableContentTrust else 'false'} "
+                    f"{get_option('dns', self.dns)}"
+                    f"{get_option('dns-option', self.dnsOptions)}"
+                    f"{get_option('dns-search', self.dnsSearch)}"
+                    f"{get_option('domainname', self.domainname)}"
+                    f"{get_option('entrypoint', self.entrypoint)}"
+                    f"{get_option('env', self.env)}"
+                    f"{get_option('env-file', self.envFile)}"
+                    f"{get_option('expose', self.expose)}"
+                    f"{get_option('gpus', self.gpus)}"
+                    f"{get_option('group-add', self.groupAdd)}"
+                    f"{get_option('health-cmd', self.healthCmd)}"
+                    f"{get_option('health-interval', self.healthInterval)}"
+                    f"{get_option('health-retries', self.healthRetries)}"
+                    f"{get_option('health-start-period', self.healthStartPeriod)}"
+                    f"{get_option('health-timeout', self.healthTimeout)}"
+                    f"{get_option('hostname', self.hostname)}"
+                    f"{get_option('init', self.init)}"
+                    f"{get_option('ip', self.ip)}"
+                    f"{get_option('ip6', self.ip6)}"
+                    f"{get_option('ipc', self.ipc)}"
+                    f"{get_option('isolation', self.isolation)}"
+                    f"{get_option('kernel-memory', self.kernelMemory)}"
+                    f"{get_option('label', self.label)}"
+                    f"{get_option('label-file', self.labelFile)}"
+                    f"{get_option('link', self.link)}"
+                    f"{get_option('link-local-ip', self.linkLocalIP)}"
+                    f"{get_option('log-driver', self.logDriver)}"
+                    f"{get_option('log-opt', self.logOpts)}"
+                    f"{get_option('mac-address', self.macAddress)}"
+                    f"{get_option('memory', self.memory)}"
+                    f"{get_option('memory-reservation', self.memoryReservation)}"
+                    f"{get_option('memory-swap', self.memorySwap)}"
+                    f"{get_option('memory-swappiness', self.memorySwappiness)}"
+                    f"{get_option('mount', self.mount)}"
+                    f"{get_option('network', self.network)}"
+                    f"{get_option('network-alias', self.networkAlias)}"
+                    f"{get_option('no-healthcheck', self.noHealthcheck)}"
+                    f"{get_option('oom-kill-disable', self.oomKillDisable)}"
+                    f"{get_option('oom-score-adj', self.oomScoreAdj)}"
+                    f"{get_option('pid', self.pid)}"
+                    f"{get_option('pids-limit', self.pidsLimit)}"
+                    f"{get_option('privileged', self.privileged)}"
+                    f"{get_option('publish', self.publish)}"
+                    f"{get_option('publish-all', self.publishAll)}"
+                    f"{get_option('read-only', self.readOnly)}"
+                    f"{get_option('restart', self.restart)}"
+                    f"{get_option('rm', self.rm)}"
+                    f"{get_option('runtime', self.runtime)}"
+                    f"{get_option('security-opt', self.securityOpts)}"
+                    f"{get_option('shm-size', self.shmSize)}"
+                    f"--sig-proxy={'true' if self.sigProxy else 'false'} "
+                    f"{get_option('stop-signal', self.stopSignal)}"
+                    f"{get_option('stop-timeout', self.stopTimeout)}"
+                    f"{get_option('storage-opt', self.storageOpts)}"
+                    f"{get_option('sysctl', self.sysctl)}"
+                    f"{get_option('tmpfs', self.tmpfs)}"
+                    f"{get_option('ulimit', self.ulimit)}"
+                    f"{get_option('user', self.user)}"
+                    f"{get_option('userns', self.userns)}"
+                    f"{get_option('uts', self.uts)}"
+                    f"{get_option('volume', self.volume)}"
+                    f"{get_option('volume-driver', self.volumeDriver)}"
+                    f"{get_option('volumes-from', self.volumesFrom)}"
+                    f"{get_option('workdir', self.workdir)}"
+                    f"{self.image} "
+                    f"{' '.join(self.command) if self.command else ''}"
                 )
                 if logger.isEnabledFor(logging.DEBUG):
                     logger.debug(f"EXECUTING command {deploy_command}")
@@ -786,24 +775,22 @@ class DockerComposeConnector(DockerBaseConnector):
         self.tlsverify = tlsverify
 
     def _get_base_command(self) -> str:
-        return "".join(
-            [
-                "docker-compose ",
-                self.get_option("file", self.files),
-                self.get_option("project-name", self.projectName),
-                self.get_option("verbose", self.verbose),
-                self.get_option("log-level", self.logLevel),
-                self.get_option("no-ansi", self.noAnsi),
-                self.get_option("host", self.host),
-                self.get_option("tls", self.tls),
-                self.get_option("tlscacert", self.tlscacert),
-                self.get_option("tlscert", self.tlscert),
-                self.get_option("tlskey", self.tlskey),
-                self.get_option("tlsverify", self.tlsverify),
-                self.get_option("skip-hostname-check", self.skipHostnameCheck),
-                self.get_option("project-directory", self.projectDirectory),
-                self.get_option("compatibility", self.compatibility),
-            ]
+        return (
+            f"docker-compose "
+            f"{get_option('file', self.files)}"
+            f"{get_option('project-name', self.projectName)}"
+            f"{get_option('verbose', self.verbose)}"
+            f"{get_option('log-level', self.logLevel)}"
+            f"{get_option('no-ansi', self.noAnsi)}"
+            f"{get_option('host', self.host)}"
+            f"{get_option('tls', self.tls)}"
+            f"{get_option('tlscacert', self.tlscacert)}"
+            f"{get_option('tlscert', self.tlscert)}"
+            f"{get_option('tlskey', self.tlskey)}"
+            f"{get_option('tlsverify', self.tlsverify)}"
+            f"{get_option('skip-hostname-check', self.skipHostnameCheck)}"
+            f"{get_option('project-directory', self.projectDirectory)}"
+            f"{get_option('compatibility', self.compatibility)}"
         )
 
     async def deploy(self, external: bool) -> None:
@@ -823,17 +810,14 @@ class DockerComposeConnector(DockerBaseConnector):
                     f"Using Docker {await _get_docker_version()} "
                     f"and Docker Compose {version}."
                 )
-            deploy_command = self._get_base_command() + "".join(
-                [
-                    "up ",
-                    "--detach ",
-                    self.get_option("no-deps ", self.noDeps),
-                    self.get_option("force-recreate", self.forceRecreate),
-                    self.get_option("always-recreate-deps", self.alwaysRecreateDeps),
-                    self.get_option("no-recreate", self.noRecreate),
-                    self.get_option("no-build", self.noBuild),
-                    self.get_option("no-start", self.noStart),
-                ]
+            deploy_command = (
+                f"{self._get_base_command()} up --detach "
+                f"{get_option('no-deps ', self.noDeps)}"
+                f"{get_option('force-recreate', self.forceRecreate)}"
+                f"{get_option('always-recreate-deps', self.alwaysRecreateDeps)}"
+                f"{get_option('no-recreate', self.noRecreate)}"
+                f"{get_option('no-build', self.noBuild)}"
+                f"{get_option('no-start', self.noStart)}"
             )
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug(f"EXECUTING command {deploy_command}")
@@ -891,7 +875,7 @@ class DockerComposeConnector(DockerBaseConnector):
         if not external:
             undeploy_command = (
                 self._get_base_command()
-                + f"down {self.get_option('volumes', self.removeVolumes)}"
+                + f"down {get_option('volumes', self.removeVolumes)}"
             )
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug(f"EXECUTING command {undeploy_command}")
@@ -1107,61 +1091,61 @@ class SingularityConnector(ContainerConnector):
                 instance_name = utils.random_name()
                 deploy_command = (
                     f"singularity instance start "
-                    f"{self.get_option('add-caps', self.addCaps)}"
-                    f"{self.get_option('allow-setuid', self.allowSetuid)}"
-                    f"{self.get_option('apply-cgroups', self.applyCgroups)}"
-                    f"{self.get_option('bind', self.bind)}"
-                    f"{self.get_option('blkio-weight', self.blkioWeight)}"
-                    f"{self.get_option('blkio-weight-device', self.blkioWeightDevice)}"
-                    f"{self.get_option('boot', self.boot)}"
-                    f"{self.get_option('cleanenv', self.cleanenv)}"
-                    f"{self.get_option('compat', self.compat)}"
-                    f"{self.get_option('contain', self.contain)}"
-                    f"{self.get_option('containall', self.containall)}"
-                    f"{self.get_option('cpu-shares', self.cpuShares)}"
-                    f"{self.get_option('cpus', self.cpus)}"
-                    f"{self.get_option('cpuset-cpus', self.cpusetCpus)}"
-                    f"{self.get_option('cpuset-mems', self.cpusetMems)}"
-                    f"{self.get_option('disable-cache', self.disableCache)}"
-                    f"{self.get_option('docker-host', self.dockerHost)}"
-                    f"{self.get_option('dns', self.dns)}"
-                    f"{self.get_option('drop-caps', self.dropCaps)}"
-                    f"{self.get_option('env-file', self.envFile)}"
-                    f"{self.get_option('fakeroot', self.fakeroot)}"
-                    f"{self.get_option('fusemount', self.fusemount)}"
-                    f"{self.get_option('home', self.home)}"
-                    f"{self.get_option('hostname', self.hostname)}"
-                    f"{self.get_option('ipc', self.ipc)}"
-                    f"{self.get_option('keep-privs', self.keepPrivs)}"
-                    f"{self.get_option('memory', self.memory)}"
-                    f"{self.get_option('memory-reservation', self.memoryReservation)}"
-                    f"{self.get_option('memory-swap', self.memorySwap)}"
-                    f"{self.get_option('mount', self.mount)}"
-                    f"{self.get_option('net', self.net)}"
-                    f"{self.get_option('network', self.network)}"
-                    f"{self.get_option('network-args', self.networkArgs)}"
-                    f"{self.get_option('no-eval', self.noEval)}"
-                    f"{self.get_option('no-home', self.noHome)}"
-                    f"{self.get_option('no-https', self.noHttps)}"
-                    f"{self.get_option('no-init', self.noInit)}"
-                    f"{self.get_option('no-mount', self.noMount)}"
-                    f"{self.get_option('no-privs', self.noPrivs)}"
-                    f"{self.get_option('no-umask', self.noUmask)}"
-                    f"{self.get_option('nv', self.nv)}"
-                    f"{self.get_option('nvccli', self.nvccli)}"
-                    f"{self.get_option('oom-kill-disable', self.oomKillDisable)}"
-                    f"{self.get_option('overlay', self.overlay)}"
-                    f"{self.get_option('pem-path', self.pemPath)}"
-                    f"{self.get_option('pid-file', self.pidFile)}"
-                    f"{self.get_option('pids-limit', self.pidsLimit)}"
-                    f"{self.get_option('rocm', self.rocm)}"
-                    f"{self.get_option('scratch', self.scratch)}"
-                    f"{self.get_option('security', self.security)}"
-                    f"{self.get_option('userns', self.userns)}"
-                    f"{self.get_option('uts', self.uts)}"
-                    f"{self.get_option('workdir', self.workdir)}"
-                    f"{self.get_option('writable', self.writable)}"
-                    f"{self.get_option('writable-tmpfs', self.writableTmpfs)}"
+                    f"{get_option('add-caps', self.addCaps)}"
+                    f"{get_option('allow-setuid', self.allowSetuid)}"
+                    f"{get_option('apply-cgroups', self.applyCgroups)}"
+                    f"{get_option('bind', self.bind)}"
+                    f"{get_option('blkio-weight', self.blkioWeight)}"
+                    f"{get_option('blkio-weight-device', self.blkioWeightDevice)}"
+                    f"{get_option('boot', self.boot)}"
+                    f"{get_option('cleanenv', self.cleanenv)}"
+                    f"{get_option('compat', self.compat)}"
+                    f"{get_option('contain', self.contain)}"
+                    f"{get_option('containall', self.containall)}"
+                    f"{get_option('cpu-shares', self.cpuShares)}"
+                    f"{get_option('cpus', self.cpus)}"
+                    f"{get_option('cpuset-cpus', self.cpusetCpus)}"
+                    f"{get_option('cpuset-mems', self.cpusetMems)}"
+                    f"{get_option('disable-cache', self.disableCache)}"
+                    f"{get_option('docker-host', self.dockerHost)}"
+                    f"{get_option('dns', self.dns)}"
+                    f"{get_option('drop-caps', self.dropCaps)}"
+                    f"{get_option('env-file', self.envFile)}"
+                    f"{get_option('fakeroot', self.fakeroot)}"
+                    f"{get_option('fusemount', self.fusemount)}"
+                    f"{get_option('home', self.home)}"
+                    f"{get_option('hostname', self.hostname)}"
+                    f"{get_option('ipc', self.ipc)}"
+                    f"{get_option('keep-privs', self.keepPrivs)}"
+                    f"{get_option('memory', self.memory)}"
+                    f"{get_option('memory-reservation', self.memoryReservation)}"
+                    f"{get_option('memory-swap', self.memorySwap)}"
+                    f"{get_option('mount', self.mount)}"
+                    f"{get_option('net', self.net)}"
+                    f"{get_option('network', self.network)}"
+                    f"{get_option('network-args', self.networkArgs)}"
+                    f"{get_option('no-eval', self.noEval)}"
+                    f"{get_option('no-home', self.noHome)}"
+                    f"{get_option('no-https', self.noHttps)}"
+                    f"{get_option('no-init', self.noInit)}"
+                    f"{get_option('no-mount', self.noMount)}"
+                    f"{get_option('no-privs', self.noPrivs)}"
+                    f"{get_option('no-umask', self.noUmask)}"
+                    f"{get_option('nv', self.nv)}"
+                    f"{get_option('nvccli', self.nvccli)}"
+                    f"{get_option('oom-kill-disable', self.oomKillDisable)}"
+                    f"{get_option('overlay', self.overlay)}"
+                    f"{get_option('pem-path', self.pemPath)}"
+                    f"{get_option('pid-file', self.pidFile)}"
+                    f"{get_option('pids-limit', self.pidsLimit)}"
+                    f"{get_option('rocm', self.rocm)}"
+                    f"{get_option('scratch', self.scratch)}"
+                    f"{get_option('security', self.security)}"
+                    f"{get_option('userns', self.userns)}"
+                    f"{get_option('uts', self.uts)}"
+                    f"{get_option('workdir', self.workdir)}"
+                    f"{get_option('writable', self.writable)}"
+                    f"{get_option('writable-tmpfs', self.writableTmpfs)}"
                     f"{self.image} "
                     f"{instance_name} "
                     f"{' '.join(self.command) if self.command else ''}"

--- a/streamflow/deployment/connector/kubernetes.py
+++ b/streamflow/deployment/connector/kubernetes.py
@@ -44,6 +44,7 @@ from streamflow.core.exception import (
     WorkflowExecutionException,
 )
 from streamflow.core.scheduling import AvailableLocation
+from streamflow.core.utils import get_option
 from streamflow.deployment import aiotarstream
 from streamflow.deployment.aiotarstream import BaseStreamWrapper
 from streamflow.deployment.connector.base import BaseConnector, extract_tar_stream
@@ -413,18 +414,14 @@ class BaseKubernetesConnector(BaseConnector, ABC):
         self, command: str, location: Location, interactive: bool = False
     ):
         pod, container = location.name.split(":")
-        return "".join(
-            [
-                "kubectl ",
-                self.get_option("namespace", self.namespace),
-                self.get_option("kubeconfig", self.kubeconfig),
-                "exec ",
-                f"{pod} ",
-                self.get_option("i", interactive),
-                self.get_option("container", container),
-                "-- ",
-                command,
-            ]
+        return (
+            f"kubectl "
+            f"{get_option('namespace', self.namespace)}"
+            f"{get_option('kubeconfig', self.kubeconfig)}"
+            f"exec {pod} "
+            f"{get_option('i', interactive)}"
+            f"{get_option('container', container)}"
+            f"-- {command}"
         )
 
     @abstractmethod
@@ -978,17 +975,15 @@ class Helm3Connector(BaseKubernetesConnector):
         self.wait: bool = wait
 
     def _get_base_command(self) -> str:
-        return "".join(
-            [
-                "helm ",
-                self.get_option("debug", self.debug),
-                self.get_option("kube-context", self.kubeContext),
-                self.get_option("kubeconfig", self.kubeconfig),
-                self.get_option("namespace", self.namespace),
-                self.get_option("registry-config", self.registryConfig),
-                self.get_option("repository-cache", self.repositoryCache),
-                self.get_option("repository-config", self.repositoryConfig),
-            ]
+        return (
+            f"helm "
+            f"{get_option('debug', self.debug)}"
+            f"{get_option('kube-context', self.kubeContext)}"
+            f"{get_option('kubeconfig', self.kubeconfig)}"
+            f"{get_option('namespace', self.namespace)}"
+            f"{get_option('registry-config', self.registryConfig)}"
+            f"{get_option('repository-cache', self.repositoryCache)}"
+            f"{get_option('repository-config', self.repositoryConfig)}"
         )
 
     async def _get_running_pods(self) -> MutableSequence[Any]:
@@ -1013,34 +1008,32 @@ class Helm3Connector(BaseKubernetesConnector):
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug(f"Using Helm {version}.")
             # Deploy Helm charts
-            deploy_command = self._get_base_command() + "".join(
-                [
-                    "install ",
-                    self.get_option("atomic", self.atomic),
-                    self.get_option("ca-file", self.caFile),
-                    self.get_option("cert-file", self.certFile),
-                    self.get_option("dep-up", self.depUp),
-                    self.get_option("devel", self.devel),
-                    self.get_option("key-file", self.keyFile),
-                    self.get_option("keyring", self.keyring),
-                    self.get_option("name-template", self.nameTemplate),
-                    self.get_option("no-hooks", self.noHooks),
-                    self.get_option("password", self.password),
-                    self.get_option("render-subchart-notes", self.renderSubchartNotes),
-                    self.get_option("repo", self.repo),
-                    self.get_option("set", self.commandLineValues),
-                    self.get_option("set-file", self.fileValues),
-                    self.get_option("set-string", self.stringValues),
-                    self.get_option("skip-crds", self.skipCrds),
-                    self.get_option("timeout", self.timeout),
-                    self.get_option("username", self.username),
-                    self.get_option("values", self.yamlValues),
-                    self.get_option("verify", self.verify),
-                    self.get_option("version", self.chartVersion),
-                    self.get_option("wait", self.wait),
-                    f"{self.releaseName} ",
-                    self.chart,
-                ]
+            deploy_command = (
+                f"{self._get_base_command()} install "
+                f"{get_option('atomic', self.atomic)}"
+                f"{get_option('ca-file', self.caFile)}"
+                f"{get_option('cert-file', self.certFile)}"
+                f"{get_option('dep-up', self.depUp)}"
+                f"{get_option('devel', self.devel)}"
+                f"{get_option('key-file', self.keyFile)}"
+                f"{get_option('keyring', self.keyring)}"
+                f"{get_option('name-template', self.nameTemplate)}"
+                f"{get_option('no-hooks', self.noHooks)}"
+                f"{get_option('password', self.password)}"
+                f"{get_option('render-subchart-notes', self.renderSubchartNotes)}"
+                f"{get_option('repo', self.repo)}"
+                f"{get_option('set', self.commandLineValues)}"
+                f"{get_option('set-file', self.fileValues)}"
+                f"{get_option('set-string', self.stringValues)}"
+                f"{get_option('skip-crds', self.skipCrds)}"
+                f"{get_option('timeout', self.timeout)}"
+                f"{get_option('username', self.username)}"
+                f"{get_option('values', self.yamlValues)}"
+                f"{get_option('verify', self.verify)}"
+                f"{get_option('version', self.chartVersion)}"
+                f"{get_option('wait', self.wait)}"
+                f"{self.releaseName} "
+                f"{self.chart}"
             )
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug(f"EXECUTING {deploy_command}")
@@ -1064,14 +1057,12 @@ class Helm3Connector(BaseKubernetesConnector):
     async def undeploy(self, external: bool) -> None:
         if not external:
             # Undeploy
-            undeploy_command = self._get_base_command() + "".join(
-                [
-                    "uninstall ",
-                    self.get_option("keep-history", self.keepHistory),
-                    self.get_option("no-hooks", self.noHooks),
-                    self.get_option("timeout", self.timeout),
-                    self.releaseName,
-                ]
+            undeploy_command = (
+                f"{self._get_base_command()}  uninstall "
+                f"{get_option('keep-history', self.keepHistory)}"
+                f"{get_option('no-hooks', self.noHooks)}"
+                f"{get_option('timeout', self.timeout)}"
+                f"{self.releaseName}"
             )
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug(f"EXECUTING {undeploy_command}")

--- a/streamflow/deployment/connector/occam.py
+++ b/streamflow/deployment/connector/occam.py
@@ -14,6 +14,7 @@ from ruamel.yaml import YAML
 from streamflow.core import utils
 from streamflow.core.deployment import Location
 from streamflow.core.scheduling import AvailableLocation
+from streamflow.core.utils import get_option
 from streamflow.deployment.connector.ssh import SSHConnector
 from streamflow.log_handler import logger
 
@@ -274,18 +275,19 @@ class OccamConnector(SSHConnector):
     async def _deploy_node(
         self, name: str, service: MutableMapping[str, Any], node: str
     ):
-        deploy_command = "".join(
-            [
-                (f"cd {service.get('workdir')} && " if "workdir" in service else ""),
-                "occam-run ",
-                self.get_option("x", service.get("x11")),
-                self.get_option("n", node),
-                self.get_option("i", service.get("stdin")),
-                self.get_option("c", service.get("jobidFile")),
-                self.get_option("s", service.get("shmSize")),
-                self.get_option("v", service.get("volumes")),
-                f"{service['image']} " " ".join(service.get("command", "")),
-            ]
+        deploy_command = (
+            f"cd {service.get('workdir')} && "
+            if "workdir" in service
+            else ""
+            f"occam-run "
+            f"{get_option('x', service.get('x11'))}"
+            f"{get_option('n', node)}"
+            f"{get_option('i', service.get('stdin'))}"
+            f"{get_option('c', service.get('jobidFile'))}"
+            f"{get_option('s', service.get('shmSize'))}"
+            f"{get_option('v', service.get('volumes'))}"
+            f"{service['image']} "
+            f"{' '.join(service.get('command', ''))}"
         )
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(f"EXECUTING {deploy_command}")

--- a/streamflow/deployment/connector/schemas/flux.json
+++ b/streamflow/deployment/connector/schemas/flux.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "flux.json",
+  "type": "object",
+  "definitions": {
+    "service": {
+      "$id": "#/definitions/service",
+      "type": "object",
+      "title": "FluxService",
+      "description": "This complex type represents a submission to the Flux queue manager.",
+      "properties": {
+        "beginTime": {
+          "type": "string",
+          "description": "Convenience option for setting a ``begin-time`` dependency for a job. The job is guaranteed to start after the specified date and time"
+        },
+        "brokerOpts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "For batch jobs, pass specified options to the Flux brokers of the new instance"
+        },
+        "cores": {
+          "type": "integer",
+          "description": "Set the total number of cores"
+        },
+        "coresPerSlot": {
+          "type": "integer",
+          "description": "Set the number of cores to assign to each slot"
+        },
+        "coresPerTask": {
+          "type": "integer",
+          "description": "Set the number of cores to assign to each task"
+        },
+        "env": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Control how environment variables are exported"
+        },
+        "envFile": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Read a set of environment rules from a file"
+        },
+        "envRemove": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Remove all environment variables matching the pattern from the current generated environment"
+        },
+        "exclusive": {
+          "type": "boolean",
+          "description": "Indicate to the scheduler that nodes should be exclusively allocated to this job"
+        },
+        "file": {
+          "type": "string",
+          "description": "Path to a file containing a Jinja2 template, describing how the StreamFlow command should be executed in the remote environment"
+        },
+        "flags": {
+          "type": "string",
+          "description": "Set comma separated list of job submission flags"
+        },
+        "gpusPerNode": {
+          "type": "integer",
+          "description": "Request a specific number of GPUs per node"
+        },
+        "gpusPerSlot": {
+          "type": "integer",
+          "description": "Set the number of GPU devices to assign to each slot"
+        },
+        "gpusPerTask": {
+          "type": "integer",
+          "description": "Set the number of GPU devices to assign to each task"
+        },
+        "jobName": {
+          "type": "string",
+          "description": "Set an alternate job name for the job"
+        },
+        "labelIO": {
+          "type": "boolean",
+          "description": "Add task rank prefixes to each line of output"
+        },
+        "nodes": {
+          "type": "integer",
+          "description": "Set the number of nodes to assign to the job"
+        },
+        "nslots": {
+          "type": "integer",
+          "description": "Set the number of slots requested"
+        },
+        "ntasks": {
+          "type": "integer",
+          "description": "Set the number of tasks to launch"
+        },
+        "queue": {
+          "type": "string",
+          "description": "Submit a job to a specific named queue"
+        },
+        "requires": {
+          "type": "string",
+          "description": "Specify a set of allowable properties and other attributes to consider when matching resources for a job"
+        },
+        "rlimit": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Control how process resource limits are propagated"
+        },
+        "setattr": {
+          "type": "object",
+          "description": "Set jobspec attribute. Keys may include periods to denote hierarchy"
+        },
+        "setopt": {
+          "type": "object",
+          "description": "Set shell option. Keys may include periods to denote hierarchy"
+        },
+        "taskmap": {
+          "type": "string",
+          "description": "Choose an alternate method for mapping job task IDs to nodes of the job"
+        },
+        "tasksPerCore": {
+          "type": "integer",
+          "description": "Force a number of tasks per core"
+        },
+        "tasksPerNode": {
+          "type": "integer",
+          "description": "Set the number of tasks per node to run"
+        },
+        "unbuffered": {
+          "type": "boolean",
+          "description": "Disable buffering of standard input and output as much as practical"
+        },
+        "urgency": {
+          "type": "integer",
+          "description": "Specify job urgency, which affects queue order. Numerically higher urgency jobs are considered by the scheduler first"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "queue_manager.json"
+    }
+  ],
+  "properties": {
+    "services": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z][a-zA-Z0-9._-]*$": {
+          "$ref": "#/definitions/service"
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/streamflow/deployment/connector/schemas/pbs.json
+++ b/streamflow/deployment/connector/schemas/pbs.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "pbs.json",
+  "type": "object",
+  "definitions": {
+    "service": {
+      "$id": "#/definitions/service",
+      "type": "object",
+      "title": "PBSService",
+      "description": "This complex type represents a submission to the PBS queue manager.",
+      "properties": {
+        "account": {
+          "type": "string",
+          "description": "Defines the account string associated with the job"
+        },
+        "additionalAttributes": {
+          "type": "object",
+          "description": "Specify additional job attributes"
+        },
+        "begin": {
+          "type": "string",
+          "description": "Declares the time after which the job is eligible for execution"
+        },
+        "checkpoint": {
+          "type": "string",
+          "description": "Defines the interval at which the job will be checkpointed"
+        },
+        "destination": {
+          "type": "string",
+          "description": "Defines the destination of the job. The destination names a queue, a server, or a queue at a server"
+        },
+        "exportAllVariables": {
+          "type": "boolean",
+          "description": "Declares that all environment variables in the qsub command's environment are to be exported to the batch job"
+        },
+        "file": {
+          "type": "string",
+          "description": "Path to a file containing a Jinja2 template, describing how the StreamFlow command should be executed in the remote environment"
+        },
+        "jobName": {
+          "type": "string",
+          "description": "Declares a name for the job. The name specified may be up to and including 15 characters in length. It must consist of printable characters with the first character alphabetic"
+        },
+        "mailOptions": {
+          "type": "string",
+          "description": "Defines the set of conditions under which the execution server will send a mail message about the job"
+        },
+        "prefix": {
+          "type": "string",
+          "description": "Defines the prefix that declares a directive to the qsub command within the script file"
+        },
+        "priority": {
+          "type": "integer",
+          "description": "Defines the priority of the job. The priority argument must be a integer between -1024 and +1023 inclusive"
+        },
+        "rerunnable": {
+          "type": "boolean",
+          "description": "Declares whether the job is rerunable"
+        },
+        "resources": {
+          "type": "object",
+          "description": "Defines the resources that are required by the job and establishes a limit to the amount of resource that can be consumed"
+        },
+        "shellList": {
+          "type": "string",
+          "description": "Declares the shell that interprets the job script"
+        },
+        "userList": {
+          "type": "string",
+          "description": "Defines the user name under which the job is to run on the execution system"
+        },
+        "variableList": {
+          "type": "string",
+          "description": "Expands the list of environment variables that are exported to the job"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "queue_manager.json"
+    }
+  ],
+  "properties": {
+    "services": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z][a-zA-Z0-9._-]*$": {
+          "$ref": "#/definitions/service"
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/streamflow/deployment/connector/schemas/queue_manager.json
+++ b/streamflow/deployment/connector/schemas/queue_manager.json
@@ -52,15 +52,6 @@
       "description": "Time interval (in seconds) between consecutive termination checks",
       "default": 5
     },
-    "services": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z][a-zA-Z0-9._-]*$": {
-          "type": "string",
-          "description": "Path to a file containing a Jinja2 template, describing how the StreamFlow command should be executed in the remote environment"
-        }
-      }
-    },
     "sshKey": {
       "type": "string",
       "description": "(**Deprecated.** Use the `wraps` directive to wrap a standalone SSH connector.) Path to the SSH key needed to connect with Slurm environment"
@@ -83,6 +74,5 @@
       "type": "string",
       "description": "(**Deprecated.** Use the `wraps` directive to wrap a standalone SSH connector.) Username needed to connect with the SSH environment"
     }
-  },
-  "additionalProperties": false
+  }
 }

--- a/streamflow/deployment/connector/schemas/slurm.json
+++ b/streamflow/deployment/connector/schemas/slurm.json
@@ -1,0 +1,414 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "slurm.json",
+  "type": "object",
+  "definitions": {
+    "service": {
+      "$id": "#/definitions/service",
+      "type": "object",
+      "title": "SlurmService",
+      "description": "This complex type represents a submission to the Slurm queue manager.",
+      "properties": {
+        "account": {
+          "type": "string",
+          "description": "Charge resources used by this job to specified account"
+        },
+        "acctgFreq": {
+          "type": "string",
+          "description": "Define the job accounting and profiling sampling intervals in seconds"
+        },
+        "array": {
+          "type": "string",
+          "description": "Submit a job array, multiple jobs to be executed with identical parameters"
+        },
+        "batch": {
+          "type": "string",
+          "description": "Nodes can have features assigned to them by the Slurm administrator. Users can specify which of these features are required by their batch script using this options. The ``batch`` argument must be a subset of the job's ``constraint`` argument"
+        },
+        "bb": {
+          "type": "string",
+          "description": "Burst buffer specification. The form of the specification is system dependent"
+        },
+        "bbf": {
+          "type": "string",
+          "description": "Path of file containing burst buffer specification. The form of the specification is system dependent"
+        },
+        "begin": {
+          "type": "string",
+          "description": "Submit the batch script to the Slurm controller immediately, like normal, but tell the controller to defer the allocation of the job until the specified time"
+        },
+        "clusterConstraint": {
+          "type": "string",
+          "description": "Specifies features that a federated cluster must have to have a sibling job submitted to it. Slurm will attempt to submit a sibling job to a cluster if it has at least one of the specified features. If the ``!`` option is included, Slurm will attempt to submit a sibling job to a cluster that has none of the specified features"
+        },
+        "clusters": {
+          "type": "string",
+          "description": "Clusters to issue commands to. Multiple cluster names may be comma separated. The job will be submitted to the one cluster providing the earliest expected job initiation time. The default value is the current cluster"
+        },
+        "constraint": {
+          "type": "string",
+          "description": "Nodes can have features assigned to them by the Slurm administrator. Users can specify which of these features are required by their job using the constraint option"
+        },
+        "container": {
+          "type": "string",
+          "description": "Absolute path to OCI container bundle"
+        },
+        "containerId": {
+          "type": "string",
+          "description": "Unique name for OCI container"
+        },
+        "contiguous": {
+          "type": "boolean",
+          "description": "If set, then the allocated nodes must form a contiguous set"
+        },
+        "coreSpec": {
+          "type": "integer",
+          "description": "Count of specialized cores per node reserved by the job for system operations and not used by the application. The application will not use these cores, but will be charged for their allocation"
+        },
+        "coresPerSocket": {
+          "type": "integer",
+          "description": "Restrict node selection to nodes with at least the specified number of cores per socket"
+        },
+        "cpuFreq": {
+          "type": "string",
+          "description": "Request that job steps initiated by srun commands inside this sbatch script be run at some requested frequency if possible, on the CPUs selected for the step on the compute node(s)"
+        },
+        "cpusPerGpu": {
+          "type": "integer",
+          "description": "Advise Slurm that ensuing job steps will require ncpus processors per allocated GPU. Not compatible with the ``cpusPerTask`` option"
+        },
+        "cpusPerTask": {
+          "type": "integer",
+          "description": "Advise the Slurm controller that ensuing job steps will require ncpus number of processors per task. Without this option, the controller will just try to allocate one processor per task"
+        },
+        "deadline": {
+          "type": "string",
+          "description": "Remove the job if no ending is possible before this deadline. Default is no deadline"
+        },
+        "delayBoot": {
+          "type": "integer",
+          "description": "Do not reboot nodes in order to satisfied this job's feature specification if the job has been eligible to run for less than this time period. If the job has waited for less than the specified period, it will use only nodes which already have the specified features. The argument is in units of minutes"
+        },
+        "distribution": {
+          "type": "string",
+          "description": "Specify alternate distribution methods for remote processes. For job allocation, this sets environment variables that will be used by subsequent srun requests and also affects which cores will be selected for job allocation"
+        },
+        "exclude": {
+          "type": "string",
+          "description": "Explicitly exclude certain nodes from the resources granted to the jo"
+        },
+        "exclusive": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "The job allocation can not share nodes with other running jobs (or just other users with the ``user`` option or with the ``mcs`` option). If ``user``/``mcs`` are not specified (i.e. the job allocation can not share nodes with other running jobs), the job is allocated all CPUs and GRES on all nodes in the allocation, but is only allocated as much memory as it requested"
+        },
+        "export": {
+          "type": "string",
+          "description": "Identify which environment variables from the submission environment are propagated to the launched application"
+        },
+        "exportFile": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "If a number between 3 and ``OPEN_MAX`` is specified as the argument to this option, a readable file descriptor will be assumed (``STDIN`` and ``STDOUT`` are not supported as valid arguments). Otherwise a filename is assumed. Export environment variables defined in ``filename`` or read from ``fd`` to the job's execution environment"
+        },
+        "extraNodeInfo": {
+          "type": "string",
+          "description": "Restrict node selection to nodes with at least the specified number of sockets, cores per socket and/or threads per core"
+        },
+        "file": {
+          "type": "string",
+          "description": "Path to a file containing a Jinja2 template, describing how the StreamFlow command should be executed in the remote environment"
+        },
+        "getUserEnv": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "This option will tell sbatch to retrieve the login environment variables for the user specified in the ``uid`` option. Be aware that any environment variables already set in sbatch's environment will take precedence over any environment variables in the user's login environment. The optional timeout value is in seconds (default: 8)"
+        },
+        "gid": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Submit the job with group's group access permissions. The ``gid`` option may be the group name or the numerical group ID"
+        },
+        "gpuBind": {
+          "type": "string",
+          "description": "Bind tasks to specific GPUs. By default every spawned task can access every GPU allocated to the step"
+        },
+        "gpuFreq": {
+          "type": "string",
+          "description": "Request that GPUs allocated to the job are configured with specific frequency values. This option can be used to independently configure the GPU and its memory frequencies"
+        },
+        "gpus": {
+          "type": "string",
+          "description": "Specify the total number of GPUs required for the job. An optional GPU type specification can be supplied (e.g., ``volta:3``)"
+        },
+        "gpusPerNode": {
+          "type": "string",
+          "description": "Specify the number of GPUs required for the job on each node included in the job's resource allocation. An optional GPU type specification can be supplied (e.g., ``volta:3``)"
+        },
+        "gpusPerSocket": {
+          "type": "string",
+          "description": "Specify the number of GPUs required for the job on each socket included in the job's resource allocation. An optional GPU type specification can be supplied (e.g., ``volta:3``)"
+        },
+        "gpusPerTask": {
+          "type": "string",
+          "description": "Specify the number of GPUs required for the job on each task to be spawned in the job's resource allocation. An optional GPU type specification can be supplied (e.g., ``volta:3``)"
+        },
+        "gres": {
+          "type": "string",
+          "description": "Specifies a comma-delimited list of generic consumable resources"
+        },
+        "gresFlags": {
+          "type": "string",
+          "description": "Specify generic resource task binding options"
+        },
+        "hint": {
+          "type": "string",
+          "description": "Bind tasks according to application hints. This option cannot be used in conjunction with ``ntasksPerCore``, ``threadsPerCore``, or ``extraNodeInfo``"
+        },
+        "ignorePBS": {
+          "type": "boolean",
+          "description": "Ignore all ``#PBS`` and ``#BSUB`` options specified in the batch script"
+        },
+        "jobName": {
+          "type": "string",
+          "description": "Specify a name for the job allocation. The specified name will appear along with the job id number when querying running jobs on the system"
+        },
+        "licenses": {
+          "type": "string",
+          "description": "Specification of licenses (or other resources available on all nodes of the cluster) which must be allocated to this job"
+        },
+        "mailType": {
+          "type": "string",
+          "description": "Notify user by email when certain event types occur"
+        },
+        "mailUser": {
+          "type": "string",
+          "description": "User to receive email notification of state changes as defined by ``mailType``. The default value is the submitting user"
+        },
+        "mcsLabel": {
+          "type": "string",
+          "description": "Used only when the mcs/group plugin is enabled. This parameter is a group among the groups of the user"
+        },
+        "mem": {
+          "type": "string",
+          "description": "Specify the real memory required per node. Default units are megabytes"
+        },
+        "memBind": {
+          "type": "string",
+          "description": "Bind tasks to memory. Used only when the task/affinity plugin is enabled and the NUMA memory functions are available"
+        },
+        "memPerCpu": {
+          "type": "string",
+          "description": "Minimum memory required per usable allocated CPU. Default units are megabytes"
+        },
+        "memPerGpu": {
+          "type": "string",
+          "description": "Minimum memory required per allocated GPU. Default units are megabytes"
+        },
+        "mincpus": {
+          "type": "integer",
+          "description": "Specify a minimum number of logical cpus/processors per node"
+        },
+        "network": {
+          "type": "string",
+          "description": "Specify information pertaining to the switch or network"
+        },
+        "nice": {
+          "type": "integer",
+          "description": "Run the job with an adjusted scheduling priority within Slurm. With no adjustment value the scheduling priority is decreased by 100. A negative nice value increases the priority, otherwise decreases it"
+        },
+        "noKill": {
+          "type": "boolean",
+          "description": "Do not automatically terminate a job if one of the nodes it has been allocated fails. The user will assume the responsibilities for fault-tolerance should a node fail. The job allocation will not be revoked so the user may launch new job steps on the remaining nodes in their allocation"
+        },
+        "noRequeue": {
+          "type": "boolean",
+          "description": "Specifies that the batch job should never be requeued under any circumstances"
+        },
+        "nodefile": {
+          "type": "string",
+          "description": "Much like ``nodelist``, but the list is contained in a file of name node file"
+        },
+        "nodelist": {
+          "type": "string",
+          "description": "Request a specific list of hosts. The job will contain all of these hosts and possibly additional hosts as needed to satisfy resource requirements"
+        },
+        "nodes": {
+          "type": "string",
+          "description": "Request that a minimum of minnodes nodes be allocated to this job. A maximum node count may also be specified with maxnodes. If only one number is specified, this is used as both the minimum and maximum node count. Node count can be also specified as ``size_string``. The ``size_string`` specification identifies what nodes values should be used"
+        },
+        "ntasks": {
+          "type": "integer",
+          "description": "This option advises the Slurm controller that job steps run within the allocation will launch a maximum of number tasks and to provide for sufficient resources"
+        },
+        "ntasksPerCore": {
+          "type": "integer",
+          "description": "Request the maximum ntasks be invoked on each core"
+        },
+        "ntasksPerGpu": {
+          "type": "integer",
+          "description": "Request that there are ntasks tasks invoked for every GPU"
+        },
+        "ntasksPerNode": {
+          "type": "integer",
+          "description": "Request that ntasks be invoked on each node"
+        },
+        "ntasksPerSocket": {
+          "type": "integer",
+          "description": "Request the maximum ntasks be invoked on each socket"
+        },
+        "openMode": {
+          "type": "string",
+          "description": "Open the output and error files using append or truncate mode as specified"
+        },
+        "overcommit": {
+          "type": "boolean",
+          "description": "Overcommit resources. When applied to a job allocation (not including jobs requesting exclusive access to the nodes) the resources are allocated as if only one task per node is requested. "
+        },
+        "oversubscribe": {
+          "type": "boolean",
+          "description": "The job allocation can over-subscribe resources with other running jobs. The resources to be over-subscribed can be nodes, sockets, cores, and/or hyperthreads depending upon configuration"
+        },
+        "partition": {
+          "type": "string",
+          "description": "Request a specific partition for the resource allocation. If not specified, the default behavior is to allow the slurm controller to select the default partition as designated by the system administrator"
+        },
+        "power": {
+          "type": "string",
+          "description": "Comma separated list of power management plugin options"
+        },
+        "prefer": {
+          "type": "string",
+          "description": "Nodes can have features assigned to them by the Slurm administrator. Users can specify which of these features are desired but not required by their job using the prefer option. This option operates independently from ``constraint`` and will override whatever is set there if possible"
+        },
+        "priority": {
+          "type": "string",
+          "description": "Request a specific job priority. May be subject to configuration specific constraints"
+        },
+        "profile": {
+          "type": "string",
+          "description": "Enables detailed data collection by the ``acct_gather_profile`` plugin"
+        },
+        "propagate": {
+          "type": "string",
+          "description": "Allows users to specify which of the modifiable (soft) resource limits to propagate to the compute nodes and apply to their jobs"
+        },
+        "qos": {
+          "type": "string",
+          "description": "Request a quality of service for the job"
+        },
+        "reboot": {
+          "type": "boolean",
+          "description": "Force the allocated nodes to reboot before starting the job. This is only supported with some system configurations and will otherwise be silently ignored"
+        },
+        "requeue": {
+          "type": "boolean",
+          "description": "Specifies that the batch job should be eligible for requeuing. The job may be requeued explicitly by a system administrator, after node failure, or upon preemption by a higher priority job"
+        },
+        "reservation": {
+          "type": "string",
+          "description": "Allocate resources for the job from the named reservation. If the job can use more than one reservation, specify their names in a comma separate list and the one offering earliest initiation"
+        },
+        "signal": {
+          "type": "string",
+          "description": "When a job is within ``sig_time`` seconds of its end time, send it the signal ``sig_num``. Due to the resolution of event handling by Slurm, the signal may be sent up to 60 seconds earlier than specified"
+        },
+        "socketsPerNode": {
+          "type": "integer",
+          "description": "Restrict node selection to nodes with at least the specified number of sockets"
+        },
+        "spreadJob": {
+          "type": "boolean",
+          "description": "Spread the job allocation over as many nodes as possible and attempt to evenly distribute tasks across the allocated nodes"
+        },
+        "switches": {
+          "type": "string",
+          "description": "When a tree topology is used, this defines the maximum count of leaf switches desired for the job allocation and optionally the maximum time to wait for that number of switches. If Slurm finds an allocation containing more switches than the count specified, the job remains pending until it either finds an allocation with desired switch count or the time limit expires"
+        },
+        "threadSpec": {
+          "type": "integer",
+          "description": "Count of specialized threads per node reserved by the job for system operations and not used by the application. The application will not use these threads, but will be charged for their allocation"
+        },
+        "threadsPerCore": {
+          "type": "integer",
+          "description": "Restrict node selection to nodes with at least the specified number of threads per core. In task layout, use the specified maximum number of threads per core"
+        },
+        "timeMin": {
+          "type": "string",
+          "description": "Set a minimum time limit on the job allocation. If specified, the job may have its ``time`` limit lowered to a value no lower than ``timeMin`` if doing so permits the job to begin execution earlier than otherwise possible"
+        },
+        "tmp": {
+          "type": "integer",
+          "description": "Specify a minimum amount of temporary disk space per node. Default units are megabytes"
+        },
+        "tresPerTask": {
+          "type": "string",
+          "description": "Specifies a comma-delimited list of trackable resources required for the job on each task to be spawned in the job's resource allocation"
+        },
+        "uid": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Attempt to submit and/or run a job as ``user`` instead of the invoking user id. ``user`` may be the user name or numerical user ID"
+        },
+        "useMinNodes": {
+          "type": "boolean",
+          "description": "If a range of node counts is given, prefer the smaller count"
+        },
+        "waitAllNodes": {
+          "type": "boolean",
+          "description": "Controls when the execution of the command begins. By default the job will begin execution as soon as the allocation is made"
+        },
+        "wckey": {
+          "type": "string",
+          "description": "Specify wckey to be used with job"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "queue_manager.json"
+    }
+  ],
+  "properties": {
+    "services": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z][a-zA-Z0-9._-]*$": {
+          "$ref": "#/definitions/service"
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
This commit adds explicit options to configure QueueManagerConnector classes, i.e., PBS, Slurm, and Flux. Before this commit, such options were only available through custom files. Note that inline options are passed directly to the run command, and therefore they override those provided in the file.