### PR TITLE
Add `optional` param to composite processors

### DIFF
--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -550,11 +550,11 @@ def _create_token_processor(
                         schema_def_types=schema_def_types,
                         format_graph=format_graph,
                         context=context,
-                        optional=optional,
                         check_type=check_type,
                         force_deep_listing=force_deep_listing,
                         only_propagate_secondary_files=only_propagate_secondary_files,
                     ),
+                    optional=optional,
                 )
             # Enum type: -> create output processor
             elif port_type["type"] == "enum":
@@ -613,6 +613,7 @@ def _create_token_processor(
                         )
                         for port_type in port_type["fields"]
                     },
+                    optional=optional,
                 )
             # Unknown type -> raise Exception
             else:

--- a/streamflow/deployment/connector/container.py
+++ b/streamflow/deployment/connector/container.py
@@ -343,8 +343,14 @@ class DockerBaseConnector(ContainerConnector, ABC):
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        stdout, _ = await proc.communicate()
-        return json.loads(stdout.decode().strip()) if stdout else []
+        stdout, stderr = await proc.communicate()
+        try:
+            return json.loads(stdout.decode().strip()) if stdout else []
+        except json.decoder.JSONDecodeError:
+            raise WorkflowExecutionException(
+                f"Error retrieving volumes for Docker container {location.name}: "
+                f"{stderr.decode().strip()}"
+            )
 
 
 class DockerConnector(DockerBaseConnector):


### PR DESCRIPTION
Composite `TokenProcessor` objects failed to validate `Token` value when receiving `None`, even if `optional` was set to true. Indeed, the `optional` parameter was only set to the inner `processor` objects, which were called after a first `Token` validation.

This commit explicitly sets the `optional` parameter to the outer `TokenProcessor` object, solving the issue.