### PR TITLE
Fixed symbolic link remote input data error

### DIFF
--- a/streamflow/cwl/step.py
+++ b/streamflow/cwl/step.py
@@ -257,6 +257,10 @@ class CWLInputInjectorStep(InputInjectorStep):
         if filepath:
             if not path_processor.isabs(filepath):
                 filepath = path_processor.join(job.output_directory, filepath)
+            real_filepaths = []
+            for location in locations:
+                 real_filepaths.append(await remotepath.follow_symlink(self.workflow.context, connector, location, filepath))
+            filepath = real_filepaths[0]
             new_token_value = await utils.get_file_token(
                 context=self.workflow.context,
                 connector=connector,

--- a/streamflow/cwl/step.py
+++ b/streamflow/cwl/step.py
@@ -257,10 +257,6 @@ class CWLInputInjectorStep(InputInjectorStep):
         if filepath:
             if not path_processor.isabs(filepath):
                 filepath = path_processor.join(job.output_directory, filepath)
-            real_filepaths = []
-            for location in locations:
-                 real_filepaths.append(await remotepath.follow_symlink(self.workflow.context, connector, location, filepath))
-            filepath = real_filepaths[0]
             new_token_value = await utils.get_file_token(
                 context=self.workflow.context,
                 connector=connector,

--- a/streamflow/data/manager.py
+++ b/streamflow/data/manager.py
@@ -169,13 +169,7 @@ class DefaultDataManager(DataManager):
         )
         # Create destination folder
         await remotepath.mkdir(dst_connector, dst_locations, str(Path(dst_path).parent))
-        # Follow symlink for source path
-        # if (src_location)
-        # await src_location.available.wait()
-        # a = self.path_mapper.get(src_path)
-        # src_path = await remotepath.follow_symlink(
-        #     self.context, src_connector, src_location, src_path
-        # )
+
         primary_locations = self.path_mapper.get(src_path, DataType.PRIMARY)
         copy_tasks = []
         remote_locations = []

--- a/streamflow/data/manager.py
+++ b/streamflow/data/manager.py
@@ -170,6 +170,7 @@ class DefaultDataManager(DataManager):
         # Create destination folder
         await remotepath.mkdir(dst_connector, dst_locations, str(Path(dst_path).parent))
         # Follow symlink for source path
+        await src_location.available.wait()
         src_path = await remotepath.follow_symlink(
             self.context, src_connector, src_location, src_path
         )

--- a/streamflow/data/manager.py
+++ b/streamflow/data/manager.py
@@ -169,7 +169,14 @@ class DefaultDataManager(DataManager):
         )
         # Create destination folder
         await remotepath.mkdir(dst_connector, dst_locations, str(Path(dst_path).parent))
-
+        # Follow symlink for source path
+        for src_data_loc in self.get_data_locations(
+            src_path, src_location.deployment, src_location.name
+        ):
+            await src_data_loc.available.wait()
+        src_path = await remotepath.follow_symlink(
+            self.context, src_connector, src_location, src_path
+        )
         primary_locations = self.path_mapper.get(src_path, DataType.PRIMARY)
         copy_tasks = []
         remote_locations = []

--- a/streamflow/data/manager.py
+++ b/streamflow/data/manager.py
@@ -170,10 +170,12 @@ class DefaultDataManager(DataManager):
         # Create destination folder
         await remotepath.mkdir(dst_connector, dst_locations, str(Path(dst_path).parent))
         # Follow symlink for source path
-        await src_location.available.wait()
-        src_path = await remotepath.follow_symlink(
-            self.context, src_connector, src_location, src_path
-        )
+        # if (src_location)
+        # await src_location.available.wait()
+        # a = self.path_mapper.get(src_path)
+        # src_path = await remotepath.follow_symlink(
+        #     self.context, src_connector, src_location, src_path
+        # )
         primary_locations = self.path_mapper.get(src_path, DataType.PRIMARY)
         copy_tasks = []
         remote_locations = []

--- a/streamflow/data/manager.py
+++ b/streamflow/data/manager.py
@@ -170,10 +170,14 @@ class DefaultDataManager(DataManager):
         # Create destination folder
         await remotepath.mkdir(dst_connector, dst_locations, str(Path(dst_path).parent))
         # Follow symlink for source path
-        for src_data_loc in self.get_data_locations(
-            src_path, src_location.deployment, src_location.name
-        ):
-            await src_data_loc.available.wait()
+        await asyncio.gather(
+            *(
+                asyncio.create_task(src_data_loc.available.wait())
+                for src_data_loc in self.get_data_locations(
+                    src_path, src_location.deployment, src_location.name
+                )
+            )
+        )
         src_path = await remotepath.follow_symlink(
             self.context, src_connector, src_location, src_path
         )

--- a/streamflow/deployment/connector/base.py
+++ b/streamflow/deployment/connector/base.py
@@ -275,6 +275,27 @@ class BaseConnector(Connector, FutureAware):
         await self._copy_local_to_remote(
             src=src, dst=dst, locations=locations, read_only=read_only
         )
+        if logger.isEnabledFor(logging.INFO):
+            if len(locations) > 1:
+                logger.info(
+                    "COMPLETED copy {src} on local file-system to {dst} on locations:\n\t{locations}".format(
+                        src=src,
+                        dst=dst,
+                        locations="\n\t".join([str(loc) for loc in locations]),
+                    )
+                )
+            else:
+                logger.info(
+                    "COMPLETED copy {src} on local file-system to {dst} {location}".format(
+                        src=src,
+                        dst=dst,
+                        location=(
+                            "on local file-system"
+                            if locations[0].name == LOCAL_LOCATION
+                            else f"on location {locations[0]}"
+                        ),
+                    )
+                )
 
     async def copy_remote_to_local(
         self,
@@ -292,6 +313,10 @@ class BaseConnector(Connector, FutureAware):
         await self._copy_remote_to_local(
             src=src, dst=dst, location=locations[0], read_only=read_only
         )
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(
+                f"COMPLETED copy {src} on location {locations[0]} to {dst} on local file-system"
+            )
 
     async def copy_remote_to_remote(
         self,
@@ -329,6 +354,25 @@ class BaseConnector(Connector, FutureAware):
             source_connector=source_connector,
             read_only=read_only,
         )
+        if logger.isEnabledFor(logging.INFO):
+            if len(locations) > 1:
+                logger.info(
+                    "COMPLETED copy {src} on location {src_loc} to {dst} on locations:\n\t{locations}".format(
+                        src_loc=source_location,
+                        src=src,
+                        dst=dst,
+                        locations="\n\t".join([str(loc) for loc in locations]),
+                    )
+                )
+            else:
+                logger.info(
+                    "COMPLETED copy {src} on location {src_loc} to {dst} on location {location}".format(
+                        src_loc=source_location,
+                        src=src,
+                        dst=dst,
+                        location=locations[0],
+                    )
+                )
 
     async def run(
         self,

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -1267,15 +1267,16 @@ class ScheduleStep(BaseStep):
                 job.output_directory,
                 job.tmp_directory,
             ):
-                realpath = await remotepath.follow_symlink(
-                    self.workflow.context, connector, location, directory
-                )
-                if realpath != directory:
-                    self.workflow.context.data_manager.register_path(
-                        location=location,
-                        path=realpath,
-                        relpath=realpath,
-                    )
+                realpath = directory
+                # realpath = await remotepath.follow_symlink(
+                #     self.workflow.context, connector, location, directory
+                # )
+                # if realpath != directory:
+                #     self.workflow.context.data_manager.register_path(
+                #         location=location,
+                #         path=realpath,
+                #         relpath=realpath,
+                #     )
                 self.workflow.context.data_manager.register_path(
                     location=location,
                     path=directory,

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -1267,23 +1267,26 @@ class ScheduleStep(BaseStep):
                 job.output_directory,
                 job.tmp_directory,
             ):
-                realpath = await remotepath.follow_symlink(
-                    self.workflow.context, connector, location, directory
-                )
-                if realpath != directory:
+                if not self.workflow.context.data_manager.get_data_locations(
+                    directory, location.deployment, location.name
+                ):
+                    realpath = await remotepath.follow_symlink(
+                        self.workflow.context, connector, location, directory
+                    )
+                    if realpath != directory:
+                        self.workflow.context.data_manager.register_path(
+                            location=location,
+                            path=realpath,
+                            relpath=realpath,
+                        )
                     self.workflow.context.data_manager.register_path(
                         location=location,
-                        path=realpath,
-                        relpath=realpath,
+                        path=directory,
+                        relpath=directory,
+                        data_type=DataType.PRIMARY
+                        if realpath == directory
+                        else DataType.SYMBOLIC_LINK,
                     )
-                self.workflow.context.data_manager.register_path(
-                    location=location,
-                    path=directory,
-                    relpath=directory,
-                    data_type=DataType.PRIMARY
-                    if realpath == directory
-                    else DataType.SYMBOLIC_LINK,
-                )
         # Propagate job
         token_inputs = []
         for step_port_name in self.input_ports.keys():

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -1267,7 +1267,9 @@ class ScheduleStep(BaseStep):
                 job.output_directory,
                 job.tmp_directory,
             ):
-                realpath = await remotepath.follow_symlink(self.workflow.context, connector, location, directory)
+                realpath = await remotepath.follow_symlink(
+                    self.workflow.context, connector, location, directory
+                )
                 if realpath != directory:
                     self.workflow.context.data_manager.register_path(
                         location=location,
@@ -1278,7 +1280,9 @@ class ScheduleStep(BaseStep):
                     location=location,
                     path=directory,
                     relpath=directory,
-                    data_type=DataType.PRIMARY if realpath == directory else DataType.SYMBOLIC_LINK
+                    data_type=DataType.PRIMARY
+                    if realpath == directory
+                    else DataType.SYMBOLIC_LINK,
                 )
         # Propagate job
         token_inputs = []

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -1267,16 +1267,15 @@ class ScheduleStep(BaseStep):
                 job.output_directory,
                 job.tmp_directory,
             ):
-                realpath = directory
-                # realpath = await remotepath.follow_symlink(
-                #     self.workflow.context, connector, location, directory
-                # )
-                # if realpath != directory:
-                #     self.workflow.context.data_manager.register_path(
-                #         location=location,
-                #         path=realpath,
-                #         relpath=realpath,
-                #     )
+                realpath = await remotepath.follow_symlink(
+                    self.workflow.context, connector, location, directory
+                )
+                if realpath != directory:
+                    self.workflow.context.data_manager.register_path(
+                        location=location,
+                        path=realpath,
+                        relpath=realpath,
+                    )
                 self.workflow.context.data_manager.register_path(
                     location=location,
                     path=directory,


### PR DESCRIPTION
This commit fixes the case of input remote data are in a symbolic link path. The path was saved in the filesystem as regular file without checking. Now, the right file type is saved (`PRIMARY` for regular files, `SYMBOLIC_LINK` for Symbolic link files). In the case of Symbolic link path, also the Primary path is saved.

Futhermore, fixed a not syncrhonized transferring data. If a remote data is required by two concurrent steps on the same location and the two steps are executed together, the first starts the copying, while the second creates a symbolic link from the data copied by the first one. However, the second must wait that the first ends, before to starts the creation of the symbolic link.

Finally, new messages were added in the logger to notify the end of data copying.