### PR TITLE
Fixed job name

### DIFF
--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -1357,9 +1357,7 @@ class ScheduleStep(BaseStep):
                             inputs = inputs_map.pop(tag)
                             # Create Job
                             job = Job(
-                                name=posixpath.join(
-                                    self.job_prefix, tag.split(".")[-1]
-                                ),
+                                name=posixpath.join(self.job_prefix, tag),
                                 workflow_id=self.workflow.persistent_id,
                                 inputs=inputs,
                                 input_directory=self.input_directory,


### PR DESCRIPTION
This commit fixes the uniqueness of job names, which it is helpful mostly in the scheduler.

Before this commit, the job name is composed of the step name and the last tag level of its inputs. However, only the last tag level is not correct because some jobs could have the same name.
In particular, nested scatter can generate tags such as 0.0.0 and 0.1.0, thus the jobs will have the same name, i.e. `step_name/0`.
Now, the entire tag is used as identifier.