### PR TITLE
Added `StreamWrapper` documentation

### DIFF
--- a/docs/source/ext/database.rst
+++ b/docs/source/ext/database.rst
@@ -121,7 +121,7 @@ The ``Database`` interface, defined in the ``streamflow.core.persistence`` modul
         ...
 
     async def get_deployment(
-        self, deplyoment_id: int
+        self, deployment_id: int
     ) -> MutableMapping[str, Any]:
         ...
 

--- a/streamflow/core/data.py
+++ b/streamflow/core/data.py
@@ -117,8 +117,8 @@ class FileType(Enum):
 
 
 class StreamWrapper(ABC):
-    def __init__(self, stream):
-        self.stream = stream
+    def __init__(self, stream: Any):
+        self.stream: Any = stream
 
     @abstractmethod
     async def close(self):
@@ -133,7 +133,7 @@ class StreamWrapper(ABC):
         ...
 
 
-class StreamWrapperContext(ABC):
+class StreamWrapperContextManager(ABC):
     @abstractmethod
     async def __aenter__(self) -> StreamWrapper:
         ...

--- a/streamflow/core/deployment.py
+++ b/streamflow/core/deployment.py
@@ -14,7 +14,7 @@ from streamflow.core.context import SchemaEntity
 from streamflow.core.persistence import DatabaseLoadingContext, PersistableEntity
 
 if TYPE_CHECKING:
-    from streamflow.core.data import StreamWrapperContext
+    from streamflow.core.data import StreamWrapperContextManager
     from streamflow.core.context import StreamFlowContext
     from streamflow.core.scheduling import AvailableLocation
     from streamflow.core.workflow import Job
@@ -141,7 +141,7 @@ class Connector(SchemaEntity):
     @abstractmethod
     async def get_stream_reader(
         self, location: Location, src: str
-    ) -> StreamWrapperContext:
+    ) -> StreamWrapperContextManager:
         ...
 
 

--- a/streamflow/deployment/connector/base.py
+++ b/streamflow/deployment/connector/base.py
@@ -10,7 +10,7 @@ from abc import abstractmethod
 from typing import MutableSequence, TYPE_CHECKING
 
 from streamflow.core import utils
-from streamflow.core.data import StreamWrapperContext
+from streamflow.core.data import StreamWrapperContextManager
 from streamflow.core.deployment import (
     Connector,
     LOCAL_LOCATION,
@@ -23,7 +23,7 @@ from streamflow.deployment.future import FutureAware
 from streamflow.deployment.stream import (
     StreamReaderWrapper,
     StreamWriterWrapper,
-    SubprocessStreamReaderWrapperContext,
+    SubprocessStreamReaderWrapperContextManager,
 )
 from streamflow.log_handler import logger
 
@@ -228,9 +228,9 @@ class BaseConnector(Connector, FutureAware):
 
     async def get_stream_reader(
         self, location: Location, src: str
-    ) -> StreamWrapperContext:
+    ) -> StreamWrapperContextManager:
         dirname, basename = posixpath.split(src)
-        return SubprocessStreamReaderWrapperContext(
+        return SubprocessStreamReaderWrapperContextManager(
             coro=asyncio.create_subprocess_exec(
                 *shlex.split(
                     self._get_run_command(

--- a/streamflow/deployment/connector/kubernetes.py
+++ b/streamflow/deployment/connector/kubernetes.py
@@ -37,7 +37,7 @@ from kubernetes_asyncio.utils import create_from_yaml
 
 from streamflow.core import utils
 from streamflow.core.asyncache import cachedmethod
-from streamflow.core.data import StreamWrapperContext
+from streamflow.core.data import StreamWrapperContextManager
 from streamflow.core.deployment import Connector, Location
 from streamflow.core.exception import (
     WorkflowDefinitionException,
@@ -138,7 +138,7 @@ class KubernetesResponseWrapper(BaseStreamWrapper):
         await self.stream.send_bytes(payload)
 
 
-class KubernetesResponseWrapperContext(StreamWrapperContext):
+class KubernetesResponseWrapperContextManager(StreamWrapperContextManager):
     def __init__(self, coro: Coroutine):
         self.coro: Coroutine = coro
         self.response: KubernetesResponseWrapper | None = None
@@ -430,10 +430,10 @@ class BaseKubernetesConnector(BaseConnector, ABC):
 
     async def get_stream_reader(
         self, location: Location, src: str
-    ) -> StreamWrapperContext:
+    ) -> StreamWrapperContextManager:
         pod, container = location.name.split(":")
         dirname, basename = posixpath.split(src)
-        return KubernetesResponseWrapperContext(
+        return KubernetesResponseWrapperContextManager(
             coro=cast(
                 Coroutine,
                 self.client_ws.connect_get_namespaced_pod_exec(

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -16,7 +16,7 @@ from importlib_resources import files
 
 from streamflow.core import utils
 from streamflow.core.asyncache import cachedmethod
-from streamflow.core.data import StreamWrapperContext
+from streamflow.core.data import StreamWrapperContextManager
 from streamflow.core.deployment import Connector, Location
 from streamflow.core.exception import WorkflowExecutionException
 from streamflow.core.scheduling import AvailableLocation, Hardware
@@ -223,7 +223,7 @@ class SSHContextFactory:
         )
 
 
-class SSHStreamWrapperContext(StreamWrapperContext):
+class SSHStreamWrapperContextManager(StreamWrapperContextManager):
     def __init__(self, src: str, ssh_context_factory: SSHContextFactory):
         super().__init__()
         self.src: str = src
@@ -643,7 +643,7 @@ class SSHConnector(BaseConnector):
 
     async def get_stream_reader(
         self, location: Location, src: str
-    ) -> StreamWrapperContext:
+    ) -> StreamWrapperContextManager:
         if self.dataTransferConfig:
             if location not in self.data_transfer_context_factories:
                 self.data_transfer_context_factories[location.name] = SSHContextFactory(
@@ -662,7 +662,9 @@ class SSHConnector(BaseConnector):
                     max_connections=self.maxConnections,
                 )
             ssh_context_factory = self.ssh_context_factories[location.name]
-        return SSHStreamWrapperContext(src=src, ssh_context_factory=ssh_context_factory)
+        return SSHStreamWrapperContextManager(
+            src=src, ssh_context_factory=ssh_context_factory
+        )
 
     async def deploy(self, external: bool) -> None:
         pass

--- a/streamflow/deployment/future.py
+++ b/streamflow/deployment/future.py
@@ -10,7 +10,7 @@ from streamflow.core.scheduling import AvailableLocation
 from streamflow.log_handler import logger
 
 if TYPE_CHECKING:
-    from streamflow.core.data import StreamWrapperContext
+    from streamflow.core.data import StreamWrapperContextManager
 
 
 class FutureConnector(Connector):
@@ -131,7 +131,7 @@ class FutureConnector(Connector):
 
     async def get_stream_reader(
         self, location: Location, src: str
-    ) -> StreamWrapperContext:
+    ) -> StreamWrapperContextManager:
         if self.connector is None:
             if not self.deploying:
                 self.deploying = True

--- a/streamflow/deployment/stream.py
+++ b/streamflow/deployment/stream.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio.subprocess
 from typing import Any, Coroutine
 
-from streamflow.core.data import StreamWrapper, StreamWrapperContext
+from streamflow.core.data import StreamWrapper, StreamWrapperContextManager
 
 
 class BaseStreamWrapper(StreamWrapper):
@@ -48,7 +48,7 @@ class StreamWriterWrapper(StreamWrapper):
         await self.stream.drain()
 
 
-class SubprocessStreamReaderWrapperContext(StreamWrapperContext):
+class SubprocessStreamReaderWrapperContextManager(StreamWrapperContextManager):
     def __init__(self, coro: Coroutine):
         self.coro: Coroutine = coro
         self.proc: asyncio.subprocess.Process | None = None
@@ -65,7 +65,7 @@ class SubprocessStreamReaderWrapperContext(StreamWrapperContext):
             await self.stream.close()
 
 
-class SubprocessStreamWriterWrapperContext(StreamWrapperContext):
+class SubprocessStreamWriterWrapperContextManager(StreamWrapperContextManager):
     def __init__(self, coro: Coroutine):
         self.coro: Coroutine = coro
         self.proc: asyncio.subprocess.Process | None = None

--- a/streamflow/deployment/wrapper.py
+++ b/streamflow/deployment/wrapper.py
@@ -5,7 +5,7 @@ from typing import Any, MutableMapping, MutableSequence, Optional, Tuple, Union
 from streamflow.core.deployment import Connector, Location
 from streamflow.core.scheduling import AvailableLocation
 from streamflow.deployment.future import FutureAware
-from streamflow.core.data import StreamWrapperContext
+from streamflow.core.data import StreamWrapperContextManager
 
 
 class ConnectorWrapper(Connector, FutureAware, ABC):
@@ -84,7 +84,7 @@ class ConnectorWrapper(Connector, FutureAware, ABC):
 
     async def get_stream_reader(
         self, location: Location, src: str
-    ) -> StreamWrapperContext:
+    ) -> StreamWrapperContextManager:
         return await self.connector.get_stream_reader(location, src)
 
     async def run(


### PR DESCRIPTION
This commit documents the `StreamWrapper` feature in the `Connector` abstraction. After the promotion of the `get_stream_reader` method to the standard `Connector` interface, a proper documentation of the `StreamWrapper` feature was missing.