### PR TITLE
Added parameter to choose the deployments to use in pytests

### DIFF
--- a/tests/test_remotepath.py
+++ b/tests/test_remotepath.py
@@ -8,12 +8,12 @@ from streamflow.core.data import FileType
 from streamflow.core.deployment import Connector, Location
 from streamflow.data import remotepath
 from streamflow.deployment.utils import get_path_processor
-from tests.conftest import deployment_types, get_location
+from tests.conftest import get_location
 
 
-@pytest_asyncio.fixture(scope="module", params=deployment_types())
-async def location(context, request) -> Location:
-    return await get_location(context, request)
+@pytest_asyncio.fixture(scope="module")
+async def location(context, deployment_src) -> Location:
+    return await get_location(context, deployment_src)
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -12,12 +12,12 @@ from streamflow.core.deployment import Connector, Location
 from streamflow.data import remotepath
 from streamflow.deployment.connector import LocalConnector
 from streamflow.deployment.utils import get_path_processor
-from tests.conftest import deployment_types, get_location
+from tests.conftest import get_location
 
 
-@pytest_asyncio.fixture(scope="module", params=deployment_types())
-async def src_location(context, request) -> Location:
-    return await get_location(context, request)
+@pytest_asyncio.fixture(scope="module")
+async def src_location(context, deployment_src) -> Location:
+    return await get_location(context, deployment_src)
 
 
 @pytest.fixture(scope="module")
@@ -25,9 +25,9 @@ def src_connector(context, src_location) -> Connector:
     return context.deployment_manager.get_connector(src_location.deployment)
 
 
-@pytest_asyncio.fixture(scope="module", params=deployment_types())
-async def dst_location(context, request) -> Location:
-    return await get_location(context, request)
+@pytest_asyncio.fixture(scope="module")
+async def dst_location(context, deployment_dst) -> Location:
+    return await get_location(context, deployment_dst)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This PR adds a pytest parameter to indicate the deployments to use in the tests.
This parameter (named `--deploys`) is helpful for debugging, loading only the necessary deployments.

It is necessary to declare the deployments to be used separated by a comma.
e.g. `pytest --deploys local,kubernetes,ssh tests/test_transfer.py`

By default all deployments are used. So
`pytest --deploys local,docker,ssh,kubernetes,singularity tests/test_transfer.py`
and
`pytest tests/test_transfer.py`
have the same result.