### PR TITLE
Fix type checking in conftest

### DIFF
--- a/examples/flux/Dockerfile
+++ b/examples/flux/Dockerfile
@@ -6,15 +6,18 @@ FROM fluxrm/flux-sched:focal
 LABEL maintainer="Vanessasaurus <@vsoch>"
 
 USER root
-RUN apt-get update && \
-    python3 -m pip install IPython 
+RUN apt-get update \
+ && python3 -m pip install IPython
     
 COPY . /code
 WORKDIR /code
 
 # Install in development mode in case container used for development
-RUN pip install develop . && pip install lockfile && \
-    chown -R fluxuser /code
+RUN pip install develop . \
+ && pip install \
+        attrs \
+        lockfile \
+ && chown -R fluxuser /code
 
 # Ensure we enter the container as the fluxuser
 USER fluxuser

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,10 +146,10 @@ def are_equals(elem1, elem2, obj_compared=None):
     obj_compared = obj_compared if obj_compared else []
 
     # if the objects are of different types, they are definitely not the same
-    if type(elem1) != type(elem2):
+    if type(elem1) is not type(elem2):
         return False
 
-    if type(elem1) == Lock:
+    if isinstance(elem1, Lock):
         return True
 
     if is_primitive_type(elem1):


### PR DESCRIPTION
Type comparison should always be done using either `isinstance` or `is` and `is not` operators. This commit fixes a wrong behaviour in the `conftest.py` file.