### PR TITLE
Enable distributed inheritance for plugins

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ cwltool==3.1.20230719185429
 cwl-utils==0.28
 importlib_metadata==6.8.0
 Jinja2==3.1.2
-jsonref==1.1.0
 jsonschema==4.19.0
 kubernetes_asyncio==24.2.3
 psutil==5.9.5

--- a/streamflow/config/schema.py
+++ b/streamflow/config/schema.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+import os
+import posixpath
+from typing import MutableMapping
+
+import pkg_resources
+from referencing import Registry, Resource
+
+from streamflow.core.context import SchemaEntity
+from streamflow.core.exception import WorkflowDefinitionException
+from streamflow.cwl.requirement.docker import (
+    cwl_docker_translator_classes,
+)
+from streamflow.data import data_manager_classes
+from streamflow.deployment import deployment_manager_classes
+from streamflow.deployment.connector import connector_classes
+from streamflow.deployment.filter import binding_filter_classes
+from streamflow.persistence import database_classes
+from streamflow.recovery import (
+    checkpoint_manager_classes,
+    failure_manager_classes,
+)
+from streamflow.scheduling import scheduler_classes
+from streamflow.scheduling.policy import policy_classes
+
+_CONFIGS = {
+    "v1.0": "https://streamflow.di.unito.it/schemas/config/v1.0/config_schema.json"
+}
+
+
+ext_schemas = [
+    pkg_resources.resource_filename(
+        "streamflow.deployment.connector", os.path.join("schemas", "queue_manager.json")
+    )
+]
+
+
+class SfSchema:
+    def __init__(self):
+        self.registry: Registry = Registry()
+        for version in _CONFIGS.keys():
+            schema = pkg_resources.resource_filename(
+                __name__, os.path.join("schemas", version, "config_schema.json")
+            )
+            self.add_schema(schema)
+        self.inject_ext(binding_filter_classes, "bindingFilter")
+        self.inject_ext(checkpoint_manager_classes, "checkpointManager")
+        self.inject_ext(cwl_docker_translator_classes, "cwl/docker")
+        self.inject_ext(database_classes, "database")
+        self.inject_ext(data_manager_classes, "dataManager")
+        self.inject_ext(connector_classes, "deployment")
+        self.inject_ext(deployment_manager_classes, "deploymentManager")
+        self.inject_ext(failure_manager_classes, "failureManager")
+        self.inject_ext(policy_classes, "policy")
+        self.inject_ext(scheduler_classes, "scheduler")
+        for schema in ext_schemas:
+            self.add_schema(schema)
+        self.registry = self.registry.crawl()
+
+    def add_schema(self, schema: str) -> Resource:
+        with open(schema) as f:
+            resource = Resource.from_contents(json.load(f))
+            self.registry = resource @ self.registry
+            return resource
+
+    def get_config(self, version: str) -> Resource:
+        if version not in _CONFIGS:
+            raise WorkflowDefinitionException(
+                f"Version {version} is unsupported. The `version` clause should be equal to `v1.0`."
+            )
+        return self.registry.get(_CONFIGS[version])
+
+    def inject_ext(
+        self,
+        classes: MutableMapping[str, type[SchemaEntity]],
+        definition_name: str,
+    ):
+        for name, entity in classes.items():
+            if entity_schema := entity.get_schema():
+                entity_schema = self.add_schema(entity_schema).contents
+                for config_id in _CONFIGS.values():
+                    config = self.registry.contents(config_id)
+                    definition = config["$defs"]
+                    for el in definition_name.split(posixpath.sep):
+                        definition = definition[el]
+                    definition["properties"]["type"].setdefault("enum", []).append(name)
+                    definition["$defs"][name] = entity_schema
+                    definition.setdefault("allOf", []).append(
+                        {
+                            "if": {"properties": {"type": {"const": name}}},
+                            "then": {"properties": {"config": entity_schema}},
+                        }
+                    )

--- a/streamflow/config/schemas/v1.0/config_schema.json
+++ b/streamflow/config/schemas/v1.0/config_schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/streamflow/config/schemas/v1.0/config_schema.json",
+  "$id": "https://streamflow.di.unito.it/schemas/config/v1.0/config_schema.json",
   "type": "object",
   "$defs": {
     "binding": {

--- a/streamflow/config/validator.py
+++ b/streamflow/config/validator.py
@@ -1,25 +1,12 @@
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING
 
-import jsonref
-import pkg_resources
 from jsonschema.validators import validator_for
 from ruamel.yaml import YAML
 
-from streamflow.core import utils
+from streamflow.config.schema import SfSchema
 from streamflow.core.exception import WorkflowDefinitionException
-from streamflow.core.utils import config_loader
-from streamflow.cwl.requirement.docker import cwl_docker_translator_classes
-from streamflow.data import data_manager_classes
-from streamflow.deployment import deployment_manager_classes
-from streamflow.deployment.connector import connector_classes
-from streamflow.deployment.filter import binding_filter_classes
-from streamflow.persistence import database_classes
-from streamflow.recovery import checkpoint_manager_classes, failure_manager_classes
-from streamflow.scheduling import scheduler_classes
-from streamflow.scheduling.policy import policy_classes
 
 if TYPE_CHECKING:
     from typing import Any, MutableMapping
@@ -36,36 +23,10 @@ def handle_errors(errors):
     )
 
 
-def load_jsonschema(config_file: MutableMapping[str, Any]):
-    if "version" not in config_file:
-        raise WorkflowDefinitionException(
-            "The `version` clause is mandatory and should be equal to `v1.0`."
-        )
-    try:
-        base_path = pkg_resources.resource_filename(
-            __name__, os.path.join("schemas", config_file["version"])
-        )
-    except pkg_resources.ResolutionError:
-        raise WorkflowDefinitionException(
-            f"Version {config_file['version']} is unsupported. The `version` clause should be equal to `v1.0`."
-        )
-    filename = os.path.join(base_path, "config_schema.json")
-    if not os.path.exists(filename):
-        raise WorkflowDefinitionException(
-            f"Version {config_file['version']} is unsupported. The `version` clause should be equal to `v1.0`."
-        )
-    with open(os.path.join(base_path, "config_schema.json")) as f:
-        return jsonref.loads(
-            f.read(),
-            base_uri=f"file://{base_path}/",
-            loader=config_loader,
-            jsonschema=True,
-        )
-
-
 class SfValidator:
     def __init__(self) -> None:
         super().__init__()
+        self.schema: SfSchema = SfSchema()
         self.yaml = YAML(typ="safe")
 
     def validate_file(self, streamflow_file: str) -> MutableMapping[str, Any]:
@@ -73,19 +34,13 @@ class SfValidator:
             streamflow_config = self.yaml.load(f)
         return self.validate(streamflow_config)
 
-    def validate(self, streamflow_config: MutableMapping[str, Any]):
-        schema = load_jsonschema(streamflow_config)
-        utils.inject_schema(schema, binding_filter_classes, "bindingFilter")
-        utils.inject_schema(schema, checkpoint_manager_classes, "checkpointManager")
-        utils.inject_schema(schema, cwl_docker_translator_classes, "cwl/docker")
-        utils.inject_schema(schema, database_classes, "database")
-        utils.inject_schema(schema, data_manager_classes, "dataManager")
-        utils.inject_schema(schema, connector_classes, "deployment")
-        utils.inject_schema(schema, deployment_manager_classes, "deploymentManager")
-        utils.inject_schema(schema, failure_manager_classes, "failureManager")
-        utils.inject_schema(schema, policy_classes, "policy")
-        utils.inject_schema(schema, scheduler_classes, "scheduler")
-        cls = validator_for(schema)
-        validator = cls(schema)
-        handle_errors(validator.iter_errors(streamflow_config))
-        return streamflow_config
+    def validate(self, streamflow_file: MutableMapping[str, Any]):
+        if "version" not in streamflow_file:
+            raise WorkflowDefinitionException(
+                "The `version` clause is mandatory and should be equal to `v1.0`."
+            )
+        config = self.schema.get_config(streamflow_file["version"]).contents
+        cls = validator_for(config)
+        validator = cls(config, registry=self.schema.registry)
+        handle_errors(validator.iter_errors(streamflow_file))
+        return streamflow_file

--- a/streamflow/cwl/requirement/docker/schemas/docker.json
+++ b/streamflow/cwl/requirement/docker/schemas/docker.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/streamflow/cwl/requirement/docker/schemas/docker.json",
+  "$id": "https://streamflow.di.unito.it/schemas/cwl/requirement/docker/docker.json",
   "type": "object",
   "properties": {
     "addHost": {

--- a/streamflow/cwl/requirement/docker/schemas/kubernetes.json
+++ b/streamflow/cwl/requirement/docker/schemas/kubernetes.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/streamflow/cwl/requirement/docker/schemas/kubernetes.json",
+  "$id": "https://streamflow.di.unito.it/schemas/cwl/requirement/docker/kubernetes.json",
   "type": "object",
   "properties": {
     "file": {

--- a/streamflow/cwl/requirement/docker/schemas/singularity.json
+++ b/streamflow/cwl/requirement/docker/schemas/singularity.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/streamflow/cwl/requirement/docker/schemas/singularity.json",
+  "$id": "https://streamflow.di.unito.it/schemas/cwl/requirement/docker/singularity.json",
   "type": "object",
   "properties": {
     "addCaps": {

--- a/streamflow/deployment/connector/schemas/docker-compose.json
+++ b/streamflow/deployment/connector/schemas/docker-compose.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/streamflow/deployment/connector/schemas/docker-compose.json",
+  "$id": "https://streamflow.di.unito.it/schemas/deployment/connector/docker-compose.json",
   "type": "object",
   "properties": {
     "files": {

--- a/streamflow/deployment/connector/schemas/docker.json
+++ b/streamflow/deployment/connector/schemas/docker.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/streamflow/deployment/connector/schemas/docker.json",
+  "$id": "https://streamflow.di.unito.it/schemas/deployment/connector/docker.json",
   "type": "object",
   "properties": {
     "image": {

--- a/streamflow/deployment/connector/schemas/flux.json
+++ b/streamflow/deployment/connector/schemas/flux.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/streamflow/deployment/connector/schemas/flux.json",
+  "$id": "https://streamflow.di.unito.it/schemas/deployment/connector/flux.json",
   "type": "object",
   "$defs": {
     "service": {
@@ -144,7 +144,7 @@
   },
   "allOf": [
     {
-      "$ref": "/streamflow/deployment/connector/schemas/queue_manager.json"
+      "$ref": "https://streamflow.di.unito.it/schemas/deployment/connector/queue_manager.json"
     }
   ],
   "properties": {

--- a/streamflow/deployment/connector/schemas/helm3.json
+++ b/streamflow/deployment/connector/schemas/helm3.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/streamflow/deployment/connector/schemas/helm3.json",
+  "$id": "https://streamflow.di.unito.it/schemas/deployment/connector/helm3.json",
   "type": "object",
   "properties": {
     "atomic": {

--- a/streamflow/deployment/connector/schemas/kubernetes.json
+++ b/streamflow/deployment/connector/schemas/kubernetes.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/streamflow/deployment/connector/schemas/kubernetes.json",
+  "$id": "https://streamflow.di.unito.it/schemas/deployment/connector/kubernetes.json",
   "type": "object",
   "properties": {
     "files": {

--- a/streamflow/deployment/connector/schemas/local.json
+++ b/streamflow/deployment/connector/schemas/local.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/streamflow/deployment/connector/schemas/local.json",
+  "$id": "https://streamflow.di.unito.it/schemas/deployment/connector/local.json",
   "type": "object",
   "properties": {
     "transferBufferSize": {

--- a/streamflow/deployment/connector/schemas/occam.json
+++ b/streamflow/deployment/connector/schemas/occam.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/streamflow/deployment/connector/schemas/occam.json",
+  "$id": "https://streamflow.di.unito.it/schemas/deployment/connector/occam.json",
   "type": "object",
   "properties": {
     "file": {

--- a/streamflow/deployment/connector/schemas/pbs.json
+++ b/streamflow/deployment/connector/schemas/pbs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/streamflow/deployment/connector/schemas/pbs.json",
+  "$id": "https://streamflow.di.unito.it/schemas/deployment/connector/pbs.json",
   "type": "object",
   "$defs": {
     "service": {
@@ -77,7 +77,7 @@
   },
   "allOf": [
     {
-      "$ref": "/streamflow/deployment/connector/schemas/queue_manager.json"
+      "$ref": "https://streamflow.di.unito.it/schemas/deployment/connector/queue_manager.json"
     }
   ],
   "properties": {

--- a/streamflow/deployment/connector/schemas/queue_manager.json
+++ b/streamflow/deployment/connector/schemas/queue_manager.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/streamflow/deployment/connector/schemas/queue_manager.json",
+  "$id": "https://streamflow.di.unito.it/schemas/deployment/connector/queue_manager.json",
   "type": "object",
   "properties": {
     "checkHostKey": {
@@ -15,7 +15,7 @@
         },
         {
           "type": "object",
-          "$ref": "/streamflow/deployment/connector/schemas/ssh.json#/$defs/connection"
+          "$ref": "https://streamflow.di.unito.it/schemas/deployment/connector/ssh.json#/$defs/connection"
         }
       ],
       "description": "(**Deprecated.** Use the `wraps` directive to wrap a standalone SSH connector.) Sometimes HPC clusters provide dedicated hostnames for large data transfers, which guarantee a higher efficiency for data movements"
@@ -68,7 +68,7 @@
     "tunnel": {
       "type": "object",
       "description": "(**Deprecated.** Use the `wraps` directive to wrap a standalone SSH connector.) External SSH connection parameters for tunneling",
-      "$ref": "/streamflow/deployment/connector/schemas/ssh.json#/$defs/connection"
+      "$ref": "https://streamflow.di.unito.it/schemas/deployment/connector/ssh.json#/$defs/connection"
     },
     "username": {
       "type": "string",

--- a/streamflow/deployment/connector/schemas/singularity.json
+++ b/streamflow/deployment/connector/schemas/singularity.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/streamflow/deployment/connector/schemas/singularity.json",
+  "$id": "https://streamflow.di.unito.it/schemas/deployment/connector/singularity.json",
   "type": "object",
   "properties": {
     "image": {

--- a/streamflow/deployment/connector/schemas/slurm.json
+++ b/streamflow/deployment/connector/schemas/slurm.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/streamflow/deployment/connector/schemas/slurm.json",
+  "$id": "/https://streamflow.di.unito.it/schemas/deployment/connector/slurm.json",
   "type": "object",
   "$defs": {
     "service": {
@@ -396,7 +396,7 @@
   },
   "allOf": [
     {
-      "$ref": "/streamflow/deployment/connector/schemas/queue_manager.json"
+      "$ref": "https://streamflow.di.unito.it/schemas/deployment/connector/queue_manager.json"
     }
   ],
   "properties": {

--- a/streamflow/deployment/connector/schemas/ssh.json
+++ b/streamflow/deployment/connector/schemas/ssh.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/streamflow/deployment/connector/schemas/ssh.json",
+  "$id": "https://streamflow.di.unito.it/schemas/deployment/connector/ssh.json",
   "type": "object",
   "$defs": {
     "connection": {

--- a/streamflow/deployment/filter/schemas/shuffle.json
+++ b/streamflow/deployment/filter/schemas/shuffle.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/streamflow/deployment/filter/schemas/shuffle.json",
+  "$id": "https://streamflow.di.unito.it/schemas/deployment/filter/shuffle.json",
   "type": "object",
   "properties": {},
   "additionalProperties": false

--- a/streamflow/deployment/schemas/deployment_manager.json
+++ b/streamflow/deployment/schemas/deployment_manager.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/streamflow/deployment/schemas/depoloyment_manager.json",
+  "$id": "https://streamflow.di.unito.it/schemas/deployment/depoloyment_manager.json",
   "type": "object",
   "properties": {},
   "additionalProperties": false

--- a/streamflow/ext/plugin.py
+++ b/streamflow/ext/plugin.py
@@ -4,6 +4,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Any, MutableMapping, MutableSequence
 
+from streamflow.config.schema import ext_schemas
 from streamflow.core.data import DataManager
 from streamflow.core.deployment import BindingFilter, Connector, DeploymentManager
 from streamflow.core.persistence import Database
@@ -88,3 +89,6 @@ class StreamFlowPlugin(ABC):
 
     def register_scheduler(self, name: str, cls: type[Scheduler]):
         self._register(name, cls, "scheduler")
+
+    def register_schema(self, schema: str) -> None:
+        ext_schemas.append(schema)

--- a/streamflow/persistence/schemas/sqlite.json
+++ b/streamflow/persistence/schemas/sqlite.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/streamflow/persistence/schemas/sqlite.json",
+  "$id": "https://streamflow.di.unito.it/schemas/persistence/sqlite.json",
   "type": "object",
   "properties": {
     "connection": {

--- a/streamflow/recovery/schemas/default_checkpoint_manager.json
+++ b/streamflow/recovery/schemas/default_checkpoint_manager.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/streamflow/recovery/schemas/default_checkpoint_manager.json",
+  "$id": "https://streamflow.di.unito.it/schemas/recovery/default_checkpoint_manager.json",
   "type": "object",
   "properties": {
     "checkpoint_dir": {

--- a/streamflow/recovery/schemas/default_failure_manager.json
+++ b/streamflow/recovery/schemas/default_failure_manager.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/streamflow/recovery/schemas/default_failure_manager.json",
+  "$id": "https://streamflow.di.unito.it/schemas/recovery/default_failure_manager.json",
   "type": "object",
   "properties": {
     "max_retries": {

--- a/streamflow/recovery/schemas/dummy_checkpoint_manager.json
+++ b/streamflow/recovery/schemas/dummy_checkpoint_manager.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/streamflow/recovery/schemas/dummy_checkpoint_manager.json",
+  "$id": "https://streamflow.di.unito.it/schemas/recovery/dummy_checkpoint_manager.json",
   "type": "object",
   "properties": {},
   "additionalProperties": false

--- a/streamflow/recovery/schemas/dummy_failure_manager.json
+++ b/streamflow/recovery/schemas/dummy_failure_manager.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/streamflow/recovery/schemas/dummy_failure_manager.json",
+  "$id": "https://streamflow.di.unito.it/schemas/recovery/dummy_failure_manager.json",
   "type": "object",
   "properties": {},
   "additionalProperties": false

--- a/streamflow/scheduling/policy/schemas/data_locality.json
+++ b/streamflow/scheduling/policy/schemas/data_locality.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/streamflow/scheduling/schemas/data_locality.json",
+  "$id": "https://streamflow.di.unito.it/schemas/scheduling/data_locality.json",
   "type": "object",
   "properties": {},
   "additionalProperties": false

--- a/streamflow/scheduling/schemas/scheduler.json
+++ b/streamflow/scheduling/schemas/scheduler.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/streamflow/scheduling/schemas/scheduler.json",
+  "$id": "https://streamflow.di.unito.it/schemas/scheduling/scheduler.json",
   "type": "object",
   "properties": {
     "retry_delay": {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -101,8 +101,8 @@ def test_ext_support():
         "dataManager": {"type": "default", "config": {}},
         "deployments": {
             "example": {
-                "type": "docker",
-                "config": {"image": "alpine:latest"},
+                "type": "slurm",
+                "config": {"maxConcurrentJobs": 10},
             }
         },
         "deploymentManager": {"type": "default", "config": {}},


### PR DESCRIPTION
This commit enables distributed inheritance for StreamFlow plugins. A plugin developer can now extend a JSON Schema coming from a different plugin using the full `$id` of the remote plugin in a `$ref` field. As a by product, this commit:
 - Replaces the `jsonref` library with the `referencing` library;
 - Modifies the plugin structure, allowing users to register custom base schemas that are not directly describing a class;
 - Modifies the `$id` schema of all StreamFlow config files.