### PR TITLE
Fixed get method of RemotePathMapper

### DIFF
--- a/streamflow/data/manager.py
+++ b/streamflow/data/manager.py
@@ -361,7 +361,7 @@ class RemotePathMapper:
         result = []
         for dep in [deployment] if deployment is not None else node.locations:
             for n in [name] if name is not None else node.locations.setdefault(dep, {}):
-                locations = node.locations[dep].setdefault(n, [])
+                locations = node.locations.setdefault(dep, {}).setdefault(n, [])
                 result.extend(
                     [
                         loc


### PR DESCRIPTION
This commit fixes a misleading access of a location not yet registered in the StreamFlow filesystem.

This commit fixes the issue #342 and the occurrence of this error may be a regression introduced in PR #328.

 

