### PR TITLE
Fixed Config persistence

### DIFF
--- a/streamflow/config/config.py
+++ b/streamflow/config/config.py
@@ -26,7 +26,7 @@ class WorkflowConfig(Config):
         super().__init__(
             name=name, type=workflow_config["type"], config=workflow_config["config"]
         )
-        self.deplyoments = config.get("deployments", {})
+        self.deployments = config.get("deployments", {})
         self.policies = {
             k: Config(name=k, type=v["type"], config=v["config"])
             for k, v in config.get("scheduling", {}).get("policies", {}).items()
@@ -38,16 +38,16 @@ class WorkflowConfig(Config):
             k: Config(name=k, type=v["type"], config=v["config"])
             for k, v in config.get("bindingFilters", {}).items()
         }
-        if not self.deplyoments:
-            self.deplyoments = config.get("models", {})
-            if self.deplyoments:
+        if not self.deployments:
+            self.deployments = config.get("models", {})
+            if self.deployments:
                 if logger.isEnabledFor(logging.WARNING):
                     logger.warning(
                         "The `models` keyword is deprecated and will be removed in StreamFlow 0.3.0. "
                         "Use `deployments` instead."
                     )
         self.scheduling_groups: MutableMapping[str, MutableSequence[str]] = {}
-        for name, deployment in self.deplyoments.items():
+        for name, deployment in self.deployments.items():
             deployment["name"] = name
         self.filesystem = {"children": {}}
         for binding in workflow_config.get("bindings", []):
@@ -68,7 +68,7 @@ class WorkflowConfig(Config):
         for target in targets:
             policy = target.get(
                 "policy",
-                self.deplyoments[target.get("deployment", target.get("model", {}))].get(
+                self.deployments[target.get("deployment", target.get("model", {}))].get(
                     "policy", "__DEFAULT__"
                 ),
             )

--- a/streamflow/core/config.py
+++ b/streamflow/core/config.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any, MutableMapping, MutableSequence, TYPE_CHECKING, cast
+import json
+from typing import Any, MutableMapping, MutableSequence, TYPE_CHECKING, cast, Type
 
+from streamflow.core import utils
 from streamflow.core.persistence import PersistableEntity
 
 if TYPE_CHECKING:
@@ -24,13 +26,40 @@ class Config(PersistableEntity):
     async def load(
         cls,
         context: StreamFlowContext,
+        persistent_id: int,
+        loading_context: DatabaseLoadingContext,
+    ) -> Config:
+        row = await context.database.get_config(persistent_id)
+        type = cast(Type[Config], utils.get_class_from_name(row["type"]))
+        config = await type._load(context, row, loading_context)
+        config.persistent_id = persistent_id
+        loading_context.add_config(persistent_id, config)
+        return config
+
+    @classmethod
+    async def _load(
+        cls,
+        context: StreamFlowContext,
         row: MutableMapping[str, Any],
         loading_context: DatabaseLoadingContext,
     ) -> Config:
-        return cls(row["name"], row["type"], row["config"])
+        return cls(row["name"], row["attr_type"], json.loads(row["config"]))
 
-    async def save(self, context: StreamFlowContext):
-        return {"name": self.name, "type": self.type, "config": self.config}
+    async def _save_additional_params(
+        self, context: StreamFlowContext
+    ) -> MutableMapping[str, Any]:
+        return {}
+
+    async def save(self, context: StreamFlowContext) -> None:
+        async with self.persistence_lock:
+            if not self.persistent_id:
+                self.persistent_id = await context.database.add_config(
+                    name=self.name,
+                    attr_type=self.type,
+                    config=self.config,
+                    type=type(self),
+                    params=await self._save_additional_params(context),
+                )
 
 
 class BindingConfig:
@@ -63,7 +92,7 @@ class BindingConfig:
                 MutableSequence,
                 await asyncio.gather(
                     *(
-                        asyncio.create_task(Config.load(context, f, loading_context))
+                        asyncio.create_task(loading_context.load_config(context, f))
                         for f in row["filters"]
                     )
                 ),
@@ -74,9 +103,10 @@ class BindingConfig:
         await asyncio.gather(
             *(asyncio.create_task(t.save(context)) for t in self.targets)
         )
+        await asyncio.gather(
+            *(asyncio.create_task(f.save(context)) for f in self.filters)
+        )
         return {
             "targets": [t.persistent_id for t in self.targets],
-            "filters": await asyncio.gather(
-                *(asyncio.create_task(f.save(context)) for f in self.filters)
-            ),
+            "filters": [f.persistent_id for f in self.filters],
         }

--- a/streamflow/core/config.py
+++ b/streamflow/core/config.py
@@ -1,75 +1,33 @@
 from __future__ import annotations
 
 import asyncio
-import json
-from typing import Any, MutableMapping, MutableSequence, TYPE_CHECKING, cast, Type
-
-from streamflow.core import utils
-from streamflow.core.persistence import PersistableEntity
+from typing import Any, MutableMapping, MutableSequence, TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from streamflow.core.context import StreamFlowContext
-    from streamflow.core.deployment import Target
+    from streamflow.core.deployment import Target, FilterConfig
     from streamflow.core.persistence import DatabaseLoadingContext
 
 
-class Config(PersistableEntity):
+class Config:
     __slots__ = ("name", "type", "config")
 
     def __init__(self, name: str, type: str, config: MutableMapping[str, Any]) -> None:
-        super().__init__()
         self.name: str = name
         self.type: str = type
         self.config: MutableMapping[str, Any] = config or {}
-
-    @classmethod
-    async def load(
-        cls,
-        context: StreamFlowContext,
-        persistent_id: int,
-        loading_context: DatabaseLoadingContext,
-    ) -> Config:
-        row = await context.database.get_config(persistent_id)
-        type = cast(Type[Config], utils.get_class_from_name(row["type"]))
-        config = await type._load(context, row, loading_context)
-        config.persistent_id = persistent_id
-        loading_context.add_config(persistent_id, config)
-        return config
-
-    @classmethod
-    async def _load(
-        cls,
-        context: StreamFlowContext,
-        row: MutableMapping[str, Any],
-        loading_context: DatabaseLoadingContext,
-    ) -> Config:
-        return cls(row["name"], row["attr_type"], json.loads(row["config"]))
-
-    async def _save_additional_params(
-        self, context: StreamFlowContext
-    ) -> MutableMapping[str, Any]:
-        return {}
-
-    async def save(self, context: StreamFlowContext) -> None:
-        async with self.persistence_lock:
-            if not self.persistent_id:
-                self.persistent_id = await context.database.add_config(
-                    name=self.name,
-                    attr_type=self.type,
-                    config=self.config,
-                    type=type(self),
-                    params=await self._save_additional_params(context),
-                )
 
 
 class BindingConfig:
     __slots__ = ("targets", "filters")
 
     def __init__(
-        self, targets: MutableSequence[Target], filters: MutableSequence[Config] = None
+        self,
+        targets: MutableSequence[Target],
+        filters: MutableSequence[FilterConfig] = None,
     ):
         self.targets: MutableSequence[Target] = targets
-        self.filters: MutableSequence[Config] = filters or []
+        self.filters: MutableSequence[FilterConfig] = filters or []
 
     @classmethod
     async def load(
@@ -92,7 +50,7 @@ class BindingConfig:
                 MutableSequence,
                 await asyncio.gather(
                     *(
-                        asyncio.create_task(loading_context.load_config(context, f))
+                        asyncio.create_task(loading_context.load_filter(context, f))
                         for f in row["filters"]
                     )
                 ),
@@ -101,10 +59,8 @@ class BindingConfig:
 
     async def save(self, context: StreamFlowContext):
         await asyncio.gather(
-            *(asyncio.create_task(t.save(context)) for t in self.targets)
-        )
-        await asyncio.gather(
-            *(asyncio.create_task(f.save(context)) for f in self.filters)
+            *(asyncio.create_task(t.save(context)) for t in self.targets),
+            *(asyncio.create_task(f.save(context)) for f in self.filters),
         )
         return {
             "targets": [t.persistent_id for t in self.targets],

--- a/streamflow/core/persistence.py
+++ b/streamflow/core/persistence.py
@@ -8,14 +8,17 @@ from typing import Any, MutableMapping, MutableSequence, TYPE_CHECKING
 from streamflow.core.context import SchemaEntity, StreamFlowContext
 
 if TYPE_CHECKING:
-    from streamflow.core.config import Config
-    from streamflow.core.deployment import Target
+    from streamflow.core.deployment import DeploymentConfig, Target, FilterConfig
     from streamflow.core.workflow import Port, Step, Token, Workflow
 
 
 class DatabaseLoadingContext(ABC):
     @abstractmethod
-    def add_config(self, persistent_id: int, config: Config):
+    def add_deployment(self, persistent_id: int, deployment: DeploymentConfig):
+        ...
+
+    @abstractmethod
+    def add_filter(self, persistent_id: int, filter_config: FilterConfig):
         ...
 
     @abstractmethod
@@ -39,7 +42,11 @@ class DatabaseLoadingContext(ABC):
         ...
 
     @abstractmethod
-    async def load_config(self, context: StreamFlowContext, persistent_id: int):
+    async def load_deployment(self, context: StreamFlowContext, persistent_id: int):
+        ...
+
+    @abstractmethod
+    async def load_filter(self, context: StreamFlowContext, persistent_id: int):
         ...
 
     @abstractmethod
@@ -103,13 +110,23 @@ class Database(SchemaEntity):
         ...
 
     @abstractmethod
-    async def add_config(
+    async def add_deployment(
         self,
         name: str,
-        type: type[Config],
-        attr_type: str,
-        config: MutableMapping[str, Any],
-        params: MutableMapping[str, Any],
+        type: str,
+        config: str,
+        external: bool,
+        lazy: bool,
+        workdir: str | None,
+    ) -> int:
+        ...
+
+    @abstractmethod
+    async def add_filter(
+        self,
+        name: str,
+        type: str,
+        config: str,
     ) -> int:
         ...
 
@@ -189,7 +206,11 @@ class Database(SchemaEntity):
         ...
 
     @abstractmethod
-    async def get_config(self, config_id: int) -> MutableMapping[str, Any]:
+    async def get_deployment(self, deployment_id: int) -> MutableMapping[str, Any]:
+        ...
+
+    @abstractmethod
+    async def get_filter(self, filter_id: int) -> MutableMapping[str, Any]:
         ...
 
     @abstractmethod
@@ -265,8 +286,14 @@ class Database(SchemaEntity):
         ...
 
     @abstractmethod
-    async def update_config(
-        self, config_id: int, updates: MutableMapping[str, Any]
+    async def update_deployment(
+        self, deployment_id: int, updates: MutableMapping[str, Any]
+    ) -> int:
+        ...
+
+    @abstractmethod
+    async def update_filter(
+        self, filter_id: int, updates: MutableMapping[str, Any]
     ) -> int:
         ...
 

--- a/streamflow/core/persistence.py
+++ b/streamflow/core/persistence.py
@@ -8,13 +8,14 @@ from typing import Any, MutableMapping, MutableSequence, TYPE_CHECKING
 from streamflow.core.context import SchemaEntity, StreamFlowContext
 
 if TYPE_CHECKING:
-    from streamflow.core.deployment import DeploymentConfig, Target
+    from streamflow.core.config import Config
+    from streamflow.core.deployment import Target
     from streamflow.core.workflow import Port, Step, Token, Workflow
 
 
 class DatabaseLoadingContext(ABC):
     @abstractmethod
-    def add_deployment(self, persistent_id: int, deployment: DeploymentConfig):
+    def add_config(self, persistent_id: int, config: Config):
         ...
 
     @abstractmethod
@@ -38,7 +39,7 @@ class DatabaseLoadingContext(ABC):
         ...
 
     @abstractmethod
-    async def load_deployment(self, context: StreamFlowContext, persistent_id: int):
+    async def load_config(self, context: StreamFlowContext, persistent_id: int):
         ...
 
     @abstractmethod
@@ -102,14 +103,13 @@ class Database(SchemaEntity):
         ...
 
     @abstractmethod
-    async def add_deployment(
+    async def add_config(
         self,
         name: str,
-        type: str,
-        config: str,
-        external: bool,
-        lazy: bool,
-        workdir: str | None,
+        type: type[Config],
+        attr_type: str,
+        config: MutableMapping[str, Any],
+        params: MutableMapping[str, Any],
     ) -> int:
         ...
 
@@ -189,7 +189,7 @@ class Database(SchemaEntity):
         ...
 
     @abstractmethod
-    async def get_deployment(self, deplyoment_id: int) -> MutableMapping[str, Any]:
+    async def get_config(self, config_id: int) -> MutableMapping[str, Any]:
         ...
 
     @abstractmethod
@@ -265,8 +265,8 @@ class Database(SchemaEntity):
         ...
 
     @abstractmethod
-    async def update_deployment(
-        self, deployment_id: int, updates: MutableMapping[str, Any]
+    async def update_config(
+        self, config_id: int, updates: MutableMapping[str, Any]
     ) -> int:
         ...
 

--- a/streamflow/deployment/utils.py
+++ b/streamflow/deployment/utils.py
@@ -8,7 +8,12 @@ from types import ModuleType
 from typing import TYPE_CHECKING
 
 from streamflow.core.config import BindingConfig
-from streamflow.core.deployment import DeploymentConfig, LocalTarget, Target
+from streamflow.core.deployment import (
+    DeploymentConfig,
+    LocalTarget,
+    Target,
+    FilterConfig,
+)
 from streamflow.deployment.connector import LocalConnector
 from streamflow.log_handler import logger
 
@@ -27,9 +32,9 @@ def get_binding_config(
         for target in config["targets"]:
             workdir = target.get("workdir") if target is not None else None
             if "deployment" in target:
-                target_deployment = workflow_config.deplyoments[target["deployment"]]
+                target_deployment = workflow_config.deployments[target["deployment"]]
             else:
-                target_deployment = workflow_config.deplyoments[target["model"]]
+                target_deployment = workflow_config.deployments[target["model"]]
                 if logger.isEnabledFor(logging.WARNING):
                     logger.warning(
                         "The `model` keyword is deprecated and will be removed in StreamFlow 0.3.0. "
@@ -63,7 +68,14 @@ def get_binding_config(
                     workdir=workdir,
                 )
             )
-        return BindingConfig(targets=targets, filters=config.get("filters"))
+        return BindingConfig(
+            targets=targets,
+            filters=[
+                # tmp solution
+                FilterConfig(name=c.name, type=c.type, config=c.config)
+                for c in config.get("filters")
+            ],
+        )
     else:
         return BindingConfig(targets=[LocalTarget()])
 

--- a/streamflow/deployment/utils.py
+++ b/streamflow/deployment/utils.py
@@ -71,7 +71,6 @@ def get_binding_config(
         return BindingConfig(
             targets=targets,
             filters=[
-                # tmp solution
                 FilterConfig(name=c.name, type=c.type, config=c.config)
                 for c in config.get("filters")
             ],

--- a/streamflow/persistence/base.py
+++ b/streamflow/persistence/base.py
@@ -10,7 +10,7 @@ from streamflow.core.persistence import Database
 class CachedDatabase(Database, ABC):
     def __init__(self, context: StreamFlowContext):
         super().__init__(context)
-        self.deployment_cache: Cache = LRUCache(maxsize=sys.maxsize)
+        self.config_cache: Cache = LRUCache(maxsize=sys.maxsize)
         self.port_cache: Cache = LRUCache(maxsize=sys.maxsize)
         self.step_cache: Cache = LRUCache(maxsize=sys.maxsize)
         self.target_cache: Cache = LRUCache(maxsize=sys.maxsize)

--- a/streamflow/persistence/base.py
+++ b/streamflow/persistence/base.py
@@ -10,9 +10,10 @@ from streamflow.core.persistence import Database
 class CachedDatabase(Database, ABC):
     def __init__(self, context: StreamFlowContext):
         super().__init__(context)
-        self.config_cache: Cache = LRUCache(maxsize=sys.maxsize)
+        self.deployment_cache: Cache = LRUCache(maxsize=sys.maxsize)
         self.port_cache: Cache = LRUCache(maxsize=sys.maxsize)
         self.step_cache: Cache = LRUCache(maxsize=sys.maxsize)
         self.target_cache: Cache = LRUCache(maxsize=sys.maxsize)
+        self.filter_cache: Cache = LRUCache(maxsize=sys.maxsize)
         self.token_cache: Cache = LRUCache(maxsize=sys.maxsize)
         self.workflow_cache: Cache = LRUCache(maxsize=sys.maxsize)

--- a/streamflow/persistence/loading_context.py
+++ b/streamflow/persistence/loading_context.py
@@ -1,7 +1,8 @@
 from typing import MutableMapping
 
+from streamflow.core.config import Config
 from streamflow.core.context import StreamFlowContext
-from streamflow.core.deployment import DeploymentConfig, Target
+from streamflow.core.deployment import Target
 from streamflow.core.persistence import DatabaseLoadingContext
 from streamflow.core.workflow import Port, Step, Token, Workflow
 
@@ -9,15 +10,15 @@ from streamflow.core.workflow import Port, Step, Token, Workflow
 class DefaultDatabaseLoadingContext(DatabaseLoadingContext):
     def __init__(self):
         super().__init__()
-        self._deployment_configs: MutableMapping[int, DeploymentConfig] = {}
+        self._configs: MutableMapping[int, Config] = {}
         self._ports: MutableMapping[int, Port] = {}
         self._steps: MutableMapping[int, Step] = {}
         self._targets: MutableMapping[int, Target] = {}
         self._tokens: MutableMapping[int, Token] = {}
         self._workflows: MutableMapping[int, Workflow] = {}
 
-    def add_deployment(self, persistent_id: int, deployment: DeploymentConfig):
-        self._deployment_configs[persistent_id] = deployment
+    def add_config(self, persistent_id: int, config: Config):
+        self._configs[persistent_id] = config
 
     def add_port(self, persistent_id: int, port: Port):
         self._ports[persistent_id] = port
@@ -34,10 +35,10 @@ class DefaultDatabaseLoadingContext(DatabaseLoadingContext):
     def add_workflow(self, persistent_id: int, workflow: Workflow):
         self._workflows[persistent_id] = workflow
 
-    async def load_deployment(self, context: StreamFlowContext, persistent_id: int):
-        return self._deployment_configs.get(
-            persistent_id
-        ) or await DeploymentConfig.load(context, persistent_id, self)
+    async def load_config(self, context: StreamFlowContext, persistent_id: int):
+        return self._configs.get(persistent_id) or await Config.load(
+            context, persistent_id, self
+        )
 
     async def load_port(self, context: StreamFlowContext, persistent_id: int):
         return self._ports.get(persistent_id) or await Port.load(

--- a/streamflow/persistence/loading_context.py
+++ b/streamflow/persistence/loading_context.py
@@ -1,8 +1,7 @@
 from typing import MutableMapping
 
-from streamflow.core.config import Config
 from streamflow.core.context import StreamFlowContext
-from streamflow.core.deployment import Target
+from streamflow.core.deployment import DeploymentConfig, Target, FilterConfig
 from streamflow.core.persistence import DatabaseLoadingContext
 from streamflow.core.workflow import Port, Step, Token, Workflow
 
@@ -10,15 +9,19 @@ from streamflow.core.workflow import Port, Step, Token, Workflow
 class DefaultDatabaseLoadingContext(DatabaseLoadingContext):
     def __init__(self):
         super().__init__()
-        self._configs: MutableMapping[int, Config] = {}
+        self._deployment_configs: MutableMapping[int, DeploymentConfig] = {}
         self._ports: MutableMapping[int, Port] = {}
         self._steps: MutableMapping[int, Step] = {}
         self._targets: MutableMapping[int, Target] = {}
+        self._filter_configs: MutableMapping[int, FilterConfig] = {}
         self._tokens: MutableMapping[int, Token] = {}
         self._workflows: MutableMapping[int, Workflow] = {}
 
-    def add_config(self, persistent_id: int, config: Config):
-        self._configs[persistent_id] = config
+    def add_deployment(self, persistent_id: int, deployment: DeploymentConfig):
+        self._deployment_configs[persistent_id] = deployment
+
+    def add_filter(self, persistent_id: int, filter_config: FilterConfig):
+        self._filter_configs[persistent_id] = filter_config
 
     def add_port(self, persistent_id: int, port: Port):
         self._ports[persistent_id] = port
@@ -35,8 +38,13 @@ class DefaultDatabaseLoadingContext(DatabaseLoadingContext):
     def add_workflow(self, persistent_id: int, workflow: Workflow):
         self._workflows[persistent_id] = workflow
 
-    async def load_config(self, context: StreamFlowContext, persistent_id: int):
-        return self._configs.get(persistent_id) or await Config.load(
+    async def load_deployment(self, context: StreamFlowContext, persistent_id: int):
+        return self._deployment_configs.get(
+            persistent_id
+        ) or await DeploymentConfig.load(context, persistent_id, self)
+
+    async def load_filter(self, context: StreamFlowContext, persistent_id: int):
+        return self._filter_configs.get(persistent_id) or await FilterConfig.load(
             context, persistent_id, self
         )
 

--- a/streamflow/persistence/schemas/sqlite.sql
+++ b/streamflow/persistence/schemas/sqlite.sql
@@ -78,14 +78,15 @@ CREATE TABLE IF NOT EXISTS provenance
 );
 
 
-CREATE TABLE IF NOT EXISTS config
+CREATE TABLE IF NOT EXISTS deployment
 (
-    id              INTEGER PRIMARY KEY,
-    name            TEXT,
-    attr_type       TEXT,
-    config          TEXT,
-    type            TEXT,
-    params          TEXT
+    id       INTEGER PRIMARY KEY,
+    name     TEXT,
+    type     TEXT,
+    config   TEXT,
+    external INTEGER,
+    lazy     INTEGER,
+    workdir  TEXT
 );
 
 
@@ -99,4 +100,13 @@ CREATE TABLE IF NOT EXISTS target
     workdir    TEXT,
     params     TEXT,
     FOREIGN KEY (deployment) REFERENCES deployment (id)
+);
+
+
+CREATE TABLE IF NOT EXISTS filter
+(
+    id              INTEGER PRIMARY KEY,
+    name            TEXT,
+    type            TEXT,
+    config          TEXT
 );

--- a/streamflow/persistence/schemas/sqlite.sql
+++ b/streamflow/persistence/schemas/sqlite.sql
@@ -78,15 +78,14 @@ CREATE TABLE IF NOT EXISTS provenance
 );
 
 
-CREATE TABLE IF NOT EXISTS deployment
+CREATE TABLE IF NOT EXISTS config
 (
-    id       INTEGER PRIMARY KEY,
-    name     TEXT,
-    type     TEXT,
-    config   TEXT,
-    external INTEGER,
-    lazy     INTEGER,
-    workdir  TEXT
+    id              INTEGER PRIMARY KEY,
+    name            TEXT,
+    attr_type       TEXT,
+    config          TEXT,
+    type            TEXT,
+    params          TEXT
 );
 
 

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -454,7 +454,7 @@ class DeployStep(BaseStep):
         return cls(
             name=row["name"],
             workflow=await loading_context.load_workflow(context, row["workflow"]),
-            deployment_config=await loading_context.load_deployment(
+            deployment_config=await loading_context.load_config(
                 context, params["deployment_config"]
             ),
             connector_port=cast(

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -454,7 +454,7 @@ class DeployStep(BaseStep):
         return cls(
             name=row["name"],
             workflow=await loading_context.load_workflow(context, row["workflow"]),
-            deployment_config=await loading_context.load_config(
+            deployment_config=await loading_context.load_deployment(
                 context, params["deployment_config"]
             ),
             connector_port=cast(

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -32,6 +32,7 @@ from streamflow.workflow.token import (
 )
 from tests.conftest import save_load_and_test
 from tests.utils.deployment import get_docker_deployment_config
+from tests.utils.workflow import create_workflow
 
 
 @pytest.mark.asyncio
@@ -135,21 +136,33 @@ async def test_deploy_step(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_schedule_step(context: StreamFlowContext):
     """Test saving and loading ScheduleStep from database"""
-    workflow = Workflow(
-        context=context, type="cwl", name=utils.random_name(), config={}
+    workflow, _ = await create_workflow(context, 0)
+    binding_config = BindingConfig(
+        targets=[
+            LocalTarget(workdir=utils.random_name()),
+            Target(
+                deployment=get_docker_deployment_config(),
+                workdir=utils.random_name(),
+            ),
+        ],
+        filters=[
+            Config(config={"hello": "world"}, name=utils.random_name(), type="shuffle")
+        ],
     )
-    port = workflow.create_port()
+    connector_ports = {
+        target.deployment.name: workflow.create_port(ConnectorPort)
+        for target in binding_config.targets
+    }
     await workflow.save(context)
 
-    binding_config = BindingConfig(targets=[LocalTarget(workdir=utils.random_name())])
     schedule_step = workflow.create_step(
         cls=ScheduleStep,
-        name=posixpath.join(utils.random_name() + "-injector", "__schedule__"),
+        name=posixpath.join(utils.random_name(), "__schedule__"),
         job_prefix="something",
-        connector_ports={binding_config.targets[0].deployment.name: port},
-        input_directory=binding_config.targets[0].workdir,
-        output_directory=binding_config.targets[0].workdir,
-        tmp_directory=binding_config.targets[0].workdir,
+        connector_ports=connector_ports,
+        input_directory=posixpath.join(*(utils.random_name() for _ in range(2))),
+        output_directory=posixpath.join(*(utils.random_name() for _ in range(2))),
+        tmp_directory=posixpath.join(*(utils.random_name() for _ in range(2))),
         binding_config=binding_config,
     )
     await save_load_and_test(schedule_step, context)

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -145,11 +145,7 @@ async def test_schedule_step(context: StreamFlowContext):
                 workdir=utils.random_name(),
             ),
         ],
-        filters=[
-            FilterConfig(
-                config={"hello": "world"}, name=utils.random_name(), type="shuffle"
-            )
-        ],
+        filters=[FilterConfig(config={}, name=utils.random_name(), type="shuffle")],
     )
     connector_ports = {
         target.deployment.name: workflow.create_port(ConnectorPort)
@@ -337,9 +333,7 @@ async def test_iteration_termination_token(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_filter_config(context: StreamFlowContext):
     """Test saving and loading filter configuration from database"""
-    config = FilterConfig(
-        config={"hello": "world"}, name=utils.random_name(), type="shuffle"
-    )
+    config = FilterConfig(config={}, name=utils.random_name(), type="shuffle")
     await save_load_and_test(config, context)
 
 

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -3,7 +3,7 @@ import posixpath
 import pytest
 
 from streamflow.core import utils
-from streamflow.core.config import BindingConfig
+from streamflow.core.config import BindingConfig, Config
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.deployment import LocalTarget, Target
 from streamflow.core.workflow import Job, Token, Workflow
@@ -317,6 +317,13 @@ async def test_iteration_termination_token(context: StreamFlowContext):
     """Test saving and loading IterationTerminationToken from database"""
     token = IterationTerminationToken("1")
     await save_load_and_test(token, context)
+
+
+@pytest.mark.asyncio
+async def test_config(context: StreamFlowContext):
+    """Test saving and loading config configuration from database"""
+    config = Config(config={"hello": "world"}, name=utils.random_name(), type="shuffle")
+    await save_load_and_test(config, context)
 
 
 @pytest.mark.asyncio

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -3,9 +3,9 @@ import posixpath
 import pytest
 
 from streamflow.core import utils
-from streamflow.core.config import BindingConfig, Config
+from streamflow.core.config import BindingConfig
 from streamflow.core.context import StreamFlowContext
-from streamflow.core.deployment import LocalTarget, Target
+from streamflow.core.deployment import LocalTarget, Target, FilterConfig
 from streamflow.core.workflow import Job, Token, Workflow
 from streamflow.workflow.combinator import (
     CartesianProductCombinator,
@@ -146,7 +146,9 @@ async def test_schedule_step(context: StreamFlowContext):
             ),
         ],
         filters=[
-            Config(config={"hello": "world"}, name=utils.random_name(), type="shuffle")
+            FilterConfig(
+                config={"hello": "world"}, name=utils.random_name(), type="shuffle"
+            )
         ],
     )
     connector_ports = {
@@ -333,9 +335,11 @@ async def test_iteration_termination_token(context: StreamFlowContext):
 
 
 @pytest.mark.asyncio
-async def test_config(context: StreamFlowContext):
-    """Test saving and loading config configuration from database"""
-    config = Config(config={"hello": "world"}, name=utils.random_name(), type="shuffle")
+async def test_filter_config(context: StreamFlowContext):
+    """Test saving and loading filter configuration from database"""
+    config = FilterConfig(
+        config={"hello": "world"}, name=utils.random_name(), type="shuffle"
+    )
     await save_load_and_test(config, context)
 
 


### PR DESCRIPTION
This commit fixes the `ScheduleStep` persistence, particularly the `BindingFilter` object.
The `filters` attribute in `BindingFilter` was not being saved correctly in the database.
A new class extends the `Config`, called `FilterConfig`, and a new table was added to the database. 

The extention of `PersistableEntity` was moved from `Config` to its superclasses only where needed, i.e. `DeploymentConfig` and `FilterConfig`.