### PR TITLE
Handling `allOf` directives in config schemas

### DIFF
--- a/streamflow/deployment/connector/schemas/flux.json
+++ b/streamflow/deployment/connector/schemas/flux.json
@@ -151,6 +151,7 @@
   "properties": {
     "services": {
       "type": "object",
+      "description": "Map containing named configurations of Flux submissions. Parameters can be either specified as #flux directives in a file or directly in YAML format.",
       "patternProperties": {
         "^[a-z][a-zA-Z0-9._-]*$": {
           "$ref": "#/definitions/service"

--- a/streamflow/deployment/connector/schemas/pbs.json
+++ b/streamflow/deployment/connector/schemas/pbs.json
@@ -84,6 +84,7 @@
   "properties": {
     "services": {
       "type": "object",
+      "description": "Map containing named configurations of PBS submissions. Parameters can be either specified as #BSUB directives in a file or directly in YAML format.",
       "patternProperties": {
         "^[a-z][a-zA-Z0-9._-]*$": {
           "$ref": "#/definitions/service"

--- a/streamflow/deployment/connector/schemas/slurm.json
+++ b/streamflow/deployment/connector/schemas/slurm.json
@@ -403,6 +403,7 @@
   "properties": {
     "services": {
       "type": "object",
+      "description": "Map containing named configurations of Slurm submissions. Parameters can be either specified as #SBATCH directives in a file or directly in YAML format.",
       "patternProperties": {
         "^[a-z][a-zA-Z0-9._-]*$": {
           "$ref": "#/definitions/service"


### PR DESCRIPTION
In JSON Schema, the `allOf` directive is commonly used to extend a base schema with new properties. In the case of StreamFlow extensions, all the nested `allOf` directives should be flattened when users call the `streamflow ext show` subcommand, in order to display a complete documentation.