### PR TITLE
Fixed incomplete stream reading

### DIFF
--- a/streamflow/deployment/aiotarstream.py
+++ b/streamflow/deployment/aiotarstream.py
@@ -253,7 +253,13 @@ class TellableStreamWrapper(BaseStreamWrapper):
         self.position: int = 0
 
     async def read(self, size: int | None = None):
-        buf = await self.stream.read(size)
+        buf = b""
+        while size > 0:
+            res = await self.stream.read(size)
+            if len(res) == 0:
+                break
+            size -= len(res)
+            buf += res
         self.position += len(buf)
         return buf
 

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -167,7 +167,7 @@ async def test_directory_to_directory(
         src_path = await _create_tmp_dir(
             context, src_connector, src_location, n_files=4
         )
-        for i in range(2):
+        for i in range(3):
             inner_dir = await _create_tmp_dir(
                 context,
                 src_connector,

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -142,6 +142,7 @@ def dst_connector(context, dst_location) -> Connector:
 async def test_directory_to_directory(
     context, src_connector, src_location, dst_connector, dst_location
 ):
+    """Test transferring a directory and its content from one location to another."""
     src_path = None
     dst_path = None
     # dir

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -144,22 +144,22 @@ async def test_directory_to_directory(
 ):
     src_path = None
     dst_path = None
-    # dir_0
+    # dir
     #   |- file_0
     #   |- file_1
     #   |- file_2
     #   |- file_3
-    #   |- dir_0_0
-    #   |   |- file_0_0_0
-    #   |   |- file_0_0_1
-    #   |   |- dir_0_0_0
-    #   |   |   |- file_0_0_0_1
-    #   |   |   |- file_0_0_0_2
-    #   |- dir_0_1
-    #   |   |- file_0_1_0
-    #   |   |- file_0_1_1
-    #   |   |- file_0_1_2
-    #   |- dir_0_2
+    #   |- dir_0
+    #   |   |- file_0_0
+    #   |   |- file_0_1
+    #   |   |- dir_0_0
+    #   |   |   |- file_0_0_1
+    #   |   |   |- file_0_0_2
+    #   |- dir_1
+    #   |   |- file_1_0
+    #   |   |- file_1_1
+    #   |   |- file_1_2
+    #   |- dir_2
     #   |   |   empty
     try:
         # create src structure


### PR DESCRIPTION
This commit fixes the data copying remote-to-local, which raised the InvalidHeaderError in some cases.
The stream did not read the size of the buffer required.
