### PR TITLE
Adjust JSONSchema ids

### DIFF
--- a/streamflow/data/schemas/data_manager.json
+++ b/streamflow/data/schemas/data_manager.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "data_manager.json",
+  "$id": "https://streamflow.di.unito.it/schemas/data/data_manager.json",
   "type": "object",
   "properties": {},
   "additionalProperties": false

--- a/streamflow/deployment/connector/schemas/flux.json
+++ b/streamflow/deployment/connector/schemas/flux.json
@@ -144,7 +144,7 @@
   },
   "allOf": [
     {
-      "$ref": "https://streamflow.di.unito.it/schemas/deployment/connector/queue_manager.json"
+      "$ref": "queue_manager.json"
     }
   ],
   "properties": {

--- a/streamflow/deployment/connector/schemas/pbs.json
+++ b/streamflow/deployment/connector/schemas/pbs.json
@@ -77,7 +77,7 @@
   },
   "allOf": [
     {
-      "$ref": "https://streamflow.di.unito.it/schemas/deployment/connector/queue_manager.json"
+      "$ref": "queue_manager.json"
     }
   ],
   "properties": {

--- a/streamflow/deployment/connector/schemas/queue_manager.json
+++ b/streamflow/deployment/connector/schemas/queue_manager.json
@@ -15,7 +15,7 @@
         },
         {
           "type": "object",
-          "$ref": "https://streamflow.di.unito.it/schemas/deployment/connector/ssh.json#/$defs/connection"
+          "$ref": "ssh.json#/$defs/connection"
         }
       ],
       "description": "(**Deprecated.** Use the `wraps` directive to wrap a standalone SSH connector.) Sometimes HPC clusters provide dedicated hostnames for large data transfers, which guarantee a higher efficiency for data movements"
@@ -68,7 +68,7 @@
     "tunnel": {
       "type": "object",
       "description": "(**Deprecated.** Use the `wraps` directive to wrap a standalone SSH connector.) External SSH connection parameters for tunneling",
-      "$ref": "https://streamflow.di.unito.it/schemas/deployment/connector/ssh.json#/$defs/connection"
+      "$ref": "ssh.json#/$defs/connection"
     },
     "username": {
       "type": "string",

--- a/streamflow/deployment/connector/schemas/slurm.json
+++ b/streamflow/deployment/connector/schemas/slurm.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "/https://streamflow.di.unito.it/schemas/deployment/connector/slurm.json",
+  "$id": "https://streamflow.di.unito.it/schemas/deployment/connector/slurm.json",
   "type": "object",
   "$defs": {
     "service": {
@@ -396,7 +396,7 @@
   },
   "allOf": [
     {
-      "$ref": "https://streamflow.di.unito.it/schemas/deployment/connector/queue_manager.json"
+      "$ref": "queue_manager.json"
     }
   ],
   "properties": {


### PR DESCRIPTION
This commit fixes some minor bugs in JSON Schema naming and reference, allowing correct documentation generation and improving readability of JSON Schema files.