### PR TITLE
Fixed minor issue with port-targets documentation

### DIFF
--- a/docs/source/advanced/port-targets.rst
+++ b/docs/source/advanced/port-targets.rst
@@ -20,7 +20,7 @@ Similarly to steps, ports are uniquely identified using a Posix-like path, where
          file: main.cwl
          settings: config.yml
        bindings:
-         - step: /compile/src
+         - port: /compile/src
            target:
              deployment: hpc-slurm
              workdir: /archive/home/myuser


### PR DESCRIPTION
The code snippet in the port-target documentation didn't use any port target. I replaced `step` with `port`.