### PR TITLE
Added check after the creation data

### DIFF
--- a/streamflow/cwl/step.py
+++ b/streamflow/cwl/step.py
@@ -559,6 +559,19 @@ class CWLTransferStep(TransferStep):
                 load_contents="contents" in token_value,
                 load_listing=LoadListing.no_listing,
             )
+
+            if (
+                "checksum" in token_value
+                and new_token_value["checksum"] != token_value["checksum"]
+            ):
+                raise WorkflowExecutionException(
+                    "Error creating file {} with path {} in locations {}.".format(
+                        token_value["path"],
+                        new_token_value["path"],
+                        dst_locations
+                    )
+                )
+
             # If listing is specified, recursively process its contents
             if "listing" in token_value:
                 new_token_value["listing"] = await asyncio.gather(

--- a/streamflow/cwl/step.py
+++ b/streamflow/cwl/step.py
@@ -566,9 +566,7 @@ class CWLTransferStep(TransferStep):
             ):
                 raise WorkflowExecutionException(
                     "Error creating file {} with path {} in locations {}.".format(
-                        token_value["path"],
-                        new_token_value["path"],
-                        dst_locations
+                        token_value["path"], new_token_value["path"], dst_locations
                     )
                 )
 


### PR DESCRIPTION
This commit adds a new check when the data are created.
This check is helpful to avoid wrong creations. It is possible that the data are not found: e.g. the location fails and the data have been lost, or the user adds in the config file a wrong path. Before this commit, the data was created empty in the new location when there was a copy of the data and they was not found. Now, an exception is thrown. 