### PR TITLE
Improve `test_download` logic

### DIFF
--- a/streamflow/data/remotepath.py
+++ b/streamflow/data/remotepath.py
@@ -45,8 +45,8 @@ def _file_checksum_local(path: str) -> str:
 def _get_filename_from_response(response: ClientResponse, url: str):
     if cd_header := response.headers.get("Content-Disposition"):
         message = Message()
-        message["Content-Disposition"] = cd_header
-        if filename := message.get_param("filename"):
+        message["content-disposition"] = cd_header
+        if filename := message.get_param("filename", header="content-disposition"):
             return filename
     return url.rsplit("/", 1)[-1]
 
@@ -133,7 +133,7 @@ async def download(
                         location=location,
                         command=[
                             f'if [ command -v curl ]; then curl -L -o "{filepath}" "{url}"; '
-                            f'else wget -P "{parent_dir}" "{url}"; fi'
+                            f'else wget -O "{filepath}" "{url}"; fi'
                         ],
                     )
                 )

--- a/tests/test_remotepath.py
+++ b/tests/test_remotepath.py
@@ -65,15 +65,23 @@ async def test_directory(context, connector, location):
 @pytest.mark.asyncio
 async def test_download(context, connector, location):
     """Test remote file download."""
-    url1 = "https://raw.githubusercontent.com/alpha-unito/streamflow/master/LICENSE"
-    url2 = "https://github.com/alpha-unito/streamflow/archive/refs/tags/0.1.6.zip"
+    urls = [
+        "https://raw.githubusercontent.com/alpha-unito/streamflow/master/LICENSE",
+        "https://github.com/alpha-unito/streamflow/archive/refs/tags/0.1.6.zip",
+    ]
     parent_dir = (
         tempfile.gettempdir() if isinstance(connector, LocalConnector) else "/tmp"
     )
+    path_processor = get_path_processor(connector)
+    paths = [
+        path_processor.join(parent_dir, "LICENSE"),
+        path_processor.join(parent_dir, "streamflow-0.1.6.zip"),
+    ]
 
-    for url in [url1, url2]:
+    for i, url in enumerate(urls):
         try:
             path = await remotepath.download(connector, [location], url, parent_dir)
+            assert path == paths[i]
             assert await remotepath.exists(connector, location, path)
         finally:
             if await remotepath.exists(connector, location, path):


### PR DESCRIPTION
This commit improves the `test_download` function to verify the correctness of the extracted file name. This commit also fixes the filename handling in the `remotepath.download` function.