### PR TITLE
Connector and CWL Runner fixes

### DIFF
--- a/streamflow/cwl/runner.py
+++ b/streamflow/cwl/runner.py
@@ -55,10 +55,10 @@ parser.add_argument(
 
 
 async def _async_main(args: argparse.Namespace):
+    load_extensions()
     validator = SfValidator()
     args.name = args.name or str(uuid.uuid4())
     if args.streamflow_file:
-        load_extensions()
         with open(args.streamflow_file) as f:
             streamflow_config = validator.yaml.load(f)
         workflows = streamflow_config.get("workflows", {})

--- a/streamflow/deployment/connector/base.py
+++ b/streamflow/deployment/connector/base.py
@@ -335,7 +335,13 @@ class BaseConnector(Connector, FutureAware):
         job_name: str | None = None,
     ) -> tuple[Any | None, int] | None:
         command = utils.create_command(
-            command, environment, workdir, stdin, stdout, stderr
+            self.__class__.__name__,
+            command,
+            environment,
+            workdir,
+            stdin,
+            stdout,
+            stderr,
         )
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(

--- a/streamflow/deployment/connector/kubernetes.py
+++ b/streamflow/deployment/connector/kubernetes.py
@@ -507,7 +507,13 @@ class BaseKubernetesConnector(BaseConnector, ABC):
         job_name: str | None = None,
     ) -> tuple[Any | None, int] | None:
         command = utils.create_command(
-            command, environment, workdir, stdin, stdout, stderr
+            self.__class__.__name__,
+            command,
+            environment,
+            workdir,
+            stdin,
+            stdout,
+            stderr,
         )
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -221,33 +221,6 @@ class SSHConfig:
 
 
 class SSHConnector(BaseConnector):
-    @staticmethod
-    def _get_command(
-        location: Location,
-        command: MutableSequence[str],
-        environment: MutableMapping[str, str] = None,
-        workdir: str | None = None,
-        stdin: int | str | None = None,
-        stdout: int | str = asyncio.subprocess.STDOUT,
-        stderr: int | str = asyncio.subprocess.STDOUT,
-        job_name: str | None = None,
-    ):
-        command = utils.create_command(
-            command=command,
-            environment=environment,
-            workdir=workdir,
-            stdin=stdin,
-            stdout=stdout,
-            stderr=stderr,
-        )
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.debug(
-                f"EXECUTING command {command} on {location}" f" for job {job_name}"
-                if job_name
-                else ""
-            )
-        return utils.encode_command(command)
-
     def __init__(
         self,
         deployment_name: str,
@@ -430,6 +403,34 @@ class SSHConnector(BaseConnector):
                                     for writer in writers
                                 )
                             )
+
+    def _get_command(
+        self,
+        location: Location,
+        command: MutableSequence[str],
+        environment: MutableMapping[str, str] = None,
+        workdir: str | None = None,
+        stdin: int | str | None = None,
+        stdout: int | str = asyncio.subprocess.STDOUT,
+        stderr: int | str = asyncio.subprocess.STDOUT,
+        job_name: str | None = None,
+    ):
+        command = utils.create_command(
+            class_name=self.__class__.__name__,
+            command=command,
+            environment=environment,
+            workdir=workdir,
+            stdin=stdin,
+            stdout=stdout,
+            stderr=stderr,
+        )
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                f"EXECUTING command {command} on {location}" f" for job {job_name}"
+                if job_name
+                else ""
+            )
+        return utils.encode_command(command)
 
     def _get_config(self, node: str | MutableMapping[str, Any]):
         if node is None:


### PR DESCRIPTION
This commit fixes three issues in the last StreamFlow version:

 - The `cwl-runner` path did not correctly load plugin extensions in the `SfValidator`. Now the `load_extensions()` method is correctly called before instantiating the `SfValidator`;
 - The deprecation warning message returned by the `QueueManagerConnector` suggested using a `connector` directive in the StreamFlow file. Now it correctly suggests the `wraps` directive;
 - Numeric streams were not correctly handled by several Connector objects. Now they are correctly treated as special cases.