### PR TITLE
Improved error message of batch systems when job fails

### DIFF
--- a/streamflow/deployment/connector/queue_manager.py
+++ b/streamflow/deployment/connector/queue_manager.py
@@ -633,7 +633,12 @@ class SlurmConnector(QueueManagerConnector):
             command=command,
             capture_output=True,
         )
-        return int(stdout.strip())
+        try:
+            return int(stdout.strip())
+        except ValueError:
+            raise WorkflowExecutionException(
+                f"Error while retrieving return code for job {job_id}: {stdout.strip()}"
+            )
 
     @cachedmethod(
         lambda self: self.jobsCache,
@@ -1024,7 +1029,12 @@ class FluxConnector(QueueManagerConnector):
             command=command,
             capture_output=True,
         )
-        return int(stdout.strip())
+        try:
+            return int(stdout.strip())
+        except ValueError:
+            raise WorkflowExecutionException(
+                f"Error while retrieving return code for job {job_id}: {stdout.strip()}"
+            )
 
     @cachedmethod(
         lambda self: self.jobsCache,


### PR DESCRIPTION
This commit improves the error message when a job fails.
Sometimes, the result message is not an integer. Before this commit, the casting in integer fails and the job error message was difficult to read.