### PR TITLE
Reduce size of database metadata

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -147,7 +147,7 @@ jobs:
           python -m pip install -r docs/requirements.txt
       - name: "Build documentation and check for consistency"
         env:
-          CHECKSUM: "827007dc58288b5b151709fcd05d37bbe7063add06640d8b6c286885d211e39b"
+          CHECKSUM: "83c4457b9471d0268d42ffe4f4d6bea83dbb2f0649a52284e233c2e6b2ed546a"
         run: |
           cd docs/
           make html

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -147,7 +147,7 @@ jobs:
           python -m pip install -r docs/requirements.txt
       - name: "Build documentation and check for consistency"
         env:
-          CHECKSUM: "83c4457b9471d0268d42ffe4f4d6bea83dbb2f0649a52284e233c2e6b2ed546a"
+          CHECKSUM: "caaa02b3477bf264a667c1684176ecf3f5e03e6c916d3107299c33670506239c"
         run: |
           cd docs/
           make html

--- a/docs/source/ext/database.rst
+++ b/docs/source/ext/database.rst
@@ -31,11 +31,6 @@ The ``Database`` interface, defined in the ``streamflow.core.persistence`` modul
 
 .. code-block:: python
 
-    async def add_command(
-        self, step_id: int, tag: str, cmd: str
-    ) -> int:
-        ...
-
     async def add_dependency(
         self, step: int, port: int, type: DependencyType, name: str
     ) -> None:
@@ -49,6 +44,11 @@ The ``Database`` interface, defined in the ``streamflow.core.persistence`` modul
         external: bool,
         lazy: bool,
         workdir: str | None,
+    ) -> int:
+        ...
+
+    async def add_execution(
+        self, step_id: int, tag: str, cmd: str
     ) -> int:
         ...
 
@@ -110,19 +110,19 @@ The ``Database`` interface, defined in the ``streamflow.core.persistence`` modul
     ) -> MutableSequence[MutableMapping[str, Any]]:
         ...
 
-    async def get_command(
-        self, command_id: int
-    ) -> MutableMapping[str, Any]:
-        ...
-
-    async def get_commands_by_step(
-        self, step_id: int
-    ) -> MutableSequence[MutableMapping[str, Any]]:
-        ...
-
     async def get_deployment(
         self, deployment_id: int
     ) -> MutableMapping[str, Any]:
+        ...
+
+    async def get_execution(
+        self, execution_id: int
+    ) -> MutableMapping[str, Any]:
+        ...
+
+    async def get_executions_by_step(
+        self, step_id: int
+    ) -> MutableSequence[MutableMapping[str, Any]]:
         ...
 
     async def get_input_ports(
@@ -190,13 +190,13 @@ The ``Database`` interface, defined in the ``streamflow.core.persistence`` modul
     ) -> MutableSequence[MutableMapping[str, Any]]:
         ...
 
-    async def update_command(
-        self, command_id: int, updates: MutableMapping[str, Any]
+    async def update_deployment(
+        self, deployment_id: int, updates: MutableMapping[str, Any]
     ) -> int:
         ...
 
-    async def update_deployment(
-        self, deployment_id: int, updates: MutableMapping[str, Any]
+    async def update_execution(
+        self, execution_id: int, updates: MutableMapping[str, Any]
     ) -> int:
         ...
 

--- a/streamflow/core/persistence.py
+++ b/streamflow/core/persistence.py
@@ -100,7 +100,7 @@ class Database(SchemaEntity):
         self.context: StreamFlowContext = context
 
     @abstractmethod
-    async def add_command(self, step_id: int, tag: str, cmd: str) -> int:
+    async def add_execution(self, step_id: int, tag: str, cmd: str) -> int:
         ...
 
     @abstractmethod
@@ -196,11 +196,11 @@ class Database(SchemaEntity):
         ...
 
     @abstractmethod
-    async def get_command(self, command_id: int) -> MutableMapping[str, Any]:
+    async def get_execution(self, command_id: int) -> MutableMapping[str, Any]:
         ...
 
     @abstractmethod
-    async def get_commands_by_step(
+    async def get_executions_by_step(
         self, step_id: int
     ) -> MutableSequence[MutableMapping[str, Any]]:
         ...
@@ -280,8 +280,8 @@ class Database(SchemaEntity):
         ...
 
     @abstractmethod
-    async def update_command(
-        self, command_id: int, updates: MutableMapping[str, Any]
+    async def update_execution(
+        self, execution_id: int, updates: MutableMapping[str, Any]
     ) -> int:
         ...
 

--- a/streamflow/core/persistence.py
+++ b/streamflow/core/persistence.py
@@ -200,7 +200,7 @@ class Database(SchemaEntity):
         ...
 
     @abstractmethod
-    async def get_execution(self, command_id: int) -> MutableMapping[str, Any]:
+    async def get_execution(self, execution_id: int) -> MutableMapping[str, Any]:
         ...
 
     @abstractmethod

--- a/streamflow/core/persistence.py
+++ b/streamflow/core/persistence.py
@@ -100,10 +100,6 @@ class Database(SchemaEntity):
         self.context: StreamFlowContext = context
 
     @abstractmethod
-    async def add_execution(self, step_id: int, tag: str, cmd: str) -> int:
-        ...
-
-    @abstractmethod
     async def add_dependency(
         self, step: int, port: int, type: DependencyType, name: str
     ) -> None:
@@ -119,6 +115,10 @@ class Database(SchemaEntity):
         lazy: bool,
         workdir: str | None,
     ) -> int:
+        ...
+
+    @abstractmethod
+    async def add_execution(self, step_id: int, tag: str, cmd: str) -> int:
         ...
 
     @abstractmethod
@@ -196,6 +196,10 @@ class Database(SchemaEntity):
         ...
 
     @abstractmethod
+    async def get_deployment(self, deployment_id: int) -> MutableMapping[str, Any]:
+        ...
+
+    @abstractmethod
     async def get_execution(self, command_id: int) -> MutableMapping[str, Any]:
         ...
 
@@ -203,10 +207,6 @@ class Database(SchemaEntity):
     async def get_executions_by_step(
         self, step_id: int
     ) -> MutableSequence[MutableMapping[str, Any]]:
-        ...
-
-    @abstractmethod
-    async def get_deployment(self, deployment_id: int) -> MutableMapping[str, Any]:
         ...
 
     @abstractmethod
@@ -280,14 +280,14 @@ class Database(SchemaEntity):
         ...
 
     @abstractmethod
-    async def update_execution(
-        self, execution_id: int, updates: MutableMapping[str, Any]
+    async def update_deployment(
+        self, deployment_id: int, updates: MutableMapping[str, Any]
     ) -> int:
         ...
 
     @abstractmethod
-    async def update_deployment(
-        self, deployment_id: int, updates: MutableMapping[str, Any]
+    async def update_execution(
+        self, execution_id: int, updates: MutableMapping[str, Any]
     ) -> int:
         ...
 

--- a/streamflow/cwl/command.py
+++ b/streamflow/cwl/command.py
@@ -855,7 +855,6 @@ class CWLCommand(CWLBaseCommand):
             command_id,
             {
                 "status": status.value,
-                "output": str(result),
                 "start_time": start_time,
                 "end_time": end_time,
             },
@@ -1260,7 +1259,6 @@ class CWLExpressionCommand(CWLBaseCommand):
             command_id,
             {
                 "status": Status.COMPLETED.value,
-                "output": str(result),
                 "start_time": start_time,
                 "end_time": end_time,
             },

--- a/streamflow/cwl/command.py
+++ b/streamflow/cwl/command.py
@@ -775,7 +775,7 @@ class CWLCommand(CWLBaseCommand):
                 )
             )
         # Persist command
-        command_id = await self.step.workflow.context.database.add_command(
+        execution_id = await self.step.workflow.context.database.add_execution(
             step_id=self.step.persistent_id,
             tag=get_tag(job.inputs.values()),
             cmd=cmd_string,
@@ -851,8 +851,8 @@ class CWLCommand(CWLBaseCommand):
         else:
             status = Status.FAILED
         # Update command persistence
-        await self.step.workflow.context.database.update_command(
-            command_id,
+        await self.step.workflow.context.database.update_execution(
+            execution_id,
             {
                 "status": status.value,
                 "start_time": start_time,
@@ -1240,7 +1240,7 @@ class CWLExpressionCommand(CWLBaseCommand):
                 f"Evaluating expression for step {self.step.name} (job {job.name})"
             )
         # Persist command
-        command_id = await self.step.workflow.context.database.add_command(
+        execution_id = await self.step.workflow.context.database.add_execution(
             step_id=self.step.persistent_id,
             tag=get_tag(job.inputs.values()),
             cmd=self.expression,
@@ -1255,8 +1255,8 @@ class CWLExpressionCommand(CWLBaseCommand):
         )
         end_time = time.time_ns()
         # Update command persistence
-        await self.step.workflow.context.database.update_command(
-            command_id,
+        await self.step.workflow.context.database.update_execution(
+            execution_id,
             {
                 "status": Status.COMPLETED.value,
                 "start_time": start_time,

--- a/streamflow/persistence/schemas/sqlite.sql
+++ b/streamflow/persistence/schemas/sqlite.sql
@@ -49,7 +49,6 @@ CREATE TABLE IF NOT EXISTS command
     step       INTEGER,
     tag        TEXT,
     cmd        TEXT,
-    output     BLOB,
     status     INTEGER,
     start_time INTEGER,
     end_time   INTEGER,

--- a/streamflow/persistence/schemas/sqlite.sql
+++ b/streamflow/persistence/schemas/sqlite.sql
@@ -43,7 +43,7 @@ CREATE TABLE IF NOT EXISTS dependency
 );
 
 
-CREATE TABLE IF NOT EXISTS command
+CREATE TABLE IF NOT EXISTS execution
 (
     id         INTEGER PRIMARY KEY,
     step       INTEGER,

--- a/streamflow/persistence/sqlite.py
+++ b/streamflow/persistence/sqlite.py
@@ -87,10 +87,10 @@ class SqliteDatabase(CachedDatabase):
             .read_text("utf-8")
         )
 
-    async def add_command(self, step_id: int, tag: str, cmd: str) -> int:
+    async def add_execution(self, step_id: int, tag: str, cmd: str) -> int:
         async with self.connection as db:
             async with db.execute(
-                "INSERT INTO command(step, tag, cmd) " "VALUES(:step, :tag, :cmd)",
+                "INSERT INTO execution(step, tag, cmd) " "VALUES(:step, :tag, :cmd)",
                 {"step": step_id, "tag": tag, "cmd": cmd},
             ) as cursor:
                 return cursor.lastrowid
@@ -281,19 +281,19 @@ class SqliteDatabase(CachedDatabase):
             ) as cursor:
                 return await cursor.fetchall()
 
-    async def get_command(self, command_id: int) -> MutableMapping[str, Any]:
+    async def get_execution(self, execution_id: int) -> MutableMapping[str, Any]:
         async with self.connection as db:
             async with db.execute(
-                "SELECT * FROM command WHERE id = :id", {"id": command_id}
+                "SELECT * FROM execution WHERE id = :id", {"id": execution_id}
             ) as cursor:
                 return await cursor.fetchone()
 
-    async def get_commands_by_step(
+    async def get_executions_by_step(
         self, step_id: int
     ) -> MutableSequence[MutableMapping[str, Any]]:
         async with self.connection as db:
             async with db.execute(
-                "SELECT * FROM command WHERE step = :id", {"id": step_id}
+                "SELECT * FROM execution WHERE step = :id", {"id": step_id}
             ) as cursor:
                 return await cursor.fetchall()
 
@@ -460,17 +460,17 @@ class SqliteDatabase(CachedDatabase):
                 ) as cursor:
                     return await cursor.fetchall()
 
-    async def update_command(
-        self, command_id: int, updates: MutableMapping[str, Any]
+    async def update_execution(
+        self, execution_id: int, updates: MutableMapping[str, Any]
     ) -> int:
         async with self.connection as db:
             await db.execute(
-                "UPDATE command SET {} WHERE id = :id".format(  # nosec
+                "UPDATE execution SET {} WHERE id = :id".format(  # nosec
                     ", ".join([f"{k} = :{k}" for k in updates])
                 ),
-                {**updates, **{"id": command_id}},
+                {**updates, **{"id": execution_id}},
             )
-            return command_id
+            return execution_id
 
     async def update_deployment(
         self, deployment_id: int, updates: MutableMapping[str, Any]

--- a/streamflow/provenance/run_crate.py
+++ b/streamflow/provenance/run_crate.py
@@ -782,28 +782,28 @@ class RunCrateProvenanceManager(ProvenanceManager, ABC):
                 # Add CreateActions
                 create_actions = []
                 if step := workflow.steps.get(step_name):
-                    for command in await self.context.database.get_commands_by_step(
+                    for execution in await self.context.database.get_executions_by_step(
                         step.persistent_id
                     ):
                         create_action = {
                             "@id": "#" + str(uuid.uuid4()),
                             "@type": "CreateAction",
                             "actionStatus": _get_action_status(
-                                Status(command["status"])
+                                Status(execution["status"])
                             ),
                             "endTime": streamflow.core.utils.get_date_from_ns(
-                                command["end_time"]
+                                execution["end_time"]
                             ),
                             "instrument": {"@id": jsonld_step["workExample"]["@id"]},
                             "name": f"Run of workflow/{jsonld_step['@id']}",
                             "startTime": streamflow.core.utils.get_date_from_ns(
-                                command["start_time"]
+                                execution["start_time"]
                             ),
                         }
                         self.graph[create_action["@id"]] = create_action
                         self.create_action_map.setdefault(wf_id, {}).setdefault(
                             jsonld_step["workExample"]["@id"], {}
-                        ).setdefault(step_name, {})[command["tag"]] = create_action
+                        ).setdefault(step_name, {})[execution["tag"]] = create_action
                         create_actions.append(create_action)
                 # Add ControlAction
                 if create_actions:


### PR DESCRIPTION
This commit reduces the footprint of database metadata by removing the `output` column of the `command` table, which stored the `stdout` of a `Job execution`. Indeed, the output of a command can be costly in terms of data size, and up to now was not used by StreamFlow.

Futhermore, the `command` table has been renamed to avoid confusion with the StreamFlow `Command` class. Indeed, the `Command` class is not a `PersistableEntity`, but is saved inside the `step` database table.
