### PR TITLE
Move black configuration to `pyproject.toml`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ flake8:
 	flake8 --exclude streamflow/cwl/antlr streamflow tests
 
 format:
-	black --exclude streamflow/cwl/antlr streamflow tests
+	black streamflow tests
 
 format-check:
-	black --diff --check --exclude streamflow/cwl/antlr streamflow tests
+	black --diff --check streamflow tests
 
 pyupgrade:
 	pyupgrade --py3-only --py38-plus $(shell git ls-files | grep .py | grep -v streamflow/cwl/antlr)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,3 +111,6 @@ omit = [
     "streamflow/__main__.py",
     "tests/*"
 ]
+
+[tool.black]
+exclude = "streamflow/cwl/antlr"

--- a/streamflow/config/schemas/v1.0/config_schema.json
+++ b/streamflow/config/schemas/v1.0/config_schema.json
@@ -29,7 +29,7 @@
             "filters": {
               "type": "array",
               "items": {
-                 "type": "string"
+                "type": "string"
               },
               "description": "The filters used to manipulate the targets associated with this binding."
             }

--- a/streamflow/cwl/requirement/docker/schemas/kubernetes.json
+++ b/streamflow/cwl/requirement/docker/schemas/kubernetes.json
@@ -3,7 +3,7 @@
   "$id": "kubernetes.json",
   "type": "object",
   "properties": {
-    "file":{
+    "file": {
       "type": "string",
       "description": "Path to a file containing a Jinja2 template, describing how the Docker container should be deployed on Kubernetes",
       "default": "./kubernetes.jinja2"

--- a/streamflow/deployment/connector/__init__.py
+++ b/streamflow/deployment/connector/__init__.py
@@ -10,9 +10,9 @@ from streamflow.deployment.connector.kubernetes import (
 from streamflow.deployment.connector.local import LocalConnector
 from streamflow.deployment.connector.occam import OccamConnector
 from streamflow.deployment.connector.queue_manager import (
+    FluxConnector,
     PBSConnector,
     SlurmConnector,
-    FluxConnector,
 )
 from streamflow.deployment.connector.ssh import SSHConnector
 

--- a/streamflow/ext/plugin.py
+++ b/streamflow/ext/plugin.py
@@ -21,7 +21,6 @@ from streamflow.recovery import checkpoint_manager_classes, failure_manager_clas
 from streamflow.scheduling import scheduler_classes
 from streamflow.scheduling.policy import policy_classes
 
-
 extension_points = {
     "binding_filter": binding_filter_classes,
     "checkpoint_manager": checkpoint_manager_classes,

--- a/streamflow/persistence/schemas/sqlite.sql
+++ b/streamflow/persistence/schemas/sqlite.sql
@@ -1,10 +1,10 @@
 CREATE TABLE IF NOT EXISTS workflow
 (
-    id     INTEGER PRIMARY KEY,
-    name   TEXT,
-    params TEXT,
-    status INTEGER,
-    type   TEXT,
+    id         INTEGER PRIMARY KEY,
+    name       TEXT,
+    params     TEXT,
+    status     INTEGER,
+    type       TEXT,
     start_time INTEGER,
     end_time   INTEGER
 );

--- a/streamflow/provenance/run_crate.py
+++ b/streamflow/provenance/run_crate.py
@@ -36,7 +36,6 @@ from streamflow.version import VERSION
 from streamflow.workflow.token import FileToken, ListToken, ObjectToken
 from streamflow.workflow.utils import get_token_value
 
-
 ESCAPED_COMMA = re.compile(r"\\,")
 ESCAPED_DOT = re.compile(r"\\.")
 ESCAPED_EQUAL = re.compile(r"\\=")

--- a/streamflow/workflow/utils.py
+++ b/streamflow/workflow/utils.py
@@ -6,10 +6,10 @@ from streamflow.core.exception import WorkflowExecutionException
 from streamflow.core.workflow import Token
 from streamflow.workflow.token import (
     IterationTerminationToken,
+    JobToken,
     ListToken,
     ObjectToken,
     TerminationToken,
-    JobToken,
 )
 
 if TYPE_CHECKING:

--- a/tests/test_cwl_provenance.py
+++ b/tests/test_cwl_provenance.py
@@ -1,107 +1,118 @@
+from __future__ import annotations
+
 import posixpath
 
 import pytest
 
-from streamflow.cwl.combinator import ListMergeCombinator
-from streamflow.workflow.executor import StreamFlowExecutor
-from streamflow.workflow.step import CombinatorStep
-from streamflow.workflow.token import (
-    ListToken,
-    IterationTerminationToken,
-)
-
 from streamflow.core import utils
 from streamflow.core.context import StreamFlowContext
-from streamflow.core.workflow import Token, Status
-
-from streamflow.cwl.step import (
-    CWLTransferStep,
-    CWLConditionalStep,
-    CWLInputInjectorStep,
-    CWLEmptyScatterConditionalStep,
-    CWLLoopOutputAllStep,  # CWLLoopOutputLastStep,  # LoopOutputStep
-)
+from streamflow.core.workflow import Status, Token
+from streamflow.cwl.combinator import ListMergeCombinator
 from streamflow.cwl.processor import CWLTokenProcessor
-
+from streamflow.cwl.step import (
+    CWLConditionalStep,
+    CWLEmptyScatterConditionalStep,
+    CWLInputInjectorStep,
+    CWLLoopOutputAllStep,
+    CWLTransferStep,
+)
 from streamflow.cwl.transformer import (
-    DefaultTransformer,
-    DefaultRetagTransformer,
-    CWLTokenTransformer,
-    ValueFromTransformer,
     AllNonNullTransformer,
+    CWLTokenTransformer,
+    DefaultRetagTransformer,
+    DefaultTransformer,
     FirstNonNullTransformer,
     ForwardTransformer,
     ListToElementTransformer,
-    OnlyNonNullTransformer,
     LoopValueFromTransformer,
+    OnlyNonNullTransformer,
+    ValueFromTransformer,
 )
-
+from streamflow.workflow.combinator import (
+    CartesianProductCombinator,
+    DotProductCombinator,
+)
+from streamflow.workflow.executor import StreamFlowExecutor
+from streamflow.workflow.step import CombinatorStep
+from streamflow.workflow.token import IterationTerminationToken, ListToken
 from tests.test_provenance import (
+    create_deploy_step,
+    create_schedule_step,
+    create_workflow,
+    general_test,
+    put_tokens,
     verify_dependency_tokens,
-    _create_deploy_step,
-    _create_schedule_step,
-    _general_test,
-    _create_workflow,
-    _put_tokens,
 )
 
 
 @pytest.mark.asyncio
 async def test_default_transformer(context: StreamFlowContext):
-    """ """
-    workflow, in_port, out_port = await _create_workflow(context)
+    """Test token provenance for DefaultTransformer"""
+    workflow, (in_port, out_port) = await create_workflow(context)
     token_list = [Token("a")]
-    await _general_test(
-        context,
-        workflow,
-        in_port,
-        out_port,
-        DefaultTransformer,
-        {"name": utils.random_name() + "-transformer", "default_port": in_port},
-        token_list,
+    await general_test(
+        context=context,
+        workflow=workflow,
+        in_port=in_port,
+        out_port=out_port,
+        step_cls=DefaultTransformer,
+        kwargs_step={
+            "name": utils.random_name() + "-transformer",
+            "default_port": in_port,
+        },
+        token_list=token_list,
     )
 
     # len(token_list) = N output tokens + 1 termination token
     assert len(out_port.token_list) == 2
     await verify_dependency_tokens(
-        out_port.token_list[0], out_port, (), token_list, context
+        token=out_port.token_list[0],
+        port=out_port,
+        context=context,
+        expected_dependee=token_list,
     )
 
 
 @pytest.mark.asyncio
 async def test_default_retag_transformer(context: StreamFlowContext):
-    """ """
-    workflow, in_port, out_port = await _create_workflow(context)
+    """Test token provenance for DefaultRetagTransformer"""
+    workflow, (in_port, out_port) = await create_workflow(context)
     token_list = [Token("a")]
-    await _general_test(
-        context,
-        workflow,
-        in_port,
-        out_port,
-        DefaultRetagTransformer,
-        {"name": utils.random_name() + "-transformer", "default_port": in_port},
-        token_list,
+    await general_test(
+        context=context,
+        workflow=workflow,
+        in_port=in_port,
+        out_port=out_port,
+        step_cls=DefaultRetagTransformer,
+        kwargs_step={
+            "name": utils.random_name() + "-transformer",
+            "default_port": in_port,
+        },
+        token_list=token_list,
     )
     assert len(out_port.token_list) == 2
     await verify_dependency_tokens(
-        out_port.token_list[0], out_port, (), token_list, context
+        token=out_port.token_list[0],
+        port=out_port,
+        context=context,
+        expected_dependee=token_list,
     )
 
 
 @pytest.mark.asyncio
 async def test_cwl_token_transformer(context: StreamFlowContext):
-    """ """
-    workflow, in_port, out_port = await _create_workflow(context)
+    """Test token provenance for CWLTokenTransformer"""
+    workflow, (in_port, out_port) = await create_workflow(context)
     port_name = "test"
     step_name = utils.random_name()
     token_list = [Token("a")]
-    await _general_test(
-        context,
-        workflow,
-        in_port,
-        out_port,
-        CWLTokenTransformer,
-        {
+    await general_test(
+        context=context,
+        workflow=workflow,
+        in_port=in_port,
+        out_port=out_port,
+        step_cls=CWLTokenTransformer,
+        kwargs_step={
             "name": step_name + "-transformer",
             "port_name": port_name,
             "processor": CWLTokenProcessor(
@@ -109,28 +120,31 @@ async def test_cwl_token_transformer(context: StreamFlowContext):
                 workflow=workflow,
             ),
         },
-        token_list,
-        port_name,
+        token_list=token_list,
+        port_name=port_name,
     )
     assert len(out_port.token_list) == 2
     await verify_dependency_tokens(
-        out_port.token_list[0], out_port, (), token_list, context
+        token=out_port.token_list[0],
+        port=out_port,
+        context=context,
+        expected_dependee=token_list,
     )
 
 
 @pytest.mark.asyncio
 async def test_value_from_transformer(context: StreamFlowContext):
-    """ """
-    workflow, in_port, out_port = await _create_workflow(context)
+    """Test token provenance for ValueFromTransformer"""
+    workflow, (in_port, out_port) = await create_workflow(context)
     port_name = "test"
     token_list = [Token(10)]
-    await _general_test(
-        context,
-        workflow,
-        in_port,
-        out_port,
-        ValueFromTransformer,
-        {
+    await general_test(
+        context=context,
+        workflow=workflow,
+        in_port=in_port,
+        out_port=out_port,
+        step_cls=ValueFromTransformer,
+        kwargs_step={
             "name": utils.random_name() + "-value-from-transformer",
             "processor": CWLTokenProcessor(
                 name=in_port.name,
@@ -140,170 +154,191 @@ async def test_value_from_transformer(context: StreamFlowContext):
             "full_js": True,
             "value_from": f"$(inputs.{port_name} + 1)",
         },
-        token_list,
-        port_name,
+        token_list=token_list,
+        port_name=port_name,
     )
     assert len(out_port.token_list) == 2
     await verify_dependency_tokens(
-        out_port.token_list[0], out_port, (), token_list, context
+        token=out_port.token_list[0],
+        port=out_port,
+        context=context,
+        expected_dependee=token_list,
     )
 
 
 @pytest.mark.asyncio
 async def test_all_non_null_transformer(context: StreamFlowContext):
-    """ """
-    workflow, in_port, out_port = await _create_workflow(context)
+    """Test token provenance for AllNonNullTransformer"""
+    workflow, (in_port, out_port) = await create_workflow(context)
     token_list = [ListToken([Token("a"), Token(None), Token("b")])]
-    await _general_test(
-        context,
-        workflow,
-        in_port,
-        out_port,
-        AllNonNullTransformer,
-        {
+    await general_test(
+        context=context,
+        workflow=workflow,
+        in_port=in_port,
+        out_port=out_port,
+        step_cls=AllNonNullTransformer,
+        kwargs_step={
             "name": utils.random_name() + "-transformer",
         },
-        token_list,
+        token_list=token_list,
     )
     assert len(out_port.token_list) == 2
     await verify_dependency_tokens(
-        out_port.token_list[0], out_port, (), token_list, context
+        token=out_port.token_list[0],
+        port=out_port,
+        context=context,
+        expected_dependee=token_list,
     )
 
 
 @pytest.mark.asyncio
 async def test_first_non_null_transformer(context: StreamFlowContext):
-    """ """
-    workflow, in_port, out_port = await _create_workflow(context)
+    """Test token provenance for FirstNonNullTransformer"""
+    workflow, (in_port, out_port) = await create_workflow(context)
     token_list = [ListToken([Token(None), Token("a")])]
-    await _general_test(
-        context,
-        workflow,
-        in_port,
-        out_port,
-        FirstNonNullTransformer,
-        {
+    await general_test(
+        context=context,
+        workflow=workflow,
+        in_port=in_port,
+        out_port=out_port,
+        step_cls=FirstNonNullTransformer,
+        kwargs_step={
             "name": utils.random_name() + "-transformer",
         },
-        token_list,
+        token_list=token_list,
     )
     assert len(out_port.token_list) == 2
     await verify_dependency_tokens(
-        out_port.token_list[0], out_port, (), token_list, context
+        token=out_port.token_list[0],
+        port=out_port,
+        context=context,
+        expected_dependee=token_list,
     )
 
 
 @pytest.mark.asyncio
 async def test_forward_transformer(context: StreamFlowContext):
-    """ """
-    workflow, in_port, out_port = await _create_workflow(context)
+    """Test token provenance for ForwardTransformer"""
+    workflow, (in_port, out_port) = await create_workflow(context)
     token_list = [ListToken([Token("a")])]
-    await _general_test(
-        context,
-        workflow,
-        in_port,
-        out_port,
-        ForwardTransformer,
-        {
+    await general_test(
+        context=context,
+        workflow=workflow,
+        in_port=in_port,
+        out_port=out_port,
+        step_cls=ForwardTransformer,
+        kwargs_step={
             "name": utils.random_name() + "-transformer",
         },
-        token_list,
+        token_list=token_list,
     )
     assert len(out_port.token_list) == 2
     await verify_dependency_tokens(
-        out_port.token_list[0], out_port, (), token_list, context
+        token=out_port.token_list[0],
+        port=out_port,
+        context=context,
+        expected_dependee=token_list,
     )
 
 
 @pytest.mark.asyncio
 async def test_list_to_element_transformer(context: StreamFlowContext):
-    """ """
-    workflow, in_port, out_port = await _create_workflow(context)
+    """Test token provenance for ListToElementTransformer"""
+    workflow, (in_port, out_port) = await create_workflow(context)
     token_list = [ListToken([Token("a")])]
-    await _general_test(
-        context,
-        workflow,
-        in_port,
-        out_port,
-        ListToElementTransformer,
-        {
+    await general_test(
+        context=context,
+        workflow=workflow,
+        in_port=in_port,
+        out_port=out_port,
+        step_cls=ListToElementTransformer,
+        kwargs_step={
             "name": utils.random_name() + "-transformer",
         },
-        token_list,
+        token_list=token_list,
     )
     assert len(out_port.token_list) == 2
     await verify_dependency_tokens(
-        out_port.token_list[0], out_port, (), token_list, context
+        token=out_port.token_list[0],
+        port=out_port,
+        context=context,
+        expected_dependee=token_list,
     )
 
 
 @pytest.mark.asyncio
 async def test_only_non_null_transformer(context: StreamFlowContext):
-    """ """
-    workflow, in_port, out_port = await _create_workflow(context)
+    """Test token provenance for OnlyNonNullTransformer"""
+    workflow, (in_port, out_port) = await create_workflow(context)
     token_list = [ListToken([Token(None), Token("a")])]
-    await _general_test(
-        context,
-        workflow,
-        in_port,
-        out_port,
-        OnlyNonNullTransformer,
-        {
+    await general_test(
+        context=context,
+        workflow=workflow,
+        in_port=in_port,
+        out_port=out_port,
+        step_cls=OnlyNonNullTransformer,
+        kwargs_step={
             "name": utils.random_name() + "-transformer",
         },
-        token_list,
+        token_list=token_list,
     )
     assert len(out_port.token_list) == 2
     await verify_dependency_tokens(
-        out_port.token_list[0], out_port, (), token_list, context
+        token=out_port.token_list[0],
+        port=out_port,
+        context=context,
+        expected_dependee=token_list,
     )
 
 
 @pytest.mark.asyncio
 async def test_cwl_conditional_step(context: StreamFlowContext):
-    """ """
-    workflow, in_port, out_port = await _create_workflow(context)
+    """Test token provenance for CWLConditionalStep"""
+    workflow, (in_port, out_port) = await create_workflow(context)
     port_name = "test"
     token_list = [ListToken([Token("a")])]
-    await _general_test(
-        context,
-        workflow,
-        in_port,
-        out_port,
-        CWLConditionalStep,
-        {
+    await general_test(
+        context=context,
+        workflow=workflow,
+        in_port=in_port,
+        out_port=out_port,
+        step_cls=CWLConditionalStep,
+        kwargs_step={
             "name": utils.random_name() + "-when",
             "expression": f"$(inputs.{port_name}.length == 1)",
             "full_js": True,
         },
-        token_list,
+        token_list=token_list,
         port_name=port_name,
     )
     assert len(out_port.token_list) == 2
     await verify_dependency_tokens(
-        out_port.token_list[0], out_port, (), token_list, context
+        token=out_port.token_list[0],
+        port=out_port,
+        context=context,
+        expected_dependee=token_list,
     )
 
 
 @pytest.mark.asyncio
 async def test_transfer_step(context: StreamFlowContext):
-    """ """
-    workflow, in_port, out_port = await _create_workflow(context)
-    deploy_step = _create_deploy_step(workflow)
-    schedule_step = _create_schedule_step(workflow, deploy_step)
+    """Test token provenance for CWLTransferStep"""
+    workflow, (in_port, out_port) = await create_workflow(context)
+    deploy_step = create_deploy_step(workflow)
+    schedule_step = create_schedule_step(workflow, deploy_step)
     port_name = "test"
     token_list = [Token("a")]
-    transfer_step = await _general_test(
-        context,
-        workflow,
-        in_port,
-        out_port,
-        CWLTransferStep,
-        {
+    transfer_step = await general_test(
+        context=context,
+        workflow=workflow,
+        in_port=in_port,
+        out_port=out_port,
+        step_cls=CWLTransferStep,
+        kwargs_step={
             "name": posixpath.join(utils.random_name(), "__transfer__", port_name),
             "job_port": schedule_step.get_output_port(),
         },
-        token_list,
+        token_list=token_list,
         port_name=port_name,
     )
     job_token = transfer_step.get_input_port("__job__").token_list[0]
@@ -311,65 +346,76 @@ async def test_transfer_step(context: StreamFlowContext):
     token_list.append(job_token)
     assert len(out_port.token_list) == 2
     await verify_dependency_tokens(
-        out_port.token_list[0], out_port, (), token_list, context
+        token=out_port.token_list[0],
+        port=out_port,
+        context=context,
+        expected_dependee=token_list,
     )
 
 
 @pytest.mark.asyncio
 async def test_cwl_input_injector_step(context: StreamFlowContext):
-    """ """
-    workflow, in_port, out_port = await _create_workflow(context)
-    deploy_step = _create_deploy_step(workflow)
-    schedule_step = _create_schedule_step(workflow, deploy_step)
+    """Test token provenance for CWLInputInjectorStep"""
+    workflow, (in_port, out_port) = await create_workflow(context)
+    deploy_step = create_deploy_step(workflow)
+    schedule_step = create_schedule_step(workflow, deploy_step)
     token_list = [Token("a")]
-    injector = await _general_test(
-        context,
-        workflow,
-        in_port,
-        out_port,
-        CWLInputInjectorStep,
-        {
+    injector = await general_test(
+        context=context,
+        workflow=workflow,
+        in_port=in_port,
+        out_port=out_port,
+        step_cls=CWLInputInjectorStep,
+        kwargs_step={
             "name": posixpath.join(utils.random_name(), "-injector"),
             "job_port": schedule_step.get_output_port(),
         },
-        token_list,
+        token_list=token_list,
     )
     job_token = injector.get_input_port("__job__").token_list[0]
     await context.scheduler.notify_status(job_token.value.name, Status.COMPLETED)
     token_list.append(job_token)
     assert len(out_port.token_list) == 2
     await verify_dependency_tokens(
-        out_port.token_list[0], out_port, (), token_list, context
+        token=out_port.token_list[0],
+        port=out_port,
+        context=context,
+        expected_dependee=token_list,
     )
 
 
 @pytest.mark.asyncio
 async def test_empty_scatter_conditional_step(context: StreamFlowContext):
-    """ """
-    workflow, in_port, out_port = await _create_workflow(context)
+    """Test token provenance for CWLEmptyScatterConditionalStep"""
+    workflow, (in_port, out_port) = await create_workflow(context)
     token_list = [ListToken([Token(i), Token(i * 100)]) for i in range(1, 5)]
-    await _general_test(
-        context,
-        workflow,
-        in_port,
-        out_port,
-        CWLEmptyScatterConditionalStep,
-        {
+    await general_test(
+        context=context,
+        workflow=workflow,
+        in_port=in_port,
+        out_port=out_port,
+        step_cls=CWLEmptyScatterConditionalStep,
+        kwargs_step={
             "name": utils.random_name() + "-empty-scatter-condition",
             "scatter_method": "dotproduct",
         },
-        token_list,
+        token_list=token_list,
     )
 
     assert len(out_port.token_list) == 5
     for in_token, out_token in zip(in_port.token_list[:-1], out_port.token_list[:-1]):
-        await verify_dependency_tokens(out_token, out_port, (), [in_token], context)
+        await verify_dependency_tokens(
+            token=out_token,
+            port=out_port,
+            context=context,
+            expected_dependee=[in_token],
+        )
 
 
 @pytest.mark.asyncio
 async def test_list_merge_combinator(context: StreamFlowContext):
-    """ """
-    workflow, in_port, out_port = await _create_workflow(context)
+    """Test token provenance for ListMergeCombinator"""
+    workflow, (in_port, out_port) = await create_workflow(context)
     port_name = "test"
     step_name = utils.random_name()
     step = workflow.create_step(
@@ -388,7 +434,7 @@ async def test_list_merge_combinator(context: StreamFlowContext):
     step.add_output_port(port_name, out_port)
 
     list_token = [ListToken([Token("a"), Token("b")])]
-    await _put_tokens(list_token, in_port, context)
+    await put_tokens(list_token, in_port, context)
 
     step.combinator.add_item(port_name)
     await workflow.save(context)
@@ -397,14 +443,17 @@ async def test_list_merge_combinator(context: StreamFlowContext):
 
     assert len(out_port.token_list) == 2
     await verify_dependency_tokens(
-        out_port.token_list[0], out_port, [], list_token, context
+        token=out_port.token_list[0],
+        port=out_port,
+        context=context,
+        expected_dependee=list_token,
     )
 
 
 @pytest.mark.asyncio
 async def test_loop_value_from_transformer(context: StreamFlowContext):
-    """ """
-    workflow, in_port, out_port = await _create_workflow(context)
+    """Test token provenance for LoopValueFromTransformer"""
+    workflow, (in_port, out_port) = await create_workflow(context)
 
     name = utils.random_name()
     port_name = "test"
@@ -425,8 +474,8 @@ async def test_loop_value_from_transformer(context: StreamFlowContext):
     transformer.add_output_port(port_name, out_port)
 
     token_list = [Token(10)]
-    await _put_tokens(token_list, in_port, context)
-    await _put_tokens(token_list, loop_port, context)
+    await put_tokens(token_list, in_port, context)
+    await put_tokens(token_list, loop_port, context)
 
     await workflow.save(context)
     executor = StreamFlowExecutor(workflow)
@@ -434,18 +483,17 @@ async def test_loop_value_from_transformer(context: StreamFlowContext):
 
     assert len(transformer.get_output_port(port_name).token_list) == 2
     await verify_dependency_tokens(
-        out_port.token_list[0],
-        out_port,
-        (),
-        token_list,
-        context,
+        token=out_port.token_list[0],
+        port=out_port,
+        context=context,
+        expected_dependee=token_list,
     )
 
 
 @pytest.mark.asyncio
 async def test_cwl_loop_output_all_step(context: StreamFlowContext):
-    """ """
-    workflow, in_port, out_port = await _create_workflow(context)
+    """Test token provenance for CWLLoopOutputAllStep"""
+    workflow, (in_port, out_port) = await create_workflow(context)
 
     step = workflow.create_step(
         cls=CWLLoopOutputAllStep,
@@ -460,7 +508,7 @@ async def test_cwl_loop_output_all_step(context: StreamFlowContext):
         IterationTerminationToken(tag),
     ]
 
-    await _put_tokens(list_token, in_port, context)
+    await put_tokens(list_token, in_port, context)
 
     await workflow.save(context)
     executor = StreamFlowExecutor(workflow)
@@ -468,5 +516,141 @@ async def test_cwl_loop_output_all_step(context: StreamFlowContext):
 
     assert len(out_port.token_list) == 2
     await verify_dependency_tokens(
-        out_port.token_list[0], out_port, [], [list_token[0]], context
+        token=out_port.token_list[0],
+        port=out_port,
+        context=context,
+        expected_dependee=[list_token[0]],
     )
+
+
+@pytest.mark.asyncio
+async def test_nested_crossproduct_combinator(context: StreamFlowContext):
+    """Test token provenance for CWL nested_crossproduct feature"""
+    workflow, (in_port_1, in_port_2, out_port_1, out_port_2) = await create_workflow(
+        context, num_port=4
+    )
+    port_name_1 = "echo_in1"
+    port_name_2 = "echo_in2"
+    prefix_name = "/step1-scatter"
+    step_name = prefix_name + "-combinator"
+    combinator = DotProductCombinator(
+        workflow=workflow, name=prefix_name + "-dot-product-combinator"
+    )
+    c1 = CartesianProductCombinator(name=step_name, workflow=workflow)
+    c1.add_item(port_name_1)
+    c1.add_item(port_name_2)
+    items = c1.get_items(False)
+    combinator.add_combinator(
+        c1,
+        items,
+    )
+
+    step = workflow.create_step(
+        cls=CombinatorStep,
+        name=step_name,
+        combinator=combinator,
+    )
+
+    step.add_input_port(port_name_1, in_port_1)
+    step.add_input_port(port_name_2, in_port_2)
+    step.add_output_port(port_name_1, out_port_1)
+    step.add_output_port(port_name_2, out_port_2)
+
+    list_token_1 = [
+        ListToken([Token("a"), Token("b")], tag="0.0"),
+        ListToken([Token("c"), Token("d")], tag="0.1"),
+    ]
+    await put_tokens(list_token_1, in_port_1, context)
+
+    list_token_2 = [
+        ListToken([Token("1"), Token("2")], tag="0.0"),
+        ListToken([Token("3"), Token("4")], tag="0.1"),
+    ]
+    await put_tokens(list_token_2, in_port_2, context)
+
+    await workflow.save(context)
+    executor = StreamFlowExecutor(workflow)
+    await executor.run()
+
+    nested_crossproduct_1 = [(t1, t2) for t2 in list_token_2 for t1 in list_token_1]
+    nested_crossproduct_2 = [(t1, t2) for t1 in list_token_1 for t2 in list_token_2]
+
+    for t in list_token_1:
+        print(f"{t.persistent_id}, {t.tag}, {[tt.value for tt in t.value]}")
+
+    for t in list_token_2:
+        print(f"{t.persistent_id}, {t.tag}, {[tt.value for tt in t.value]}")
+    print()
+
+    for out_token in out_port_1.token_list[:-1]:
+        print(
+            f"{out_token.persistent_id}, {out_token.tag}, {[tt.value for tt in out_token.value]}"
+        )
+    for out_token in out_port_2.token_list[:-1]:
+        print(
+            f"{out_token.persistent_id}, {out_token.tag}, {[tt.value for tt in out_token.value]}"
+        )
+    print()
+    # The tokens id produced by combinators depend on the order of input tokens.
+    # The use of the alternative_expected_dependee parameter is necessary
+    # For example:
+    # input port_1 token: (id, tag, value)
+    #   (  3, 0.0, ['a', 'b'] )
+    #   (  6, 0.1, ['c', 'd'] )
+    # input port_2 token: (id, tag, value)
+    #   (  9, 0.0, ['1', '2'] )
+    #   ( 12, 0.1, ['3', '4'] )
+
+    # case #1: port_1 input tokens arrive first
+    # - output port_1 token: (id, tag, value)
+    #   ( 13, 0.0.0, ['a', 'b'] )
+    #   ( 15, 0.0.1, ['a', 'b'] )
+    #   ( 17, 0.1.0, ['c', 'd'] )
+    #   ( 19, 0.1.1, ['c', 'd'] )
+    # - output port_2 token: (id, tag, value)
+    #   ( 14, 0.0.0, ['1', '2'] )
+    #   ( 16, 0.0.1, ['3', '4'] )
+    #   ( 18, 0.1.0, ['1', '2'] )
+    #   ( 20, 0.1.1, ['3', '4'] )
+    # - provenance token in port_1: { output token id : input token id list }
+    #   { 13 : [3, 9], 15 : [3, 12], 17 : [6, 9], 19 : [6, 12] }
+    # - provenance token in port_2: { output token id : input token id list }
+    #   { 14 : [3, 9], 16 : [3, 12], 18 : [6, 9], 20 : [6, 12] }
+
+    # case #2: port_2 input tokens arrive first
+    # - output port_1 token: (id, tag, value)
+    #   ( 13, 0.0.0, ['a', 'b'] )
+    #   ( 15, 0.1.0, ['c', 'd'] )
+    #   ( 17, 0.0.1, ['a', 'b'] )
+    #   ( 19, 0.1.1, ['c', 'd'] )
+    # - output port_2 token: (id, tag, value)
+    #   ( 14, 0.0.0, ['1', '2'] )
+    #   ( 16, 0.1.0, ['1', '2'] )
+    #   ( 18, 0.0.1, ['3', '4'] )
+    #   ( 20, 0.1.1, ['3', '4'] )
+    # - provenance token in port_1: { output token id : input token id list }
+    #   { 13 : [3, 9], 15 : [6, 9], 17 : [3, 12], 19 : [6, 12] }
+    # - provenance token in port_2: { output token id : input token id list }
+    #   { 14 : [3, 9], 16 : [6, 9], 18 : [3, 12], 20 : [6, 12] }
+
+    # check port_1 outputs
+    assert len(out_port_1.token_list) == 5
+    for i, out_token in enumerate(out_port_1.token_list[:-1]):
+        await verify_dependency_tokens(
+            token=out_token,
+            port=out_port_1,
+            context=context,
+            expected_dependee=nested_crossproduct_1[i],
+            alternative_expected_dependee=nested_crossproduct_2[i],
+        )
+
+    # check port_2 outputs
+    assert len(out_port_2.token_list) == 5
+    for i, out_token in enumerate(out_port_2.token_list[:-1]):
+        await verify_dependency_tokens(
+            token=out_token,
+            port=out_port_2,
+            context=context,
+            expected_dependee=nested_crossproduct_1[i],
+            alternative_expected_dependee=nested_crossproduct_2[i],
+        )

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -2,40 +2,37 @@ import posixpath
 
 import pytest
 
-from tests.conftest import get_docker_deployment_config, save_load_and_test
-
 from streamflow.core import utils
-from streamflow.core.context import StreamFlowContext
 from streamflow.core.config import BindingConfig
-from streamflow.core.deployment import Target, LocalTarget
+from streamflow.core.context import StreamFlowContext
+from streamflow.core.deployment import LocalTarget, Target
 from streamflow.core.workflow import Job, Token, Workflow
-
-from streamflow.workflow.port import JobPort, ConnectorPort
-from streamflow.workflow.step import (
-    CombinatorStep,
-    DeployStep,
-    ExecuteStep,
-    GatherStep,
-    ScheduleStep,
-    ScatterStep,
-    LoopCombinatorStep,
-)
 from streamflow.workflow.combinator import (
     CartesianProductCombinator,
     DotProductCombinator,
     LoopCombinator,
     LoopTerminationCombinator,
 )
+from streamflow.workflow.port import ConnectorPort, JobPort
+from streamflow.workflow.step import (
+    CombinatorStep,
+    DeployStep,
+    ExecuteStep,
+    GatherStep,
+    LoopCombinatorStep,
+    ScatterStep,
+    ScheduleStep,
+)
 from streamflow.workflow.token import (
+    IterationTerminationToken,
     JobToken,
     ListToken,
     ObjectToken,
     TerminationToken,
-    IterationTerminationToken,
 )
+from tests.conftest import get_docker_deployment_config, save_load_and_test
 
 
-# Testing Workflow
 @pytest.mark.asyncio
 async def test_workflow(context: StreamFlowContext):
     """Test saving and loading Workflow from database"""
@@ -45,7 +42,6 @@ async def test_workflow(context: StreamFlowContext):
     await save_load_and_test(workflow, context)
 
 
-# Testing Port and its extension classes
 @pytest.mark.asyncio
 async def test_port(context: StreamFlowContext):
     """Test saving and loading Port from database"""
@@ -79,7 +75,6 @@ async def test_connector_port(context: StreamFlowContext):
     await save_load_and_test(port, context)
 
 
-# Testing Step and its extension classes
 @pytest.mark.asyncio
 async def test_combinator_step(context: StreamFlowContext):
     """Test saving and loading CombinatorStep with CartesianProductCombinator from database"""
@@ -200,7 +195,6 @@ async def test_scatter_step(context: StreamFlowContext):
     await save_load_and_test(step, context)
 
 
-# Subtest - Step param combinator
 @pytest.mark.asyncio
 async def test_dot_product_combinator(context: StreamFlowContext):
     """Test saving and loading CombinatorStep with DotProductCombinator from database"""
@@ -254,7 +248,6 @@ async def test_loop_termination_combinator(context: StreamFlowContext):
     await save_load_and_test(step, context)
 
 
-# Testing the Target and its extension classes
 @pytest.mark.asyncio
 async def test_target(context: StreamFlowContext):
     """Test saving and loading Target from database"""
@@ -273,7 +266,6 @@ async def test_local_target(context: StreamFlowContext):
     await save_load_and_test(target, context)
 
 
-# Testing the Token and its extension classes
 @pytest.mark.asyncio
 async def test_token(context: StreamFlowContext):
     """Test saving and loading Token from database"""
@@ -325,7 +317,6 @@ async def test_iteration_termination_token(context: StreamFlowContext):
     await save_load_and_test(token, context)
 
 
-# Deployment test
 @pytest.mark.asyncio
 async def test_deployment(context: StreamFlowContext):
     """Test saving and loading deployment configuration from database"""

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,157 +1,87 @@
+from __future__ import annotations
+
 import asyncio
 import posixpath
-from typing import MutableMapping, Any, MutableSequence
+from typing import Any, MutableMapping, MutableSequence, cast
 
 import pytest
 
+from streamflow.core import utils
+from streamflow.core.config import BindingConfig
+from streamflow.core.context import StreamFlowContext
+from streamflow.core.deployment import Target
+from streamflow.core.persistence import DatabaseLoadingContext
+from streamflow.core.workflow import Port, Status, Step, Token, Workflow
 from streamflow.cwl.command import CWLCommand, CWLCommandToken
 from streamflow.cwl.translator import _create_command_output_processor_base
 from streamflow.persistence.loading_context import DefaultDatabaseLoadingContext
 from streamflow.workflow.combinator import (
-    DotProductCombinator,
     CartesianProductCombinator,
+    DotProductCombinator,
     LoopCombinator,
     LoopTerminationCombinator,
 )
 from streamflow.workflow.executor import StreamFlowExecutor
-from tests.conftest import get_docker_deployment_config
-
-from streamflow.core import utils
-from streamflow.core.context import StreamFlowContext
-from streamflow.core.config import BindingConfig
-from streamflow.core.deployment import Target
-from streamflow.core.workflow import Token, Workflow, Status, Port, Step
-
 from streamflow.workflow.port import ConnectorPort
 from streamflow.workflow.step import (
+    CombinatorStep,
     DeployStep,
     ExecuteStep,
-    ScheduleStep,
-    ScatterStep,
     GatherStep,
-    CombinatorStep,
     LoopCombinatorStep,
+    ScatterStep,
+    ScheduleStep,
 )
-
 from streamflow.workflow.token import (
+    IterationTerminationToken,
     ListToken,
     TerminationToken,
-    IterationTerminationToken,
 )
+from tests.conftest import get_docker_deployment_config
 
 
-async def _put_tokens(token_list, in_port, context):
+def _contains_id(id_: int, token_list: MutableSequence[Token]) -> bool:
     for t in token_list:
-        if not isinstance(t, TerminationToken):
-            await t.save(context, in_port.persistent_id)
-        in_port.put(t)
-    in_port.put(TerminationToken())
-
-
-async def _create_workflow(context: StreamFlowContext, num_port=2):
-    workflow = Workflow(
-        context=context, type="cwl", name=utils.random_name(), config={}
-    )
-    ports = []
-    for _ in range(num_port):
-        ports.append(workflow.create_port())
-    await workflow.save(context)
-    return workflow, *ports
-
-
-async def _general_test(
-    context: StreamFlowContext,
-    workflow: Workflow,
-    in_port: Port,
-    out_port: Port,
-    step_cls: Step,
-    kargs_step: MutableMapping[str, Any],
-    token_list: MutableSequence[Token],
-    port_name: str = "test",
-):
-    """ """
-    step = workflow.create_step(cls=step_cls, **kargs_step)
-    step.add_input_port(port_name, in_port)
-    step.add_output_port(port_name, out_port)
-
-    await _put_tokens(token_list, in_port, context)
-
-    await workflow.save(context)
-    executor = StreamFlowExecutor(workflow)
-    await executor.run()
-    return step
-
-
-async def _load_dependees(token_id, loading_context, context):
-    rows = await context.database.get_dependees(token_id)
-    return await asyncio.gather(
-        *(
-            asyncio.create_task(loading_context.load_token(context, row["dependee"]))
-            for row in rows
-        )
-    )
-
-
-async def _load_dependers(token_id, loading_context, context):
-    rows = await context.database.get_dependers(token_id)
-    return await asyncio.gather(
-        *(
-            asyncio.create_task(loading_context.load_token(context, row["depender"]))
-            for row in rows
-        )
-    )
-
-
-def contains_id(id, token_list):
-    for t in token_list:
-        if id == t.persistent_id:
+        if id_ == t.persistent_id:
             return True
     return False
 
 
-async def verify_dependency_tokens(
-    token,
-    port,
-    expected_depender,
-    expected_dependee,
-    context: StreamFlowContext,
-    alternative_expected_dependee=None,
-):
-    loading_context = DefaultDatabaseLoadingContext()
-
-    token_reloaded = await context.database.get_token(token_id=token.persistent_id)
-    assert token_reloaded["port"] == port.persistent_id
-
-    depender_list = await _load_dependers(token.persistent_id, loading_context, context)
-    print(
-        "depender:",
-        {token.persistent_id: [t.persistent_id for t in depender_list]},
+async def _load_dependees(
+    token_id: int, loading_context: DatabaseLoadingContext, context: StreamFlowContext
+) -> MutableSequence[Token]:
+    rows = await context.database.get_dependees(token_id)
+    return cast(
+        MutableSequence[Token],
+        await asyncio.gather(
+            *(
+                asyncio.create_task(
+                    loading_context.load_token(context, row["dependee"])
+                )
+                for row in rows
+            )
+        ),
     )
-    print("expected_depender", [t.persistent_id for t in expected_depender])
-    assert len(depender_list) == len(expected_depender)
-    for t1 in depender_list:
-        assert contains_id(t1.persistent_id, expected_depender)
 
-    dependee_list = await _load_dependees(token.persistent_id, loading_context, context)
-    print(
-        "dependee:",
-        {token.persistent_id: [t.persistent_id for t in dependee_list]},
+
+async def _load_dependers(
+    token_id: int, loading_context: DatabaseLoadingContext, context: StreamFlowContext
+) -> MutableSequence[Token]:
+    rows = await context.database.get_dependers(token_id)
+    return cast(
+        MutableSequence[Token],
+        await asyncio.gather(
+            *(
+                asyncio.create_task(
+                    loading_context.load_token(context, row["depender"])
+                )
+                for row in rows
+            )
+        ),
     )
-    print("expected_dependee", [t.persistent_id for t in expected_dependee])
-    try:
-        assert len(dependee_list) == len(expected_dependee)
-        for t1 in dependee_list:
-            assert contains_id(t1.persistent_id, expected_dependee)
-    except AssertionError as err:
-        if alternative_expected_dependee is None:
-            raise err
-        else:
-            assert len(dependee_list) == len(alternative_expected_dependee)
-            for t1 in dependee_list:
-                assert contains_id(t1.persistent_id, alternative_expected_dependee)
 
 
-def _create_deploy_step(workflow, deployment_config=None):
+def create_deploy_step(workflow, deployment_config=None):
     connector_port = workflow.create_port(cls=ConnectorPort)
     if not deployment_config:
         deployment_config = get_docker_deployment_config()
@@ -163,7 +93,7 @@ def _create_deploy_step(workflow, deployment_config=None):
     )
 
 
-def _create_schedule_step(workflow, deploy_step, binding_config=None):
+def create_schedule_step(workflow, deploy_step, binding_config=None):
     if not binding_config:
         binding_config = BindingConfig(
             targets=[
@@ -184,50 +114,150 @@ def _create_schedule_step(workflow, deploy_step, binding_config=None):
     )
 
 
+async def create_workflow(
+    context: StreamFlowContext, num_port: int = 2
+) -> tuple[Workflow, tuple[Port]]:
+    workflow = Workflow(
+        context=context, type="cwl", name=utils.random_name(), config={}
+    )
+    ports = []
+    for _ in range(num_port):
+        ports.append(workflow.create_port())
+    await workflow.save(context)
+    return workflow, tuple(cast(MutableSequence[Port], ports))
+
+
+async def general_test(
+    context: StreamFlowContext,
+    workflow: Workflow,
+    in_port: Port,
+    out_port: Port,
+    step_cls: type[Step],
+    kwargs_step: MutableMapping[str, Any],
+    token_list: MutableSequence[Token],
+    port_name: str = "test",
+) -> Step:
+    """ """
+    step = workflow.create_step(cls=step_cls, **kwargs_step)
+    step.add_input_port(port_name, in_port)
+    step.add_output_port(port_name, out_port)
+
+    await put_tokens(token_list, in_port, context)
+
+    await workflow.save(context)
+    executor = StreamFlowExecutor(workflow)
+    await executor.run()
+    return step
+
+
+async def put_tokens(
+    token_list: MutableSequence[Token], in_port: Port, context: StreamFlowContext
+) -> None:
+    for t in token_list:
+        if not isinstance(t, TerminationToken):
+            await t.save(context, in_port.persistent_id)
+        in_port.put(t)
+    in_port.put(TerminationToken())
+
+
+async def verify_dependency_tokens(
+    token: Token,
+    port: Port,
+    context: StreamFlowContext,
+    expected_depender: MutableSequence[Token] | None = None,
+    expected_dependee: MutableSequence[Token] | None = None,
+    alternative_expected_dependee: MutableSequence[Token] | None = None,
+):
+    loading_context = DefaultDatabaseLoadingContext()
+    expected_depender = expected_depender or []
+    expected_dependee = expected_dependee or []
+
+    token_reloaded = await context.database.get_token(token_id=token.persistent_id)
+    assert token_reloaded["port"] == port.persistent_id
+
+    depender_list = await _load_dependers(token.persistent_id, loading_context, context)
+    print(
+        "depender:",
+        {token.persistent_id: [t.persistent_id for t in depender_list]},
+    )
+    print(
+        "expected_depender",
+        [t.persistent_id for t in expected_depender],
+    )
+    assert len(depender_list) == len(expected_depender)
+    for t1 in depender_list:
+        assert _contains_id(t1.persistent_id, expected_depender)
+
+    dependee_list = await _load_dependees(token.persistent_id, loading_context, context)
+    print(
+        "dependee:",
+        {token.persistent_id: [t.persistent_id for t in dependee_list]},
+    )
+    print(
+        "expected_dependee",
+        [t.persistent_id for t in expected_dependee],
+    )
+    try:
+        assert len(dependee_list) == len(expected_dependee)
+        for t1 in dependee_list:
+            assert _contains_id(t1.persistent_id, expected_dependee)
+    except AssertionError as err:
+        if alternative_expected_dependee is None:
+            raise err
+        else:
+            assert len(dependee_list) == len(alternative_expected_dependee)
+            for t1 in dependee_list:
+                assert _contains_id(t1.persistent_id, alternative_expected_dependee)
+
+
 @pytest.mark.asyncio
 async def test_scatter_step(context: StreamFlowContext):
-    """ """
-    workflow, in_port, out_port = await _create_workflow(context)
+    """Test token provenance for ScatterStep"""
+    workflow, (in_port, out_port) = await create_workflow(context)
     token_list = [ListToken([Token("a"), Token("b"), Token("c")])]
-    await _general_test(
-        context,
-        workflow,
-        in_port,
-        out_port,
-        ScatterStep,
-        {"name": utils.random_name() + "-scatter"},
-        token_list,
+    await general_test(
+        context=context,
+        workflow=workflow,
+        in_port=in_port,
+        out_port=out_port,
+        step_cls=ScatterStep,
+        kwargs_step={"name": utils.random_name() + "-scatter"},
+        token_list=token_list,
     )
     assert len(out_port.token_list) == 4
     for curr_token in out_port.token_list[:-1]:
         await verify_dependency_tokens(
-            curr_token, out_port, (), [in_port.token_list[0]], context
+            token=curr_token,
+            port=out_port,
+            context=context,
+            expected_dependee=[in_port.token_list[0]],
         )
 
 
 @pytest.mark.asyncio
 async def test_deploy_step(context: StreamFlowContext):
-    """ """
-    workflow = (await _create_workflow(context, num_port=0))[0]
-    step = _create_deploy_step(workflow)
+    """Test token provenance for DeployStep"""
+    workflow = (await create_workflow(context, num_port=0))[0]
+    step = create_deploy_step(workflow)
 
     await workflow.save(context)
     executor = StreamFlowExecutor(workflow)
     await executor.run()
 
-    # len(token_list) = N output tokens + 1 termination token
     assert len(step.get_output_port().token_list) == 2
     await verify_dependency_tokens(
-        step.get_output_port().token_list[0], step.get_output_port(), (), (), context
+        token=step.get_output_port().token_list[0],
+        port=step.get_output_port(),
+        context=context,
     )
 
 
 @pytest.mark.asyncio
 async def test_schedule_step(context: StreamFlowContext):
-    """ """
-    workflow = (await _create_workflow(context, num_port=0))[0]
-    deploy_step = _create_deploy_step(workflow)
-    schedule_step = _create_schedule_step(workflow, deploy_step)
+    """Test token provenance for ScheduleStep"""
+    workflow = (await create_workflow(context, num_port=0))[0]
+    deploy_step = create_deploy_step(workflow)
+    schedule_step = create_schedule_step(workflow, deploy_step)
 
     await workflow.save(context)
     executor = StreamFlowExecutor(workflow)
@@ -236,29 +266,27 @@ async def test_schedule_step(context: StreamFlowContext):
     await context.scheduler.notify_status(job_token.value.name, Status.COMPLETED)
 
     await verify_dependency_tokens(
-        deploy_step.get_output_port().token_list[0],
-        deploy_step.get_output_port(),
-        [job_token],
-        [],
-        context,
+        token=deploy_step.get_output_port().token_list[0],
+        port=deploy_step.get_output_port(),
+        context=context,
+        expected_depender=[job_token],
     )
     await verify_dependency_tokens(
-        job_token,
-        schedule_step.get_output_port("__job__"),
-        [],
-        [deploy_step.get_output_port().token_list[0]],
-        context,
+        token=job_token,
+        port=schedule_step.get_output_port("__job__"),
+        context=context,
+        expected_dependee=[deploy_step.get_output_port().token_list[0]],
     )
 
 
 @pytest.mark.asyncio
 async def test_execute_step(context: StreamFlowContext):
-    """ """
-    workflow, in_port_schedule, in_port, out_port = await _create_workflow(
+    """Test token provenance for ExecuteStep"""
+    workflow, (in_port_schedule, in_port, out_port) = await create_workflow(
         context, num_port=3
     )
-    deploy_step = _create_deploy_step(workflow)
-    schedule_step = _create_schedule_step(workflow, deploy_step)
+    deploy_step = create_deploy_step(workflow)
+    schedule_step = create_schedule_step(workflow, deploy_step)
 
     in_port_name = "in-1"
     out_port_name = "out-1"
@@ -289,10 +317,10 @@ async def test_execute_step(context: StreamFlowContext):
     token_list = [Token(token_value)]
 
     execute_step.add_input_port(in_port_name, in_port)
-    await _put_tokens(token_list, in_port, context)
+    await put_tokens(token_list, in_port, context)
 
     schedule_step.add_input_port(in_port_name, in_port_schedule)
-    await _put_tokens(token_list, in_port_schedule, context)
+    await put_tokens(token_list, in_port_schedule, context)
 
     await workflow.save(context)
     executor = StreamFlowExecutor(workflow)
@@ -300,45 +328,47 @@ async def test_execute_step(context: StreamFlowContext):
 
     job_token = execute_step.get_input_port("__job__").token_list[0]
     await verify_dependency_tokens(
-        job_token,
-        execute_step.get_input_port("__job__"),
-        [execute_step.get_output_port(out_port_name).token_list[0]],
-        [deploy_step.get_output_port().token_list[0], token_list[0]],
-        context,
+        token=job_token,
+        port=execute_step.get_input_port("__job__"),
+        context=context,
+        expected_depender=[execute_step.get_output_port(out_port_name).token_list[0]],
+        expected_dependee=[deploy_step.get_output_port().token_list[0], token_list[0]],
     )
     await verify_dependency_tokens(
-        execute_step.get_output_port(out_port_name).token_list[0],
-        execute_step.get_output_port(out_port_name),
-        [],
-        list(job_token.value.inputs.values()) + [job_token],
-        context,
+        token=execute_step.get_output_port(out_port_name).token_list[0],
+        port=execute_step.get_output_port(out_port_name),
+        context=context,
+        expected_dependee=list(job_token.value.inputs.values()) + [job_token],
     )
 
 
 @pytest.mark.asyncio
 async def test_gather_step(context: StreamFlowContext):
-    """ """
-    workflow, in_port, out_port = await _create_workflow(context)
+    """Test token provenance for GatherStep"""
+    workflow, (in_port, out_port) = await create_workflow(context)
     token_list = [Token(i) for i in range(3)]
-    await _general_test(
-        context,
-        workflow,
-        in_port,
-        out_port,
-        GatherStep,
-        {"name": utils.random_name() + "-gather"},
-        token_list,
+    await general_test(
+        context=context,
+        workflow=workflow,
+        in_port=in_port,
+        out_port=out_port,
+        step_cls=GatherStep,
+        kwargs_step={"name": utils.random_name() + "-gather"},
+        token_list=token_list,
     )
     assert len(out_port.token_list) == 2
     await verify_dependency_tokens(
-        out_port.token_list[0], out_port, (), token_list, context
+        token=out_port.token_list[0],
+        port=out_port,
+        context=context,
+        expected_dependee=token_list,
     )
 
 
 @pytest.mark.asyncio
 async def test_combinator_step_dot_product(context: StreamFlowContext):
-    """ """
-    workflow, in_port, out_port, in_port_2, out_port_2 = await _create_workflow(
+    """Test token provenance for DotProductCombinator"""
+    workflow, (in_port, out_port, in_port_2, out_port_2) = await create_workflow(
         context, num_port=4
     )
     step = workflow.create_step(
@@ -356,11 +386,11 @@ async def test_combinator_step_dot_product(context: StreamFlowContext):
 
     await workflow.save(context)
     list_token = ListToken([Token("fst"), Token("snd")])
-    await _put_tokens([list_token], in_port, context)
+    await put_tokens([list_token], in_port, context)
     step.combinator.add_item(port_name)
 
     tt = Token("4")
-    await _put_tokens([tt], in_port_2, context)
+    await put_tokens([tt], in_port_2, context)
     step.combinator.add_item(port_name_2)
 
     await workflow.save(context)
@@ -369,18 +399,24 @@ async def test_combinator_step_dot_product(context: StreamFlowContext):
 
     assert len(out_port.token_list) == 2
     await verify_dependency_tokens(
-        out_port.token_list[0], out_port, [], [list_token, tt], context
+        token=out_port.token_list[0],
+        port=out_port,
+        context=context,
+        expected_dependee=[list_token, tt],
     )
     assert len(out_port_2.token_list) == 2
     await verify_dependency_tokens(
-        out_port_2.token_list[0], out_port_2, [], [list_token, tt], context
+        token=out_port_2.token_list[0],
+        port=out_port_2,
+        context=context,
+        expected_dependee=[list_token, tt],
     )
 
 
 @pytest.mark.asyncio
 async def test_combinator_step_cartesian_product(context: StreamFlowContext):
-    """ """
-    workflow, in_port, out_port, in_port_2, out_port_2 = await _create_workflow(
+    """Test token provenance for CartesianProductCombinator"""
+    workflow, (in_port, out_port, in_port_2, out_port_2) = await create_workflow(
         context, num_port=4
     )
     step = workflow.create_step(
@@ -400,11 +436,11 @@ async def test_combinator_step_cartesian_product(context: StreamFlowContext):
 
     await workflow.save(context)
     token_list = [ListToken([Token("a"), Token("b")])]
-    await _put_tokens(token_list, in_port, context)
+    await put_tokens(token_list, in_port, context)
     step.combinator.add_item(port_name)
 
     token_list_2 = [Token("4")]
-    await _put_tokens(token_list_2, in_port_2, context)
+    await put_tokens(token_list_2, in_port_2, context)
     step.combinator.add_item(port_name_2)
 
     await workflow.save(context)
@@ -413,23 +449,25 @@ async def test_combinator_step_cartesian_product(context: StreamFlowContext):
 
     assert len(out_port.token_list) == 2
     await verify_dependency_tokens(
-        out_port.token_list[0], out_port, [], [token_list[0], token_list_2[0]], context
+        token=out_port.token_list[0],
+        port=out_port,
+        context=context,
+        expected_dependee=[token_list[0], token_list_2[0]],
     )
 
     assert len(out_port_2.token_list) == 2
     await verify_dependency_tokens(
-        out_port_2.token_list[0],
-        out_port_2,
-        [],
-        [token_list[0], token_list_2[0]],
-        context,
+        token=out_port_2.token_list[0],
+        port=out_port_2,
+        context=context,
+        expected_dependee=[token_list[0], token_list_2[0]],
     )
 
 
 @pytest.mark.asyncio
 async def test_loop_combinator_step(context: StreamFlowContext):
-    """ """
-    workflow, in_port, out_port, in_port_2, out_port_2 = await _create_workflow(
+    """Test token provenance for LoopCombinator"""
+    workflow, (in_port, out_port, in_port_2, out_port_2) = await create_workflow(
         context, num_port=4
     )
     name = utils.random_name()
@@ -452,11 +490,11 @@ async def test_loop_combinator_step(context: StreamFlowContext):
         ListToken([Token("a"), Token("b")], tag=tag),
         IterationTerminationToken(tag),
     ]
-    await _put_tokens(token_list, in_port, context)
+    await put_tokens(token_list, in_port, context)
     step.combinator.add_item(port_name)
 
     token_list_2 = [Token("4", tag=tag), IterationTerminationToken(tag=tag)]
-    await _put_tokens(token_list_2, in_port_2, context)
+    await put_tokens(token_list_2, in_port_2, context)
     step.combinator.add_item(port_name_2)
 
     await workflow.save(context)
@@ -465,14 +503,17 @@ async def test_loop_combinator_step(context: StreamFlowContext):
 
     assert len(out_port.token_list) == 2
     await verify_dependency_tokens(
-        out_port.token_list[0], out_port, [], [token_list[0], token_list_2[0]], context
+        token=out_port.token_list[0],
+        port=out_port,
+        context=context,
+        expected_dependee=[token_list[0], token_list_2[0]],
     )
 
 
 @pytest.mark.asyncio
 async def test_loop_termination_combinator(context: StreamFlowContext):
-    """ """
-    workflow, in_port, out_port = await _create_workflow(context, num_port=2)
+    """Test token provenance for LoopTerminationCombinator"""
+    workflow, (in_port, out_port) = await create_workflow(context, num_port=2)
     step_name = utils.random_name()
     loop_terminator_combinator = LoopTerminationCombinator(
         workflow=workflow, name=step_name + "-loop-termination-combinator"
@@ -492,7 +533,7 @@ async def test_loop_termination_combinator(context: StreamFlowContext):
         ListToken([Token("a"), Token("b")], tag="0.0"),
         ListToken([Token("c"), Token("d")], tag="0.1"),
     ]
-    await _put_tokens(list_token, in_port, context)
+    await put_tokens(list_token, in_port, context)
 
     await workflow.save(context)
     executor = StreamFlowExecutor(workflow)
@@ -500,139 +541,9 @@ async def test_loop_termination_combinator(context: StreamFlowContext):
 
     assert len(out_port.token_list) == 3
     for out_token, in_token in zip(out_port.token_list[:-1], list_token):
-        await verify_dependency_tokens(out_token, out_port, [], [in_token], context)
-
-
-@pytest.mark.asyncio
-async def test_nested_crossproduct_combinator(context: StreamFlowContext):
-    """ """
-    workflow, in_port_1, in_port_2, out_port_1, out_port_2 = await _create_workflow(
-        context, num_port=4
-    )
-    port_name_1 = "echo_in1"
-    port_name_2 = "echo_in2"
-    prefix_name = "/step1-scatter"
-    step_name = prefix_name + "-combinator"
-    combinator = DotProductCombinator(
-        workflow=workflow, name=prefix_name + "-dot-product-combinator"
-    )
-    c1 = CartesianProductCombinator(name=step_name, workflow=workflow)
-    c1.add_item(port_name_1)
-    c1.add_item(port_name_2)
-    items = c1.get_items(False)
-    combinator.add_combinator(
-        c1,
-        items,
-    )
-
-    step = workflow.create_step(
-        cls=CombinatorStep,
-        name=step_name,
-        combinator=combinator,
-    )
-
-    step.add_input_port(port_name_1, in_port_1)
-    step.add_input_port(port_name_2, in_port_2)
-    step.add_output_port(port_name_1, out_port_1)
-    step.add_output_port(port_name_2, out_port_2)
-
-    list_token_1 = [
-        ListToken([Token("a"), Token("b")], tag="0.0"),
-        ListToken([Token("c"), Token("d")], tag="0.1"),
-    ]
-    await _put_tokens(list_token_1, in_port_1, context)
-
-    list_token_2 = [
-        ListToken([Token("1"), Token("2")], tag="0.0"),
-        ListToken([Token("3"), Token("4")], tag="0.1"),
-    ]
-    await _put_tokens(list_token_2, in_port_2, context)
-
-    await workflow.save(context)
-    executor = StreamFlowExecutor(workflow)
-    await executor.run()
-
-    nested_crossproduct_1 = [(t1, t2) for t2 in list_token_2 for t1 in list_token_1]
-    nested_crossproduct_2 = [(t1, t2) for t1 in list_token_1 for t2 in list_token_2]
-
-    for t in list_token_1:
-        print(f"{t.persistent_id}, {t.tag}, {[tt.value for tt in t.value]}")
-
-    for t in list_token_2:
-        print(f"{t.persistent_id}, {t.tag}, {[tt.value for tt in t.value]}")
-    print()
-
-    for out_token in out_port_1.token_list[:-1]:
-        print(
-            f"{out_token.persistent_id}, {out_token.tag}, {[tt.value for tt in out_token.value]}"
-        )
-    for out_token in out_port_2.token_list[:-1]:
-        print(
-            f"{out_token.persistent_id}, {out_token.tag}, {[tt.value for tt in out_token.value]}"
-        )
-    print()
-    # The tokens id produced by combinators depend on the order of input tokens.
-    # The use of the alternative_expected_dependee parameter is necessary
-    # For example:
-    # input port_1 token: (id, tag, value)
-    #   (  3, 0.0, ['a', 'b'] )
-    #   (  6, 0.1, ['c', 'd'] )
-    # input port_2 token: (id, tag, value)
-    #   (  9, 0.0, ['1', '2'] )
-    #   ( 12, 0.1, ['3', '4'] )
-
-    # case #1: port_1 input tokens arrive first
-    # - output port_1 token: (id, tag, value)
-    #   ( 13, 0.0.0, ['a', 'b'] )
-    #   ( 15, 0.0.1, ['a', 'b'] )
-    #   ( 17, 0.1.0, ['c', 'd'] )
-    #   ( 19, 0.1.1, ['c', 'd'] )
-    # - output port_2 token: (id, tag, value)
-    #   ( 14, 0.0.0, ['1', '2'] )
-    #   ( 16, 0.0.1, ['3', '4'] )
-    #   ( 18, 0.1.0, ['1', '2'] )
-    #   ( 20, 0.1.1, ['3', '4'] )
-    # - provenance token in port_1: { output token id : input token id list }
-    #   { 13 : [3, 9], 15 : [3, 12], 17 : [6, 9], 19 : [6, 12] }
-    # - provenance token in port_2: { output token id : input token id list }
-    #   { 14 : [3, 9], 16 : [3, 12], 18 : [6, 9], 20 : [6, 12] }
-
-    # case #2: port_2 input tokens arrive first
-    # - output port_1 token: (id, tag, value)
-    #   ( 13, 0.0.0, ['a', 'b'] )
-    #   ( 15, 0.1.0, ['c', 'd'] )
-    #   ( 17, 0.0.1, ['a', 'b'] )
-    #   ( 19, 0.1.1, ['c', 'd'] )
-    # - output port_2 token: (id, tag, value)
-    #   ( 14, 0.0.0, ['1', '2'] )
-    #   ( 16, 0.1.0, ['1', '2'] )
-    #   ( 18, 0.0.1, ['3', '4'] )
-    #   ( 20, 0.1.1, ['3', '4'] )
-    # - provenance token in port_1: { output token id : input token id list }
-    #   { 13 : [3, 9], 15 : [6, 9], 17 : [3, 12], 19 : [6, 12] }
-    # - provenance token in port_2: { output token id : input token id list }
-    #   { 14 : [3, 9], 16 : [6, 9], 18 : [3, 12], 20 : [6, 12] }
-
-    # check port_1 outputs
-    assert len(out_port_1.token_list) == 5
-    for i, out_token in enumerate(out_port_1.token_list[:-1]):
         await verify_dependency_tokens(
-            out_token,
-            out_port_1,
-            [],
-            nested_crossproduct_1[i],
-            context,
-            alternative_expected_dependee=nested_crossproduct_2[i],
-        )
-
-    # check port_2 outputs
-    assert len(out_port_2.token_list) == 5
-    for i, out_token in enumerate(out_port_2.token_list[:-1]):
-        await verify_dependency_tokens(
-            out_token,
-            out_port_2,
-            [],
-            nested_crossproduct_1[i],
-            context,
-            alternative_expected_dependee=nested_crossproduct_2[i],
+            token=out_token,
+            port=out_port,
+            context=context,
+            expected_dependee=[in_token],
         )


### PR DESCRIPTION
The `black` tool is able to retrieve configuration from `pyproject.toml`. Since PyCharm now supports `black` formatter OOTB, it is better to have a single source of truth for `black` configurations. This commit moves the list of excluded files from the inline command in `Makefile` to `pyproject.toml`.