### PR TITLE
Fix `template_map` error when service has no file

### DIFF
--- a/streamflow/deployment/template.py
+++ b/streamflow/deployment/template.py
@@ -26,7 +26,7 @@ class CommandTemplateMap:
         workdir: str = None,
         **kwargs,
     ) -> str:
-        return self.templates[template or "__DEFAULT__"].render(
+        return self.templates.get(template, self.templates["__DEFAULT__"]).render(
             streamflow_command=command,
             streamflow_environment=environment,
             streamflow_workdir=workdir,


### PR DESCRIPTION
The `CommandTemplateMap` class failed with a `KeyError` when a `service` did not contain a `file` option, due to a bad management of key values. This commit fixes this error.