### PR TITLE
Fix Flux Docker version to 0.28.0

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -138,7 +138,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container: ["fluxrm/flux-sched:focal"]
+        container: ["fluxrm/flux-sched:focal-v0.28.0"]
     container:
       image: ${{ matrix.container }}
       options: "--platform=linux/amd64 --user root -it"

--- a/examples/flux/Dockerfile
+++ b/examples/flux/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluxrm/flux-sched:focal
+FROM fluxrm/flux-sched:focal-v0.28.0
 
 # ubuntu base with Flux
 # this allows for easy development of Flux connector


### PR DESCRIPTION
Sometimes the Flux CI example broke due to unstable container versions used to perform the test. This commit fixes the container version to the latest stable one (i.e., `v0.28.0`) to avoid such problems.