### PR TITLE
Removed deprecated `pkg_resources` API

### DIFF
--- a/docs/source/ext/plugins.rst
+++ b/docs/source/ext/plugins.rst
@@ -39,7 +39,7 @@ The ``cls`` attribute points to the class that implements the extension point, w
 
 The ``register`` method of the ``StreamFlowPlugin`` implementation must contain all the required calls to the ``register_extension_point`` methods in order to make the extension points available to the StreamFlow control plane. Note that a single ``StreamFlowPlugin`` can register multiple extension points, and even multiple implementations for the same extension point.
 
-Each extension point class extends the ``SchemaEntity`` abstract class, whose method ``get_schema`` returns the path to the class configuration in `JSON Schema 2019-09 <https://json-schema.org/draft/2019-09/release-notes.html>`_ format. The root entity of this file must be an ``object`` defining a set of properties, which will be exposed to the user in the ``config`` section of the ``streamflow.yml`` file, type-checked by StreamFlow at the beginning of each workflow run, and passed to the class constructor at every instantiation.
+Each extension point class extends the ``SchemaEntity`` abstract class, whose method ``get_schema`` returns the class configuration in `JSON Schema 2019-09 <https://json-schema.org/draft/2019-09/release-notes.html>`_ format. The root entity of this file must be an ``object`` defining a set of properties, which will be exposed to the user in the ``config`` section of the ``streamflow.yml`` file, type-checked by StreamFlow at the beginning of each workflow run, and passed to the class constructor at every instantiation.
 
 The base class for each extension point defined by StreamFlow and the respective registration method exposed by the ``StreamFlowPlugin`` class are reported in the table below:
 
@@ -58,7 +58,7 @@ Base Class                                                                      
 :ref:`streamflow.core.scheduling.Scheduler <Scheduler>`                                           ``register_scheduler``
 =============================================================================================     ===================================
 
-In addition, a ``register_schema`` method allows to register additional JSON Schema files, which are not directly referenced by any ``SchemaEntity`` class through the ``get_schema`` method. This feature is useful to, for example, define some base abstract JSON Schema that concrete entities can extend.
+In addition, a ``register_schema`` method allows to register additional JSON Schemas, which are not directly referenced by any ``SchemaEntity`` class through the ``get_schema`` method. This feature is useful to, for example, define some base abstract JSON Schema that concrete entities can extend.
 
 Note that there is no official way to make JSON Schema files inherit properties from each other, as vanilla JSON Schema format does not support inheritance. However, it is possible to extend base schemas using the combination of `allOf <https://json-schema.org/understanding-json-schema/reference/combining.html#allof>`_ and `unevaluatedProperties <https://json-schema.org/understanding-json-schema/reference/object.html#unevaluated-properties>`_ directives of JSON Schema 2019-09, as follows:
 
@@ -107,8 +107,11 @@ As an example, suppose that a class ``PostgreSQLDatabase`` implements a `Postgre
     class PostgreSQLDatabase(Database):
         @classmethod
         def get_schema(cls) -> str:
-            return pkg_resources.resource_filename(
-                __name__, os.path.join("schemas", "postgresql.json")
+            return (
+                files(__package__)
+                .joinpath("schemas")
+                .joinpath("postgresql.json")
+                .read_text("utf-8")
             )
         ...
 
@@ -116,7 +119,7 @@ As an example, suppose that a class ``PostgreSQLDatabase`` implements a `Postgre
         def register(self) -> None:
             self.register_database("unito.postgresql", PostgresqlDatabase)
 
-Each extension point class must implement a ``get_schema`` method, pointing to a `JSON Schema <https://json-schema.org/>`_ file, which contains all the configurable parameters that can be specified by the user in the ``streamflow.yml`` file. Such parameters will be propagated to the class constructor at each invocation. For example, the ``PostgreSQLDatabase`` class specified above points to a ``schemas/postgresql.json`` schema file in the same Python module.
+Each extension point class must implement a ``get_schema`` method, which returns a `JSON Schema <https://json-schema.org/>`_ with all the configurable parameters that can be specified by the user in the ``streamflow.yml`` file. Such parameters will be propagated to the class constructor at each invocation. For example, the ``PostgreSQLDatabase`` class specified above points to a ``schemas/postgresql.json`` schema file in the same Python module.
 
 A schema file should follow the `2019-09 <https://json-schema.org/draft/2019-09/release-notes.html>`_ version of JSON Schema. StreamFlow uses schema files to validate the ``streamflow.yml`` file at runtime before executing a workflow instance. Plus, it relies on schema ``properties`` to print documentation when a user invokes the ``streamflow ext show`` CLI subcommand. An example of schema file for the ``PostreSQLDatabase`` class is the following:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ cachetools==5.3.2
 cwltool==3.1.20231114134824
 cwl-utils==0.31
 importlib_metadata==6.8.0
+importlib_resources==6.1.1
 Jinja2==3.1.2
 jsonschema==4.20.0
 kubernetes_asyncio==28.2.1

--- a/streamflow/cwl/antlr/ECMAScriptLexer.py
+++ b/streamflow/cwl/antlr/ECMAScriptLexer.py
@@ -1,7 +1,8 @@
 # Generated from ECMAScript.g4 by ANTLR 4.13.0
-from antlr4 import *
-from io import StringIO
 import sys
+
+from antlr4 import *
+
 if sys.version_info[1] > 5:
     from typing import TextIO
 else:

--- a/streamflow/cwl/antlr/ECMAScriptParser.py
+++ b/streamflow/cwl/antlr/ECMAScriptParser.py
@@ -1,8 +1,9 @@
 # Generated from ECMAScript.g4 by ANTLR 4.13.0
 # encoding: utf-8
-from antlr4 import *
-from io import StringIO
 import sys
+
+from antlr4 import *
+
 if sys.version_info[1] > 5:
 	from typing import TextIO
 else:

--- a/streamflow/cwl/requirement/docker/docker.py
+++ b/streamflow/cwl/requirement/docker/docker.py
@@ -4,7 +4,7 @@ import os
 import posixpath
 from typing import MutableSequence
 
-import pkg_resources
+from importlib_resources import files
 
 from streamflow.core import utils
 from streamflow.core.deployment import DeploymentConfig, Target
@@ -207,8 +207,11 @@ class DockerCWLDockerTranslator(CWLDockerTranslator):
 
     @classmethod
     def get_schema(cls) -> str:
-        return pkg_resources.resource_filename(
-            __name__, os.path.join("schemas", "docker.json")
+        return (
+            files(__package__)
+            .joinpath("schemas")
+            .joinpath("docker.json")
+            .read_text("utf-8")
         )
 
     def get_target(

--- a/streamflow/cwl/requirement/docker/singularity.py
+++ b/streamflow/cwl/requirement/docker/singularity.py
@@ -4,7 +4,7 @@ import os
 import posixpath
 from typing import MutableSequence
 
-import pkg_resources
+from importlib_resources import files
 
 from streamflow.core import utils
 from streamflow.core.deployment import DeploymentConfig, Target
@@ -143,8 +143,11 @@ class SingularityCWLDockerTranslator(CWLDockerTranslator):
 
     @classmethod
     def get_schema(cls) -> str:
-        return pkg_resources.resource_filename(
-            __name__, os.path.join("schemas", "singularity.json")
+        return (
+            files(__package__)
+            .joinpath("schemas")
+            .joinpath("singularity.json")
+            .read_text("utf-8")
         )
 
     def get_target(

--- a/streamflow/data/manager.py
+++ b/streamflow/data/manager.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import asyncio
-import os
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
-import pkg_resources
+from importlib_resources import files
 
 from streamflow.core.data import DataLocation, DataManager, DataType
 from streamflow.core.deployment import Connector, Location
@@ -77,8 +76,11 @@ class DefaultDataManager(DataManager):
 
     @classmethod
     def get_schema(cls) -> str:
-        return pkg_resources.resource_filename(
-            __name__, os.path.join("schemas", "data_manager.json")
+        return (
+            files(__package__)
+            .joinpath("schemas")
+            .joinpath("data_manager.json")
+            .read_text("utf-8")
         )
 
     def get_source_location(

--- a/streamflow/deployment/connector/container.py
+++ b/streamflow/deployment/connector/container.py
@@ -10,8 +10,8 @@ from abc import ABC, abstractmethod
 from shutil import which
 from typing import Any, MutableMapping, MutableSequence
 
-import pkg_resources
 from cachetools import Cache, TTLCache
+from importlib_resources import files
 
 from streamflow.core import utils
 from streamflow.core.asyncache import cachedmethod
@@ -684,8 +684,11 @@ class DockerConnector(DockerBaseConnector):
 
     @classmethod
     def get_schema(cls) -> str:
-        return pkg_resources.resource_filename(
-            __name__, os.path.join("schemas", "docker.json")
+        return (
+            files(__package__)
+            .joinpath("schemas")
+            .joinpath("docker.json")
+            .read_text("utf-8")
         )
 
     async def undeploy(self, external: bool) -> None:
@@ -867,8 +870,11 @@ class DockerComposeConnector(DockerBaseConnector):
 
     @classmethod
     def get_schema(cls) -> str:
-        return pkg_resources.resource_filename(
-            __name__, os.path.join("schemas", "docker-compose.json")
+        return (
+            files(__package__)
+            .joinpath("schemas")
+            .joinpath("docker-compose.json")
+            .read_text("utf-8")
         )
 
     async def undeploy(self, external: bool) -> None:
@@ -1186,8 +1192,11 @@ class SingularityConnector(ContainerConnector):
 
     @classmethod
     def get_schema(cls) -> str:
-        return pkg_resources.resource_filename(
-            __name__, os.path.join("schemas", "singularity.json")
+        return (
+            files(__package__)
+            .joinpath("schemas")
+            .joinpath("singularity.json")
+            .read_text("utf-8")
         )
 
     async def undeploy(self, external: bool) -> None:

--- a/streamflow/deployment/connector/kubernetes.py
+++ b/streamflow/deployment/connector/kubernetes.py
@@ -22,9 +22,9 @@ from typing import (
     cast,
 )
 
-import pkg_resources
 import yaml
 from cachetools import Cache, TTLCache
+from importlib_resources import files
 from kubernetes_asyncio import client
 from kubernetes_asyncio.client import ApiClient, Configuration, V1Container, V1PodList
 from kubernetes_asyncio.config import (
@@ -852,8 +852,11 @@ class KubernetesConnector(BaseKubernetesConnector):
 
     @classmethod
     def get_schema(cls) -> str:
-        return pkg_resources.resource_filename(
-            __name__, os.path.join("schemas", "kubernetes.json")
+        return (
+            files(__package__)
+            .joinpath("schemas")
+            .joinpath("kubernetes.json")
+            .read_text("utf-8")
         )
 
     async def undeploy(self, external: bool) -> None:
@@ -1056,8 +1059,11 @@ class Helm3Connector(BaseKubernetesConnector):
 
     @classmethod
     def get_schema(cls) -> str:
-        return pkg_resources.resource_filename(
-            __name__, os.path.join("schemas", "helm3.json")
+        return (
+            files(__package__)
+            .joinpath("schemas")
+            .joinpath("helm3.json")
+            .read_text("utf-8")
         )
 
     async def undeploy(self, external: bool) -> None:

--- a/streamflow/deployment/connector/local.py
+++ b/streamflow/deployment/connector/local.py
@@ -7,8 +7,8 @@ import tempfile
 from pathlib import Path
 from typing import MutableMapping, MutableSequence
 
-import pkg_resources
 import psutil
+from importlib_resources import files
 
 from streamflow.core.deployment import Connector, LOCAL_LOCATION, Location
 from streamflow.core.scheduling import AvailableLocation, Hardware
@@ -109,8 +109,11 @@ class LocalConnector(BaseConnector):
 
     @classmethod
     def get_schema(cls) -> str:
-        return pkg_resources.resource_filename(
-            __name__, os.path.join("schemas", "local.json")
+        return (
+            files(__package__)
+            .joinpath("schemas")
+            .joinpath("local.json")
+            .read_text("utf-8")
         )
 
     async def undeploy(self, external: bool) -> None:

--- a/streamflow/deployment/connector/occam.py
+++ b/streamflow/deployment/connector/occam.py
@@ -8,7 +8,7 @@ import re
 from typing import Any, MutableMapping, MutableSequence
 
 import asyncssh
-import pkg_resources
+from importlib_resources import files
 from ruamel.yaml import YAML
 
 from streamflow.core import utils
@@ -394,8 +394,11 @@ class OccamConnector(SSHConnector):
 
     @classmethod
     def get_schema(cls) -> str:
-        return pkg_resources.resource_filename(
-            __name__, os.path.join("schemas", "occam.json")
+        return (
+            files(__package__)
+            .joinpath("schemas")
+            .joinpath("occam.json")
+            .read_text("utf-8")
         )
 
     async def undeploy(self, external: bool) -> None:

--- a/streamflow/deployment/connector/queue_manager.py
+++ b/streamflow/deployment/connector/queue_manager.py
@@ -11,7 +11,7 @@ from functools import partial
 from typing import Any, MutableMapping, MutableSequence, cast
 
 import cachetools
-import pkg_resources
+from importlib_resources import files
 
 from streamflow.core import utils
 from streamflow.core.asyncache import cachedmethod
@@ -566,8 +566,11 @@ class QueueManagerConnector(ConnectorWrapper, ABC):
 class SlurmConnector(QueueManagerConnector):
     @classmethod
     def get_schema(cls) -> str:
-        return pkg_resources.resource_filename(
-            __name__, os.path.join("schemas", "slurm.json")
+        return (
+            files(__package__)
+            .joinpath("schemas")
+            .joinpath("slurm.json")
+            .read_text("utf-8")
         )
 
     async def _get_output(self, job_id: str, location: Location) -> str:
@@ -802,8 +805,11 @@ class SlurmConnector(QueueManagerConnector):
 class PBSConnector(QueueManagerConnector):
     @classmethod
     def get_schema(cls) -> str:
-        return pkg_resources.resource_filename(
-            __name__, os.path.join("schemas", "pbs.json")
+        return (
+            files(__package__)
+            .joinpath("schemas")
+            .joinpath("pbs.json")
+            .read_text("utf-8")
         )
 
     async def _get_output(self, job_id: str, location: Location) -> str:
@@ -958,8 +964,11 @@ class PBSConnector(QueueManagerConnector):
 class FluxConnector(QueueManagerConnector):
     @classmethod
     def get_schema(cls) -> str:
-        return pkg_resources.resource_filename(
-            __name__, os.path.join("schemas", "flux.json")
+        return (
+            files(__package__)
+            .joinpath("schemas")
+            .joinpath("flux.json")
+            .read_text("utf-8")
         )
 
     async def _get_output(self, job_id: str, location: Location) -> str:

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -10,9 +10,9 @@ from pathlib import PurePosixPath
 from typing import Any, MutableMapping, MutableSequence
 
 import asyncssh
-import pkg_resources
 from asyncssh import ChannelOpenError
 from cachetools import Cache, LRUCache
+from importlib_resources import files
 
 from streamflow.core import utils
 from streamflow.core.asyncache import cachedmethod
@@ -686,8 +686,11 @@ class SSHConnector(BaseConnector):
 
     @classmethod
     def get_schema(cls) -> str:
-        return pkg_resources.resource_filename(
-            __name__, os.path.join("schemas", "ssh.json")
+        return (
+            files(__package__)
+            .joinpath("schemas")
+            .joinpath("ssh.json")
+            .read_text("utf-8")
         )
 
     async def run(

--- a/streamflow/deployment/filter/shuffle.py
+++ b/streamflow/deployment/filter/shuffle.py
@@ -1,8 +1,7 @@
-import os
 import random
 from typing import MutableSequence
 
-import pkg_resources
+from importlib_resources import files
 
 from streamflow.core.deployment import BindingFilter, Target
 from streamflow.core.workflow import Job
@@ -17,6 +16,9 @@ class ShuffleBindingFilter(BindingFilter):
 
     @classmethod
     def get_schema(cls) -> str:
-        return pkg_resources.resource_filename(
-            __name__, os.path.join("schemas", "shuffle.json")
+        return (
+            files(__package__)
+            .joinpath("schemas")
+            .joinpath("shuffle.json")
+            .read_text("utf-8")
         )

--- a/streamflow/deployment/manager.py
+++ b/streamflow/deployment/manager.py
@@ -5,7 +5,7 @@ import logging
 import os
 from typing import TYPE_CHECKING
 
-import pkg_resources
+from importlib_resources import files
 
 from streamflow.core.deployment import (
     Connector,
@@ -166,8 +166,11 @@ class DefaultDeploymentManager(DeploymentManager):
 
     @classmethod
     def get_schema(cls) -> str:
-        return pkg_resources.resource_filename(
-            __name__, os.path.join("schemas", "deployment_manager.json")
+        return (
+            files(__package__)
+            .joinpath("schemas")
+            .joinpath("deployment_manager.json")
+            .read_text("utf-8")
         )
 
     async def undeploy(self, deployment_name: str) -> None:

--- a/streamflow/ext/utils.py
+++ b/streamflow/ext/utils.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import json
 import logging
 import sys
+from importlib_metadata import entry_points
 from pathlib import PurePosixPath
 from typing import Any, MutableMapping, MutableSequence
 
-from importlib_metadata import entry_points
 from referencing._core import Resolver, Resource
 
 from streamflow.config.schema import SfSchema
@@ -308,9 +308,8 @@ def show_extension(name: str, type_: str):
         class_name = get_class_fullname(class_)
         entity_schema = class_.get_schema()
         schema = SfSchema()
-        with open(entity_schema) as f:
-            resource = Resource.from_contents(json.load(f))
-            entity_schema = resource.contents
+        resource = Resource.from_contents(json.loads(entity_schema))
+        entity_schema = resource.contents
         _replace_refs(entity_schema, schema.registry.resolver(base_uri=resource.id()))
         if "allOf" in entity_schema:
             entity_schema["properties"] = _flatten_all_of(entity_schema)

--- a/streamflow/recovery/checkpoint_manager.py
+++ b/streamflow/recovery/checkpoint_manager.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 from typing import TYPE_CHECKING
 
-import pkg_resources
+from importlib_resources import files
 
 from streamflow.core import utils
 from streamflow.core.data import DataLocation
@@ -44,8 +44,11 @@ class DefaultCheckpointManager(CheckpointManager):
 
     @classmethod
     def get_schema(cls) -> str:
-        return pkg_resources.resource_filename(
-            __name__, os.path.join("schemas", "default_checkpoint_manager.json")
+        return (
+            files(__package__)
+            .joinpath("schemas")
+            .joinpath("default_checkpoint_manager.json")
+            .read_text("utf-8")
         )
 
     def register(self, data_location: DataLocation) -> None:
@@ -60,8 +63,11 @@ class DummyCheckpointManager(CheckpointManager):
 
     @classmethod
     def get_schema(cls) -> str:
-        return pkg_resources.resource_filename(
-            __name__, os.path.join("schemas", "dummy_checkpoint_manager.json")
+        return (
+            files(__package__)
+            .joinpath("schemas")
+            .joinpath("dummy_checkpoint_manager.json")
+            .read_text("utf-8")
         )
 
     def register(self, data_location: DataLocation) -> None:

--- a/streamflow/recovery/failure_manager.py
+++ b/streamflow/recovery/failure_manager.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 from typing import MutableMapping, cast
 
-import pkg_resources
+from importlib_resources import files
 
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.deployment import Connector, Location
@@ -181,8 +180,11 @@ class DefaultFailureManager(FailureManager):
 
     @classmethod
     def get_schema(cls) -> str:
-        return pkg_resources.resource_filename(
-            __name__, os.path.join("schemas", "default_failure_manager.json")
+        return (
+            files(__package__)
+            .joinpath("schemas")
+            .joinpath("default_failure_manager.json")
+            .read_text("utf-8")
         )
 
     async def handle_exception(
@@ -260,8 +262,11 @@ class DummyFailureManager(FailureManager):
 
     @classmethod
     def get_schema(cls) -> str:
-        return pkg_resources.resource_filename(
-            __name__, os.path.join("schemas", "dummy_failure_manager.json")
+        return (
+            files(__package__)
+            .joinpath("schemas")
+            .joinpath("dummy_failure_manager.json")
+            .read_text("utf-8")
         )
 
     async def handle_exception(

--- a/streamflow/scheduling/policy/data_locality.py
+++ b/streamflow/scheduling/policy/data_locality.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import asyncio
-import os
 from typing import TYPE_CHECKING
 
-import pkg_resources
+from importlib_resources import files
 
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.data import DataType
@@ -77,6 +76,9 @@ class DataLocalityPolicy(Policy):
 
     @classmethod
     def get_schema(cls) -> str:
-        return pkg_resources.resource_filename(
-            __name__, os.path.join("schemas", "data_locality.json")
+        return (
+            files(__package__)
+            .joinpath("schemas")
+            .joinpath("data_locality.json")
+            .read_text("utf-8")
         )

--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 import posixpath
 from typing import MutableSequence, TYPE_CHECKING
 
-import pkg_resources
+from importlib_resources import files
 
 from streamflow.core.config import BindingConfig, Config
 from streamflow.core.deployment import BindingFilter, Location, Target
@@ -342,8 +341,11 @@ class DefaultScheduler(Scheduler):
 
     @classmethod
     def get_schema(cls) -> str:
-        return pkg_resources.resource_filename(
-            __name__, os.path.join("schemas", "scheduler.json")
+        return (
+            files(__package__)
+            .joinpath("schemas")
+            .joinpath("scheduler.json")
+            .read_text("utf-8")
         )
 
     async def notify_status(self, job_name: str, status: Status) -> None:

--- a/tests/utils/deployment.py
+++ b/tests/utils/deployment.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import asyncio
 import os
 import tempfile
+from importlib_resources import files
+
 from jinja2 import Template
 
 import asyncssh
 import asyncssh.public_key
-import pkg_resources
 
 from streamflow.core import utils
 from streamflow.core.context import StreamFlowContext
@@ -29,8 +30,7 @@ def get_docker_deployment_config():
 
 
 def get_kubernetes_deployment_config():
-    with open(pkg_resources.resource_filename(__name__, "pod.jinja2")) as t:
-        template = Template(t.read())
+    template = Template(files(__package__).joinpath("pod.jinja2").read_text("utf-8"))
     with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
         template.stream(name=utils.random_name()).dump(f.name)
     return DeploymentConfig(


### PR DESCRIPTION
The `pkg_resources` API has been deprecated in favor of the new `importlib_resources` API. This commit replaces all the usages of `pkg_resources` with the new API.

To implement this new path, the `get_schema` method of each StreamFlow extension must now return the content of the schema instead of the path to the JSON Schema file. Documentation has been updated accordingly.