### PR TITLE
Added curl flags in Dockerfile to retry server connection when it fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apk --no-cache add \
         openssl \
         openssl-dev \
     && curl -fsSL \
-          --retry 5
+          --retry 5 \
           --retry-max-time 60 \
           --connect-timeout 5 \
           --max-time 10 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,13 @@ RUN apk --no-cache add \
         musl-dev \
         openssl \
         openssl-dev \
-    && curl -fsSL https://git.io/get_helm.sh -o /tmp/get_helm.sh \
+    && curl -fsSL \
+          --connect-timeout 5 \
+          --max-time 10 \
+          --retry 5 \
+          --retry-delay 0 \
+          --retry-max-time 40 \
+          https://git.io/get_helm.sh -o /tmp/get_helm.sh \
     && chmod +x /tmp/get_helm.sh \
     && /tmp/get_helm.sh --version ${HELM_VERSION} \
     && cd /build \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,11 +27,10 @@ RUN apk --no-cache add \
         openssl \
         openssl-dev \
     && curl -fsSL \
+          --retry 5
+          --retry-max-time 60 \
           --connect-timeout 5 \
           --max-time 10 \
-          --retry 5 \
-          --retry-delay 0 \
-          --retry-max-time 40 \
           https://git.io/get_helm.sh -o /tmp/get_helm.sh \
     && chmod +x /tmp/get_helm.sh \
     && /tmp/get_helm.sh --version ${HELM_VERSION} \


### PR DESCRIPTION
In the image build, the curl command sometimes fails to reach the server https://git.io/get_helm.sh. In these cases, it returns the error code 22 because the flag `-f` is used (e.g. https://github.com/alpha-unito/streamflow/actions/runs/5164549577/jobs/9303525727).

This PR adds the curl flags in the Dockerfile to make further attempts to connect to the server before failing.