### PR TITLE
Migrate JSONSchema to Draft 2019-09

### DIFF
--- a/streamflow/config/schemas/v1.0/config_schema.json
+++ b/streamflow/config/schemas/v1.0/config_schema.json
@@ -1,10 +1,9 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "config_schema.json",
   "type": "object",
-  "definitions": {
+  "$defs": {
     "binding": {
-      "$id": "#/definitions/binding",
       "oneOf": [
         {
           "type": "object",
@@ -16,13 +15,13 @@
               "oneOf": [
                 {
                   "type": "object",
-                  "$ref": "#/definitions/target"
+                  "$ref": "#/$defs/target"
                 },
                 {
                   "type": "array",
                   "items": {
                     "type": "object",
-                    "$ref": "#/definitions/target"
+                    "$ref": "#/$defs/target"
                   }
                 }
               ]
@@ -49,7 +48,7 @@
             },
             "target": {
               "type": "object",
-              "$ref": "#/definitions/target"
+              "$ref": "#/$defs/target"
             }
           },
           "required": [
@@ -61,9 +60,8 @@
       ]
     },
     "bindingFilter": {
-      "$id": "#/definitions/bindingFilter",
       "type": "object",
-      "definitions": {},
+      "$defs": {},
       "properties": {
         "type": {
           "type": "string"
@@ -76,9 +74,8 @@
       ]
     },
     "checkpointManager": {
-      "$id": "#/definitions/checkpointManager",
       "type": "object",
-      "definitions": {},
+      "$defs": {},
       "properties": {
         "enabled": {
           "type": "boolean",
@@ -105,12 +102,10 @@
       }
     },
     "cwl": {
-      "$id": "#/definitions/cwl",
       "type": "object",
       "docker": {
-        "$id": "#/definitions/cwl/docker",
         "type": "object",
-        "definitions": {},
+        "$defs": {},
         "properties": {
           "type": {
             "type": "string"
@@ -129,9 +124,8 @@
       }
     },
     "database": {
-      "$id": "#/definitions/database",
       "type": "object",
-      "definitions": {},
+      "$defs": {},
       "properties": {
         "type": {
           "type": "string"
@@ -144,9 +138,8 @@
       ]
     },
     "dataManager": {
-      "$id": "#/definitions/dataManager",
       "type": "object",
-      "definitions": {},
+      "$defs": {},
       "properties": {
         "type": {
           "type": "string"
@@ -159,9 +152,8 @@
       ]
     },
     "deployment": {
-      "$id": "#/definitions/deployment",
       "type": "object",
-      "definitions": {},
+      "$defs": {},
       "properties": {
         "external": {
           "type": "boolean",
@@ -198,9 +190,8 @@
       ]
     },
     "deploymentManager": {
-      "$id": "#/definitions/deploymentManager",
       "type": "object",
-      "definitions": {},
+      "$defs": {},
       "properties": {
         "type": {
           "type": "string"
@@ -213,9 +204,8 @@
       ]
     },
     "failureManager": {
-      "$id": "#/definitions/failureManager",
       "type": "object",
-      "definitions": {},
+      "$defs": {},
       "properties": {
         "enabled": {
           "type": "boolean",
@@ -242,9 +232,8 @@
       }
     },
     "policy": {
-      "$id": "#/definitions/policy",
       "type": "object",
-      "definitions": {},
+      "$defs": {},
       "properties": {
         "type": {
           "type": "string"
@@ -257,9 +246,8 @@
       ]
     },
     "scheduler": {
-      "$id": "#/definitions/scheduler",
       "type": "object",
-      "definitions": {},
+      "$defs": {},
       "properties": {
         "type": {
           "type": "string"
@@ -272,7 +260,6 @@
       ]
     },
     "target": {
-      "$id": "#/definitions/target",
       "type": "object",
       "properties": {
         "deployment": {
@@ -320,11 +307,9 @@
       "additionalProperties": false
     },
     "workflow": {
-      "$id": "#/definitions/workflow",
       "type": "object",
-      "definitions": {
+      "$defs": {
         "cwl": {
-          "$id": "#/definitions/workflow/definitions/cwl",
           "type": "object",
           "properties": {
             "file": {
@@ -343,7 +328,7 @@
                   },
                   "deployment": {
                     "type": "object",
-                    "$ref": "#/definitions/cwl/docker"
+                    "$ref": "#/$defs/cwl/docker"
                   }
                 },
                 "additionalProperties": false,
@@ -362,26 +347,24 @@
       },
       "properties": {
         "type": {
-          "$id": "#/definitions/workflow/properties/type",
           "type": "string",
           "enum": [
             "cwl"
           ]
         },
         "bindings": {
-          "$id": "#/definitions/workflow/properties/bindings",
           "type": "array",
           "items": {
             "oneOf": [
               {
                 "type": "object",
-                "$ref": "#/definitions/binding"
+                "$ref": "#/$defs/binding"
               },
               {
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "$ref": "#/definitions/binding"
+                  "$ref": "#/$defs/binding"
                 }
               }
             ]
@@ -401,9 +384,8 @@
           "then": {
             "properties": {
               "config": {
-                "$id": "#/definitions/workflow/properties/config",
                 "type": "object",
-                "$ref": "#/definitions/workflow/definitions/cwl"
+                "$ref": "#/$defs/workflow/$defs/cwl"
               }
             }
           }
@@ -417,75 +399,64 @@
   },
   "properties": {
     "bindingFilters": {
-      "$id": "#/properties/bindingFilters",
       "type": "object",
       "patternProperties": {
         "^[a-z][a-zA-Z0-9._-]*$": {
-          "$ref": "#/definitions/bindingFilter"
+          "$ref": "#/$defs/bindingFilter"
         }
       }
     },
     "checkpointManager": {
-      "$id": "#/properties/checkpointManager",
       "type": "object",
-      "$ref": "#/definitions/checkpointManager"
+      "$ref": "#/$defs/checkpointManager"
     },
     "database": {
-      "$id": "#/properties/database",
       "type": "object",
-      "$ref": "#/definitions/database"
+      "$ref": "#/$defs/database"
     },
     "dataManager": {
-      "$id": "#/properties/dataManager",
       "type": "object",
-      "$ref": "#/definitions/dataManager"
+      "$ref": "#/$defs/dataManager"
     },
     "deployments": {
-      "$id": "#/properties/deployments",
       "type": "object",
       "patternProperties": {
         "^[a-z][a-zA-Z0-9._-]*$": {
-          "$ref": "#/definitions/deployment"
+          "$ref": "#/$defs/deployment"
         }
       },
       "additionalProperties": false
     },
     "deploymentManager": {
-      "$id": "#/properties/deploymentManager",
       "type": "object",
-      "$ref": "#/definitions/deploymentManager"
+      "$ref": "#/$defs/deploymentManager"
     },
     "failureManager": {
-      "$id": "#/properties/failureManager",
       "type": "object",
-      "$ref": "#/definitions/failureManager"
+      "$ref": "#/$defs/failureManager"
     },
     "scheduling": {
-      "$id": "#/properties/scheduling",
       "type": "object",
       "properties": {
         "scheduler": {
-          "$id": "#/properties/scheduling/scheduler",
           "type": "object",
-          "$ref": "#/definitions/scheduler"
+          "$ref": "#/$defs/scheduler"
         },
         "policies": {
-          "$id": "#/properties/scheduling/policies",
           "type": "object",
           "patternProperties": {
             "^[a-z][a-zA-Z0-9._-]*$": {
-              "$ref": "#/definitions/policy"
+              "$ref": "#/$defs/policy"
             }
           }
         }
       }
     },
     "models": {
-      "$id": "#/properties/deployments",
       "type": "object",
       "patternProperties": {
         "^[a-z][a-zA-Z0-9._-]*$": {
-          "$ref": "#/definitions/deployment"
+          "$ref": "#/$defs/deployment"
         }
       },
       "additionalProperties": false
@@ -494,11 +465,10 @@
       "type": "string"
     },
     "workflows": {
-      "$id": "#/properties/workflows",
       "type": "object",
       "patternProperties": {
         "^[a-z][a-zA-Z0-9._-]*$": {
-          "$ref": "#/definitions/workflow"
+          "$ref": "#/$defs/workflow"
         }
       },
       "additionalProperties": false
@@ -506,5 +476,6 @@
   },
   "required": [
     "version"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/streamflow/core/utils.py
+++ b/streamflow/core/utils.py
@@ -260,11 +260,11 @@ def inject_schema(
                     base_uri=f"file://{os.path.dirname(entity_schema)}/",
                     jsonschema=True,
                 )
-            definition = schema["definitions"]
+            definition = schema["$defs"]
             for el in definition_name.split(posixpath.sep):
                 definition = definition[el]
             definition["properties"]["type"].setdefault("enum", []).append(name)
-            definition["definitions"][name] = entity_schema
+            definition["$defs"][name] = entity_schema
             definition.setdefault("allOf", []).append(
                 {
                     "if": {"properties": {"type": {"const": name}}},

--- a/streamflow/cwl/requirement/docker/schemas/docker.json
+++ b/streamflow/cwl/requirement/docker/schemas/docker.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "docker.json",
   "type": "object",
   "properties": {

--- a/streamflow/cwl/requirement/docker/schemas/kubernetes.json
+++ b/streamflow/cwl/requirement/docker/schemas/kubernetes.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "kubernetes.json",
   "type": "object",
   "properties": {

--- a/streamflow/cwl/requirement/docker/schemas/singularity.json
+++ b/streamflow/cwl/requirement/docker/schemas/singularity.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "singularity.json",
   "type": "object",
   "properties": {

--- a/streamflow/data/schemas/data_manager.json
+++ b/streamflow/data/schemas/data_manager.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "data_manager.json",
   "type": "object",
   "properties": {},

--- a/streamflow/deployment/connector/schemas/docker-compose.json
+++ b/streamflow/deployment/connector/schemas/docker-compose.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "docker-compose.json",
   "type": "object",
   "properties": {

--- a/streamflow/deployment/connector/schemas/docker.json
+++ b/streamflow/deployment/connector/schemas/docker.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "docker.json",
   "type": "object",
   "properties": {

--- a/streamflow/deployment/connector/schemas/flux.json
+++ b/streamflow/deployment/connector/schemas/flux.json
@@ -1,10 +1,9 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "flux.json",
   "type": "object",
-  "definitions": {
+  "$defs": {
     "service": {
-      "$id": "#/definitions/service",
       "type": "object",
       "title": "FluxService",
       "description": "This complex type represents a submission to the Flux queue manager.",
@@ -154,10 +153,10 @@
       "description": "Map containing named configurations of Flux submissions. Parameters can be either specified as #flux directives in a file or directly in YAML format.",
       "patternProperties": {
         "^[a-z][a-zA-Z0-9._-]*$": {
-          "$ref": "#/definitions/service"
+          "$ref": "#/$defs/service"
         }
       }
     }
   },
-  "additionalProperties": false
+  "unevaluatedProperties": false
 }

--- a/streamflow/deployment/connector/schemas/helm3.json
+++ b/streamflow/deployment/connector/schemas/helm3.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "helm3.json",
   "type": "object",
   "properties": {

--- a/streamflow/deployment/connector/schemas/kubernetes.json
+++ b/streamflow/deployment/connector/schemas/kubernetes.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "kubernetes.json",
   "type": "object",
   "properties": {

--- a/streamflow/deployment/connector/schemas/local.json
+++ b/streamflow/deployment/connector/schemas/local.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "local.json",
   "type": "object",
   "properties": {

--- a/streamflow/deployment/connector/schemas/occam.json
+++ b/streamflow/deployment/connector/schemas/occam.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "occam.json",
   "type": "object",
   "properties": {

--- a/streamflow/deployment/connector/schemas/pbs.json
+++ b/streamflow/deployment/connector/schemas/pbs.json
@@ -1,10 +1,9 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "pbs.json",
   "type": "object",
-  "definitions": {
+  "$defs": {
     "service": {
-      "$id": "#/definitions/service",
       "type": "object",
       "title": "PBSService",
       "description": "This complex type represents a submission to the PBS queue manager.",
@@ -87,10 +86,10 @@
       "description": "Map containing named configurations of PBS submissions. Parameters can be either specified as #BSUB directives in a file or directly in YAML format.",
       "patternProperties": {
         "^[a-z][a-zA-Z0-9._-]*$": {
-          "$ref": "#/definitions/service"
+          "$ref": "#/$defs/service"
         }
       }
     }
   },
-  "additionalProperties": false
+  "unevaluatedProperties": false
 }

--- a/streamflow/deployment/connector/schemas/queue_manager.json
+++ b/streamflow/deployment/connector/schemas/queue_manager.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "queue_manager.json",
   "type": "object",
   "properties": {
@@ -15,7 +15,7 @@
         },
         {
           "type": "object",
-          "$ref": "ssh.json#/definitions/connection"
+          "$ref": "ssh.json#/$defs/connection"
         }
       ],
       "description": "(**Deprecated.** Use the `wraps` directive to wrap a standalone SSH connector.) Sometimes HPC clusters provide dedicated hostnames for large data transfers, which guarantee a higher efficiency for data movements"
@@ -68,7 +68,7 @@
     "tunnel": {
       "type": "object",
       "description": "(**Deprecated.** Use the `wraps` directive to wrap a standalone SSH connector.) External SSH connection parameters for tunneling",
-      "$ref": "ssh.json#/definitions/connection"
+      "$ref": "ssh.json#/$defs/connection"
     },
     "username": {
       "type": "string",

--- a/streamflow/deployment/connector/schemas/singularity.json
+++ b/streamflow/deployment/connector/schemas/singularity.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "singularity.json",
   "type": "object",
   "properties": {

--- a/streamflow/deployment/connector/schemas/slurm.json
+++ b/streamflow/deployment/connector/schemas/slurm.json
@@ -1,10 +1,9 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "slurm.json",
   "type": "object",
-  "definitions": {
+  "$defs": {
     "service": {
-      "$id": "#/definitions/service",
       "type": "object",
       "title": "SlurmService",
       "description": "This complex type represents a submission to the Slurm queue manager.",
@@ -406,10 +405,10 @@
       "description": "Map containing named configurations of Slurm submissions. Parameters can be either specified as #SBATCH directives in a file or directly in YAML format.",
       "patternProperties": {
         "^[a-z][a-zA-Z0-9._-]*$": {
-          "$ref": "#/definitions/service"
+          "$ref": "#/$defs/service"
         }
       }
     }
   },
-  "additionalProperties": false
+  "unevaluatedProperties": false
 }

--- a/streamflow/deployment/connector/schemas/ssh.json
+++ b/streamflow/deployment/connector/schemas/ssh.json
@@ -1,10 +1,9 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "ssh.json",
   "type": "object",
-  "definitions": {
+  "$defs": {
     "connection": {
-      "$id": "#/definitions/connection",
       "type": "object",
       "title": "SSHConnection",
       "description": "This complex type represents an SSH connection to a remote node, identified by its hostname.",
@@ -43,7 +42,7 @@
           "oneOf": [
             {
               "type": "object",
-              "$ref": "#/definitions/connection"
+              "$ref": "#/$defs/connection"
             },
             {
               "type": "null"
@@ -78,7 +77,7 @@
         },
         {
           "type": "object",
-          "$ref": "#/definitions/connection"
+          "$ref": "#/$defs/connection"
         }
       ],
       "description": "Sometimes HPC clusters provide dedicated hostnames for large data transfers, which guarantee a higher efficiency for data movements"
@@ -96,7 +95,7 @@
           },
           {
             "type": "object",
-            "$ref": "#/definitions/connection"
+            "$ref": "#/$defs/connection"
           }
         ]
       },
@@ -148,7 +147,7 @@
     "tunnel": {
       "type": "object",
       "description": "External SSH connection parameters for tunneling",
-      "$ref": "#/definitions/connection"
+      "$ref": "#/$defs/connection"
     },
     "username": {
       "type": "string",

--- a/streamflow/deployment/filter/schemas/shuffle.json
+++ b/streamflow/deployment/filter/schemas/shuffle.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "shuffle.json",
   "type": "object",
   "properties": {},

--- a/streamflow/deployment/schemas/deployment_manager.json
+++ b/streamflow/deployment/schemas/deployment_manager.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "depoloyment_manager.json",
   "type": "object",
   "properties": {},

--- a/streamflow/persistence/schemas/sqlite.json
+++ b/streamflow/persistence/schemas/sqlite.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "sqlite.json",
   "type": "object",
   "properties": {

--- a/streamflow/recovery/schemas/default_checkpoint_manager.json
+++ b/streamflow/recovery/schemas/default_checkpoint_manager.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "default_checkpoint_manager.json",
   "type": "object",
   "properties": {

--- a/streamflow/recovery/schemas/default_failure_manager.json
+++ b/streamflow/recovery/schemas/default_failure_manager.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "failure_manager.json",
   "type": "object",
   "properties": {

--- a/streamflow/recovery/schemas/dummy_checkpoint_manager.json
+++ b/streamflow/recovery/schemas/dummy_checkpoint_manager.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "dummy_checkpoint_manager.json",
   "type": "object",
   "properties": {},

--- a/streamflow/recovery/schemas/dummy_failure_manager.json
+++ b/streamflow/recovery/schemas/dummy_failure_manager.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "dummy_failure_manager.json",
   "type": "object",
   "properties": {},

--- a/streamflow/scheduling/policy/schemas/data_locality.json
+++ b/streamflow/scheduling/policy/schemas/data_locality.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "data_locality.json",
   "type": "object",
   "properties": {},

--- a/streamflow/scheduling/schemas/scheduler.json
+++ b/streamflow/scheduling/schemas/scheduler.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "scheduler.json",
   "type": "object",
   "properties": {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+from pytest import raises
+
+from streamflow.config.validator import SfValidator
+from streamflow.core.exception import WorkflowDefinitionException
+
+
+def test_cwl_workflow():
+    """Check that CWL workflows are supported."""
+    config = {
+        "version": "v1.0",
+        "workflows": {
+            "example": {
+                "type": "cwl",
+                "config": {"file": "main.cwl", "settings": "config.yml"},
+            }
+        },
+    }
+    SfValidator().validate(config)
+
+
+def test_cwl_workflow_fail_missing_file():
+    """Check that validation fails when the `file` clause is not specified for a CWL workflow."""
+    config = {
+        "version": "v1.0",
+        "workflows": {
+            "example": {
+                "type": "cwl",
+                "config": {"settings": "config.yml"},
+            }
+        },
+    }
+    with raises(WorkflowDefinitionException):
+        SfValidator().validate(config)
+
+
+def test_cwl_workflow_fail_unsupported_property():
+    """Check that validation fails when an unsupported property is specified for a CWL workflow."""
+    config = {
+        "version": "v1.0",
+        "workflows": {
+            "example": {
+                "type": "cwl",
+                "config": {
+                    "file": "main.cwl",
+                    "settings": "config.yml",
+                    "unsupported": {},
+                },
+            }
+        },
+    }
+    with raises(WorkflowDefinitionException):
+        SfValidator().validate(config)
+
+
+def test_cwl_workflow_missing_settings():
+    """Check that validation does not fail when the `settings` clause is not specified for a CWL workflow."""
+    config = {
+        "version": "v1.0",
+        "workflows": {
+            "example": {
+                "type": "cwl",
+                "config": {"file": "main.cwl"},
+            }
+        },
+    }
+    SfValidator().validate(config)
+
+
+def test_ext_support():
+    """Check that all extension points are supported."""
+    config = {
+        "version": "v1.0",
+        "workflows": {
+            "example": {
+                "type": "cwl",
+                "config": {"file": "main.cwl", "settings": "config.yml", "docker": []},
+                "bindings": [
+                    {
+                        "step": "/",
+                        "target": {
+                            "deployment": "example",
+                            "service": "example",
+                            "locations": 2,
+                            "policy": "data_locality",
+                            "workdir": "/path/to/workdir",
+                        },
+                    }
+                ],
+            }
+        },
+        "bindingFilters": {
+            "example": {
+                "type": "shuffle",
+                "config": {},
+            }
+        },
+        "checkpointManager": {"type": "default", "config": {}},
+        "database": {"type": "sqlite", "config": {"connection": ":memory:"}},
+        "dataManager": {"type": "default", "config": {}},
+        "deployments": {
+            "example": {
+                "type": "docker",
+                "config": {"image": "alpine:latest"},
+            }
+        },
+        "deploymentManager": {"type": "default", "config": {}},
+        "failureManager": {"type": "default", "config": {}},
+        "scheduling": {
+            "scheduler": {"type": "default", "config": {}},
+            "policies": {"example": {"type": "data_locality", "config": {}}},
+        },
+    }
+    SfValidator().validate(config)
+
+
+def test_ext_support_deprecated():
+    """Check that all deprecated extension points are still supported."""
+    config = {
+        "version": "v1.0",
+        "workflows": {
+            "example": {
+                "type": "cwl",
+                "config": {"file": "main.cwl", "settings": "config.yml"},
+                "bindings": [
+                    {
+                        "step": "/",
+                        "target": {
+                            "model": "example",
+                            "resources": 2,
+                        },
+                    }
+                ],
+            }
+        },
+        "models": {
+            "example": {
+                "type": "docker",
+                "config": {"image": "alpine:latest"},
+            }
+        },
+    }
+    SfValidator().validate(config)
+
+
+def test_ext_fail_unsupported_extension_point():
+    """Check that validation fails when an unsupported extension point is specified."""
+    config = {
+        "version": "v1.0",
+        "workflows": {
+            "example": {
+                "type": "cwl",
+                "config": {"file": "main.cwl", "settings": "config.yml"},
+            }
+        },
+        "unsupported_ext": {"type": "unsupported", "config": {}},
+    }
+    with raises(WorkflowDefinitionException):
+        SfValidator().validate(config)
+
+
+def test_ext_fail_unsupoorted_type():
+    """Check that validation fails when an extension point with unsupported type is specified."""
+    config = {
+        "version": "v1.0",
+        "workflows": {
+            "example": {
+                "type": "cwl",
+                "config": {"file": "main.cwl", "settings": "config.yml"},
+            }
+        },
+        "deployments": {"type": "unsupported", "config": {}},
+    }
+    with raises(WorkflowDefinitionException):
+        SfValidator().validate(config)
+
+
+def test_target_fail_unsupported_property():
+    """Check that validation fails when an unsupported property is specified in the `target` clause."""
+    config = {
+        "version": "v1.0",
+        "workflows": {
+            "example": {
+                "type": "cwl",
+                "config": {"file": "main.cwl", "settings": "config.yml"},
+                "bindings": [
+                    {
+                        "step": "/",
+                        "target": {
+                            "deployment": "example",
+                            "unsupported": {},
+                        },
+                    }
+                ],
+            }
+        },
+        "deployments": {
+            "example": {
+                "type": "docker",
+                "config": {"image": "alpine:latest"},
+            }
+        },
+    }
+    with raises(WorkflowDefinitionException):
+        SfValidator().validate(config)
+
+
+def test_version_fail_invalid():
+    """Check that validation fails when `version` is not supported."""
+    config = {
+        "version": "v1000.0",
+        "workflows": {
+            "example": {
+                "type": "cwl",
+                "config": {"file": "main.cwl", "settings": "config.yml"},
+            }
+        },
+    }
+    with raises(WorkflowDefinitionException):
+        SfValidator().validate(config)
+
+
+def test_version_fail_missing():
+    """Check that validation fails when the `version` clause is not specified."""
+    config = {
+        "workflows": {
+            "example": {
+                "type": "cwl",
+                "config": {"file": "main.cwl", "settings": "config.yml"},
+            }
+        }
+    }
+    with raises(WorkflowDefinitionException):
+        SfValidator().validate(config)
+
+
+def test_workflow_fail_unsupported_type():
+    """Check that validation fails when a workflow with unsupported type is specified."""
+    config = {
+        "version": "v1.0",
+        "workflows": {
+            "example": {
+                "type": "unsupported",
+                "config": {},
+            }
+        },
+    }
+    with raises(WorkflowDefinitionException):
+        SfValidator().validate(config)


### PR DESCRIPTION
Updating the JSONSchema draft version allows to rely on the new `unevaluatedProperties` feature to disable adding custom properties when using the `allOf` inheritance mechanism, ensuring compile-time validation of StreamFlow extensions.