### PR TITLE
Update Node.js version in CI pipeline

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -69,7 +69,7 @@ jobs:
             test-requirements.txt
       - uses: actions/setup-node@v4
         with:
-          node-version: "15"
+          node-version: "20"
       - name: "Install Docker (MacOS X)"
         uses: douglascamata/setup-docker-macos-action@v1-alpha.10
         if: ${{ startsWith(matrix.on, 'macos-') }}
@@ -208,7 +208,7 @@ jobs:
             tox.ini
       - uses: actions/setup-node@v4
         with:
-          node-version: "15"
+          node-version: "20"
       - name: "Install Docker (MacOs X)"
         uses: douglascamata/setup-docker-macos-action@v1-alpha.10
         if: ${{ startsWith(matrix.on, 'macos-') }}


### PR DESCRIPTION
This commit updates the Node.js version from 15 to 20 in the CI tests pipeline, as Node.js 15 is now deprecated and no longer maintained.