### PR TITLE
Fix Flux and Mac OS CI steps

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -71,7 +71,7 @@ jobs:
         with:
           node-version: "15"
       - name: "Install Docker (MacOS X)"
-        uses: douglascamata/setup-docker-macos-action@v1-alpha.6
+        uses: douglascamata/setup-docker-macos-action@v1-alpha.9
         if: ${{ startsWith(matrix.on, 'macos-') }}
       - uses: docker/setup-qemu-action@v2
       - name: "Install Apptainer"
@@ -153,7 +153,7 @@ jobs:
       - name: Install Streamflow
         run: |
          pip install . 
-         pip install lockfile
+         pip install --upgrade --force-reinstall attrs lockfile
          chown -R fluxuser .
       - name: Start Flux and Test Workflow
         run: |
@@ -210,7 +210,7 @@ jobs:
         with:
           node-version: "15"
       - name: "Install Docker (MacOs X)"
-        uses: douglascamata/setup-docker-macos-action@v1-alpha.6
+        uses: douglascamata/setup-docker-macos-action@v1-alpha.9
         if: ${{ startsWith(matrix.on, 'macos-') }}
       - uses: docker/setup-qemu-action@v2
       - name: "Install Apptainer"

--- a/examples/flux/Dockerfile
+++ b/examples/flux/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /code
 
 # Install in development mode in case container used for development
 RUN pip install develop . \
- && pip install \
+ && pip install --upgrade --force-reinstall \
         attrs \
         lockfile \
  && chown -R fluxuser /code

--- a/streamflow/deployment/deployment_manager.py
+++ b/streamflow/deployment/deployment_manager.py
@@ -196,7 +196,7 @@ class DefaultDeploymentManager(DeploymentManager):
                         logger.info(f"COMPLETED Undeployment of {deployment_name}")
                 self.events_map[deployment_name].set()
             # Remove the current environment from all the other dependency graphs
-            for name, deps in (
+            for name, deps in list(
                 (k, v) for k, v in self.dependency_graph.items() if k != deployment_name
             ):
                 deps.discard(deployment_name)


### PR DESCRIPTION
The Flux CI step often fails because the `attrs` module cannot be found on the system. This commit fixes this behaviour by explicitly installing the module through `pip` in the CI workflow.
    
As per issue lima-vm/lima#1742, the QEMU 8.1.0 Homebrew package is broken on Intel architectures. This commit adds an additional step to compile QEMU from source, which fixes the issue.