### PR TITLE
Add configurable time option in HPC connectors

### DIFF
--- a/streamflow/deployment/connector/schemas/flux.json
+++ b/streamflow/deployment/connector/schemas/flux.json
@@ -131,6 +131,10 @@
           "type": "integer",
           "description": "Set the number of tasks per node to run"
         },
+        "timeLimit": {
+          "type": "string",
+          "description": "Time limit in minutes when no units provided, otherwise in Flux standard duration (e.g., 30s, 2d, 1.5h). If a `timeout` value is defined directly in the workflow specification, it will override this value"
+        },
         "unbuffered": {
           "type": "boolean",
           "description": "Disable buffering of standard input and output as much as practical"

--- a/streamflow/deployment/connector/schemas/slurm.json
+++ b/streamflow/deployment/connector/schemas/slurm.json
@@ -356,6 +356,10 @@
           "type": "integer",
           "description": "Restrict node selection to nodes with at least the specified number of threads per core. In task layout, use the specified maximum number of threads per core"
         },
+        "time": {
+          "type": "string",
+          "description": "Set a limit on the total run time of the job allocation. If a `timeout` value is defined directly in the workflow specification, it will override this value"
+        },
         "timeMin": {
           "type": "string",
           "description": "Set a minimum time limit on the job allocation. If specified, the job may have its time limit lowered to a value no lower than timeMin if doing so permits the job to begin execution earlier than otherwise possible"


### PR DESCRIPTION
This commit adds the possibility for users to specify a `timeout` value directly from the QueueManagerService options, i.e., in the `deployment` section of the `streamflow.yml` config file. If a value is inferred directly from a workflow step deifnition, the latter will prevail.