### PR TITLE
Fix `valueFrom` type checking behaviour

### DIFF
--- a/streamflow/cwl/transformer.py
+++ b/streamflow/cwl/transformer.py
@@ -276,19 +276,20 @@ class ValueFromTransformer(ManyToOneTransformer):
     async def transform(
         self, inputs: MutableMapping[str, Token]
     ) -> MutableMapping[str, Token]:
-        if self.get_output_name() in inputs:
+        output_name = self.get_output_name()
+        if output_name in inputs:
             inputs = {
                 **inputs,
                 **{
-                    self.get_output_name(): await self.processor.process(
-                        inputs, inputs[self.get_output_name()]
+                    output_name: await self.processor.process(
+                        inputs, inputs[output_name]
                     )
                 },
             }
         context = utils.build_context(inputs)
-        context = {**context, **{"self": context["inputs"].get(self.get_output_name())}}
+        context = {**context, **{"self": context["inputs"].get(output_name)}}
         return {
-            self.get_output_name(): Token(
+            output_name: Token(
                 tag=get_tag(inputs.values()),
                 value=utils.eval_expression(
                     expression=self.value_from,

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -2360,7 +2360,7 @@ class CWLTranslator:
                 processor=_create_token_processor(
                     port_name=port_name,
                     workflow=workflow,
-                    port_type=element_input.get("type", "Any"),
+                    port_type="Any",
                     cwl_element=element_input,
                     cwl_name_prefix=posixpath.join(cwl_step_name, port_name),
                     schema_def_types=schema_def_types,


### PR DESCRIPTION
This commit fixes the type checking behaviour with CWL `valueFrom` transformers. Before, the incorrect type was passed to the `TokenProcessor` class: the type resulting from the `valueFrom` expression evaluation. Instead, the correct type should be the type of the `source` value, i.e., before the expression evaluation. Since this type is difficult to infer, as the source could be still unknown at the evaluation time, now StreamFlow always passes `Any`.