### PR TITLE
Improved scatter/gather performance

### DIFF
--- a/streamflow/cwl/transformer.py
+++ b/streamflow/cwl/transformer.py
@@ -357,7 +357,7 @@ class DotProductSizeTransformer(ManyToOneTransformer):
     async def transform(
         self, inputs: MutableMapping[str, Token]
     ) -> MutableMapping[str, Token]:
-        values = set(t.value for t in inputs.values())
+        values = {t.value for t in inputs.values()}
         if len(values) > 1:
             raise WorkflowExecutionException(f"Values must be equals. Got {values}")
         if not isinstance(next(iter(values)), int) or next(iter(values)) < 0:
@@ -384,9 +384,6 @@ class CartesianProductSizeTransformer(ManyToOneTransformer):
 
 
 class DuplicateTransformer(ManyToOneTransformer):
-    def __init__(self, name: str, workflow: Workflow):
-        super().__init__(name, workflow)
-
     def _get_input_port_name(self) -> str:
         return next(n for n in self.input_ports if n != "__size__")
 

--- a/streamflow/cwl/transformer.py
+++ b/streamflow/cwl/transformer.py
@@ -31,14 +31,14 @@ class AllNonNullTransformer(OneToOneTransformer):
 
     async def transform(
         self, inputs: MutableMapping[str, Token]
-    ) -> MutableMapping[str, Token]:
+    ) -> MutableMapping[str, Token | MutableSequence[Token]]:
         return {self.get_output_name(): self._transform(*next(iter(inputs.items())))}
 
 
 class CartesianProductSizeTransformer(ManyToOneTransformer):
     async def transform(
         self, inputs: MutableMapping[str, Token]
-    ) -> MutableMapping[str, Token]:
+    ) -> MutableMapping[str, Token | MutableSequence[Token]]:
         for port_name, token in inputs.items():
             if not isinstance(token.value, int) or token.value < 0:
                 raise WorkflowExecutionException(
@@ -135,7 +135,7 @@ class CWLTokenTransformer(ManyToOneTransformer):
 
     async def transform(
         self, inputs: MutableMapping[str, Token]
-    ) -> MutableMapping[str, Token]:
+    ) -> MutableMapping[str, Token | MutableSequence[Token]]:
         return {
             self.get_output_name(): await self.processor.process(
                 inputs, inputs[self.port_name]
@@ -175,7 +175,7 @@ class DefaultTransformer(ManyToOneTransformer):
 
     async def transform(
         self, inputs: MutableMapping[str, Token]
-    ) -> MutableMapping[str, Token]:
+    ) -> MutableMapping[str, Token | MutableSequence[Token]]:
         if len(inputs) != 1:
             raise WorkflowDefinitionException(
                 f"{self.name} step must contain a single input port."
@@ -198,7 +198,7 @@ class DefaultTransformer(ManyToOneTransformer):
 class DefaultRetagTransformer(DefaultTransformer):
     async def transform(
         self, inputs: MutableMapping[str, Token]
-    ) -> MutableMapping[str, Token]:
+    ) -> MutableMapping[str, Token | MutableSequence[Token]]:
         if not self.default_port:
             raise WorkflowDefinitionException(
                 f"{self.name} step must contain a default port."
@@ -214,7 +214,7 @@ class DefaultRetagTransformer(DefaultTransformer):
 class DotProductSizeTransformer(ManyToOneTransformer):
     async def transform(
         self, inputs: MutableMapping[str, Token]
-    ) -> MutableMapping[str, Token]:
+    ) -> MutableMapping[str, Token | MutableSequence[Token]]:
         values = {t.value for t in inputs.values()}
         if len(values) > 1:
             raise WorkflowExecutionException(
@@ -242,14 +242,14 @@ class FirstNonNullTransformer(OneToOneTransformer):
 
     async def transform(
         self, inputs: MutableMapping[str, Token]
-    ) -> MutableMapping[str, Token]:
+    ) -> MutableMapping[str, Token | MutableSequence[Token]]:
         return {self.get_output_name(): self._transform(*next(iter(inputs.items())))}
 
 
 class ForwardTransformer(OneToOneTransformer):
     async def transform(
         self, inputs: MutableMapping[str, Token]
-    ) -> MutableMapping[str, Token]:
+    ) -> MutableMapping[str, Token | MutableSequence[Token]]:
         token = next(iter(inputs.values()))
         return {self.get_output_name(): token.update(token.value)}
 
@@ -270,7 +270,7 @@ class ListToElementTransformer(OneToOneTransformer):
 
     async def transform(
         self, inputs: MutableMapping[str, Token]
-    ) -> MutableMapping[str, Token]:
+    ) -> MutableMapping[str, Token | MutableSequence[Token]]:
         return {self.get_output_name(): self._transform(next(iter(inputs.values())))}
 
 
@@ -297,7 +297,7 @@ class OnlyNonNullTransformer(OneToOneTransformer):
 
     async def transform(
         self, inputs: MutableMapping[str, Token]
-    ) -> MutableMapping[str, Token]:
+    ) -> MutableMapping[str, Token | MutableSequence[Token]]:
         return {self.get_output_name(): self._transform(*next(iter(inputs.items())))}
 
 
@@ -355,7 +355,7 @@ class ValueFromTransformer(ManyToOneTransformer):
 
     async def transform(
         self, inputs: MutableMapping[str, Token]
-    ) -> MutableMapping[str, Token]:
+    ) -> MutableMapping[str, Token | MutableSequence[Token]]:
         output_name = self.get_output_name()
         if output_name in inputs:
             inputs = {
@@ -408,7 +408,7 @@ class LoopValueFromTransformer(ValueFromTransformer):
 
     async def transform(
         self, inputs: MutableMapping[str, Token]
-    ) -> MutableMapping[str, Token]:
+    ) -> MutableMapping[str, Token | MutableSequence[Token]]:
         loop_inputs = {k: inputs[k + "-in"] for k in self.loop_input_ports}
         self_token = (
             await self.processor.process(

--- a/streamflow/cwl/transformer.py
+++ b/streamflow/cwl/transformer.py
@@ -42,7 +42,7 @@ class CartesianProductSizeTransformer(ManyToOneTransformer):
         for port_name, token in inputs.items():
             if not isinstance(token.value, int) or token.value < 0:
                 raise WorkflowExecutionException(
-                    f"Step {self.name} got {token.value} on port {port_name}, but it must be a positive integer"
+                    f"Step {self.name} received {token.value} on port {port_name}, but it must be a positive integer"
                 )
         tag = get_tag(inputs.values())
         value = functools.reduce(
@@ -84,12 +84,12 @@ class CloneListTokenTransformer(ManyToOneTransformer):
             or inputs["__size__"].value < 0
         ):
             raise WorkflowExecutionException(
-                f"Step {self.name} got {inputs['__size__'].value} in the size port, but it must be a positive integer"
+                f"Step {self.name} received {inputs['__size__'].value} in the size port, but it must be a positive integer"
             )
         list_token = inputs[self._get_input_port_name()]
         if not isinstance(list_token, ListToken):
             raise WorkflowExecutionException(
-                f"Step {self.name} can clone only ListToken value, instead got a {type(list_token)}"
+                f"Step {self.name} can clone only ListToken objects, but it received a {type(list_token)}"
             )
         return {
             self.get_output_name(): ListToken(
@@ -223,11 +223,11 @@ class DotProductSizeTransformer(ManyToOneTransformer):
         values = {t.value for t in inputs.values()}
         if len(values) > 1:
             raise WorkflowExecutionException(
-                f"Step {self.name} got {values}, but they must be equal"
+                f"Step {self.name} received {values}, but they must be equal"
             )
         if not isinstance(next(iter(values)), int) or next(iter(values)) < 0:
             raise WorkflowExecutionException(
-                f"Step {self.name} got {values}, but they must be positive integers"
+                f"Step {self.name} received {next(iter(values))}, but it must be a positive integer"
             )
         return {self.get_output_name(): next(iter(inputs.values()))}
 

--- a/streamflow/cwl/transformer.py
+++ b/streamflow/cwl/transformer.py
@@ -429,9 +429,16 @@ class DuplicateTransformer(ManyToOneTransformer):
                 f"Values must be an positive integer. Got {inputs['__size__'].value}"
             )
         ancestor_token = inputs[next(k for k in inputs.keys() if k != "__size__")]
+        if isinstance(ancestor_token, ListToken):
+            tokens = ancestor_token.value
+        else:
+            tokens = [ancestor_token]
         return {
-            f"{self.get_output_name()};{i}": ancestor_token.retag(
-                f"{ancestor_token.tag}.{i}"
+            self.get_output_name(): ListToken(
+                [
+                    token.retag(f"{token.tag}.{i}")
+                    for token in tokens
+                    for i in range(inputs["__size__"].value)
+                ]
             )
-            for i in range(inputs["__size__"].value)
         }

--- a/streamflow/cwl/transformer.py
+++ b/streamflow/cwl/transformer.py
@@ -412,7 +412,7 @@ class CloneListTokenTransformer(ManyToOneTransformer):
     async def transform(
         self, inputs: MutableMapping[str, Token]
     ) -> MutableMapping[str, Token]:
-        # inputs has only two key: __size__ and a port_name
+        # inputs has only two keys: __size__ and a port_name
         if (
             not isinstance(inputs["__size__"].value, int)
             or inputs["__size__"].value < 0
@@ -420,7 +420,7 @@ class CloneListTokenTransformer(ManyToOneTransformer):
             raise WorkflowExecutionException(
                 f"Step {self.name} got {inputs['__size__'].value} in the size port, but it must be a positive integer"
             )
-        list_token = inputs[next(k for k in inputs.keys() if k != "__size__")]
+        list_token = inputs[self._get_input_port_name()]
         if not isinstance(list_token, ListToken):
             raise WorkflowExecutionException(
                 f"Step {self.name} can duplicate only ListToken value, instead got a {type(list_token)}"

--- a/streamflow/cwl/transformer.py
+++ b/streamflow/cwl/transformer.py
@@ -56,7 +56,7 @@ class CloneTransformer(ManyToOneTransformer):
         super().__init__(name, workflow)
         self.add_input_port("__size__", size_port)
 
-    def _get_input_port_name(self) -> str:
+    def get_input_port_name(self) -> str:
         return next(n for n in self.input_ports if n != "__size__")
 
     def add_input_port(self, name: str, port: Port) -> None:
@@ -69,7 +69,7 @@ class CloneTransformer(ManyToOneTransformer):
 
     def get_input_port(self, name: str | None = None) -> Port:
         return super().get_input_port(
-            self._get_input_port_name() if name is None else name
+            self.get_input_port_name() if name is None else name
         )
 
     def get_size_port(self):
@@ -86,7 +86,7 @@ class CloneTransformer(ManyToOneTransformer):
             raise WorkflowExecutionException(
                 f"Step {self.name} received {inputs['__size__'].value} in the size port, but it must be a positive integer"
             )
-        token = inputs[self._get_input_port_name()]
+        token = inputs[self.get_input_port_name()]
         return {
             self.get_output_name(): [
                 token.retag(f"{token.tag}.{i}") for i in range(inputs["__size__"].value)

--- a/streamflow/cwl/transformer.py
+++ b/streamflow/cwl/transformer.py
@@ -52,12 +52,12 @@ class CartesianProductSizeTransformer(ManyToOneTransformer):
 
 
 class CloneTransformer(ManyToOneTransformer):
-    def __init__(self, name: str, workflow: Workflow, size_port: Port):
+    def __init__(self, name: str, workflow: Workflow, replicas_port: Port):
         super().__init__(name, workflow)
-        self.add_input_port("__size__", size_port)
+        self.add_input_port("__replicas__", replicas_port)
 
     def get_input_port_name(self) -> str:
-        return next(n for n in self.input_ports if n != "__size__")
+        return next(n for n in self.input_ports if n != "__replicas__")
 
     def add_input_port(self, name: str, port: Port) -> None:
         if len(self.input_ports) < 2 or name in self.input_ports:
@@ -72,15 +72,15 @@ class CloneTransformer(ManyToOneTransformer):
             self.get_input_port_name() if name is None else name
         )
 
-    def get_size_port(self):
-        return self.get_input_port("__size__")
+    def get_replicas_port(self):
+        return self.get_input_port("__replicas__")
 
     async def transform(
         self, inputs: MutableMapping[str, Token]
-    ) -> MutableMapping[str, MutableSequence[Token]]:
+    ) -> MutableMapping[str, Token | MutableSequence[Token]]:
         # inputs has only two keys: __size__ and a port_name
         input_token = inputs[self.get_input_port_name()]
-        size_token = inputs["__size__"]
+        size_token = inputs["__replicas__"]
         if not isinstance(size_token.value, int) or size_token.value < 0:
             raise WorkflowExecutionException(
                 f"Step {self.name} received {size_token.value} in the size port, but it must be a positive integer"

--- a/streamflow/cwl/transformer.py
+++ b/streamflow/cwl/transformer.py
@@ -87,7 +87,7 @@ class CloneTransformer(ManyToOneTransformer):
             )
         if size_token.tag != input_token.tag:
             raise WorkflowExecutionException(
-                f"Step {self.name} received {inputs['__size__'].tag} on size port and {input_token.tag} on {self.get_input_port_name()} port"
+                f"Step {self.name} received {size_token.tag} on size port and {input_token.tag} on {self.get_input_port_name()} port"
             )
         return {
             self.get_output_name(): [

--- a/streamflow/cwl/transformer.py
+++ b/streamflow/cwl/transformer.py
@@ -83,11 +83,11 @@ class CloneTransformer(ManyToOneTransformer):
         size_token = inputs["__replicas__"]
         if not isinstance(size_token.value, int) or size_token.value < 0:
             raise WorkflowExecutionException(
-                f"Step {self.name} received {size_token.value} in the size port, but it must be a positive integer"
+                f"Step {self.name} received {size_token.value} on replicas port, but it must be a positive integer"
             )
         if size_token.tag != input_token.tag:
             raise WorkflowExecutionException(
-                f"Step {self.name} received {size_token.tag} on size port and {input_token.tag} on {self.get_input_port_name()} port"
+                f"Step {self.name} received {size_token.tag} on replicas port and {input_token.tag} on {self.get_input_port_name()} port"
             )
         return {
             self.get_output_name(): [
@@ -218,7 +218,7 @@ class DotProductSizeTransformer(ManyToOneTransformer):
         values = {t.value for t in inputs.values()}
         if len(values) > 1:
             raise WorkflowExecutionException(
-                f"Step {self.name} received {values}, but they must be equal"
+                f"Step {self.name} received {values}, but all sizes must be equal"
             )
         input_token = next(iter(inputs.values()))
         if not isinstance(input_token.value, int) or input_token.value < 0:

--- a/streamflow/cwl/transformer.py
+++ b/streamflow/cwl/transformer.py
@@ -87,6 +87,10 @@ class CloneTransformer(ManyToOneTransformer):
                 f"Step {self.name} received {inputs['__size__'].value} in the size port, but it must be a positive integer"
             )
         token = inputs[self.get_input_port_name()]
+        if inputs["__size__"].tag != token.tag:
+            raise WorkflowExecutionException(
+                f"Step {self.name} received {inputs['__size__'].tag} on size port and {token.tag} on {self.get_input_port_name()} port"
+            )
         return {
             self.get_output_name(): [
                 token.retag(f"{token.tag}.{i}") for i in range(inputs["__size__"].value)

--- a/streamflow/cwl/transformer.py
+++ b/streamflow/cwl/transformer.py
@@ -72,13 +72,13 @@ class CloneTransformer(ManyToOneTransformer):
             self.get_input_port_name() if name is None else name
         )
 
-    def get_replicas_port(self):
+    def get_replicas_port(self) -> Port:
         return self.get_input_port("__replicas__")
 
     async def transform(
         self, inputs: MutableMapping[str, Token]
     ) -> MutableMapping[str, Token | MutableSequence[Token]]:
-        # inputs has only two keys: __size__ and a port_name
+        # inputs has only two keys: __replicas__ and a port_name
         input_token = inputs[self.get_input_port_name()]
         size_token = inputs["__replicas__"]
         if not isinstance(size_token.value, int) or size_token.value < 0:

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -2132,15 +2132,12 @@ class CWLTranslator:
                     gather_steps = []
                     internal_output_ports[global_name] = workflow.create_port()
                     gather_input_port = internal_output_ports[global_name]
-                    for i, scatter_input in enumerate(scatter_inputs):
+                    for scatter_input in scatter_inputs:
                         scatter_port_name = posixpath.relpath(scatter_input, step_name)
-                        reverse_scatter_step = cast(
-                            ScatterStep,
-                            workflow.steps[
-                                scatter_inputs[len(scatter_inputs) - i - 1] + "-scatter"
-                            ],
+                        scatter_step = cast(
+                            ScatterStep, workflow.steps[scatter_input + "-scatter"]
                         )
-                        size_port = reverse_scatter_step.get_size_port()
+                        size_port = scatter_step.get_size_port()
                         for ext_scatter_input in scatter_inputs[::-1]:
                             if ext_scatter_input == scatter_input:
                                 break
@@ -2154,10 +2151,10 @@ class CWLTranslator:
                             scatter_transformer = workflow.create_step(
                                 cls=CloneTransformer,
                                 name=f"{step_name}-{scatter_port_name}-{ext_scatter_port_name}-scatter-size-transformer",
-                                size_port=ext_scatter_step.get_size_port(),
+                                size_port=scatter_step.get_size_port(),
                             )
                             scatter_transformer.add_input_port(
-                                scatter_port_name, size_port
+                                scatter_port_name, ext_scatter_step.get_size_port()
                             )
                             size_port = workflow.create_port()
                             scatter_transformer.add_output_port("__size__", size_port)

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -523,12 +523,14 @@ def _create_nested_size_tag(
             new_replicas_port[output_port_name] = output_port
         else:
             new_size_ports[output_port_name] = output_port
-    return _create_nested_size_tag(
+    size_ports_list = _create_nested_size_tag(
         new_size_ports,
         new_replicas_port,
         step_name,
         workflow,
-    ) + [next(iter(replicas_port.values()))]
+    )
+    size_ports_list.append(next(iter(replicas_port.values())))
+    return size_ports_list
 
 
 def _create_residual_combinator(

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -2134,10 +2134,13 @@ class CWLTranslator:
                     gather_input_port = internal_output_ports[global_name]
                     for i, scatter_input in enumerate(scatter_inputs):
                         scatter_port_name = posixpath.relpath(scatter_input, step_name)
-                        scatter_step = cast(
-                            ScatterStep, workflow.steps[scatter_inputs[len(scatter_inputs) - i - 1] + "-scatter"]
+                        reverse_scatter_step = cast(
+                            ScatterStep,
+                            workflow.steps[
+                                scatter_inputs[len(scatter_inputs) - i - 1] + "-scatter"
+                            ],
                         )
-                        size_port = scatter_step.get_size_port()
+                        size_port = reverse_scatter_step.get_size_port()
                         for ext_scatter_input in scatter_inputs[::-1]:
                             if ext_scatter_input == scatter_input:
                                 break

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -91,6 +91,7 @@ from streamflow.cwl.transformer import (
     DotProductSizeTransformer,
     CartesianProductSizeTransformer,
     CloneListTokenTransformer,
+    ListTokenWrapTransformer,
 )
 from streamflow.cwl.utils import LoadListing, SecondaryFile, resolve_dependencies
 from streamflow.deployment.utils import get_binding_config
@@ -2140,7 +2141,15 @@ class CWLTranslator:
                                 scatter_inputs[len(scatter_inputs) - i - 1] + "-scatter"
                             ],
                         )
-                        size_port = reverse_scatter_step.get_size_port()
+                        wrap_transformer = workflow.create_step(
+                            ListTokenWrapTransformer,
+                            name=scatter_input + "-wrap-transformer",
+                        )
+                        wrap_transformer.add_input_port(
+                            scatter_port_name, reverse_scatter_step.get_size_port()
+                        )
+                        size_port = workflow.create_port()
+                        wrap_transformer.add_output_port(scatter_port_name, size_port)
                         for ext_scatter_input in scatter_inputs[::-1]:
                             if ext_scatter_input == scatter_input:
                                 break

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -2135,17 +2135,19 @@ class CWLTranslator:
                     for i, scatter_input in enumerate(scatter_inputs):
                         scatter_port_name = posixpath.relpath(scatter_input, step_name)
                         scatter_step = cast(
-                            ScatterStep, workflow.steps[scatter_input + "-scatter"]
+                            ScatterStep, workflow.steps[scatter_inputs[len(scatter_inputs) - i - 1] + "-scatter"]
                         )
                         size_port = scatter_step.get_size_port()
-                        for j in range(i + 1, len(scatter_inputs)):
+                        for ext_scatter_input in scatter_inputs[::-1]:
+                            if ext_scatter_input == scatter_input:
+                                break
                             scatter_transformer = workflow.create_step(
                                 cls=DuplicateTransformer,
-                                name=f"{step_name}-{scatter_port_name}-{posixpath.relpath(scatter_inputs[j], step_name)}-scatter-size-transformer",
+                                name=f"{step_name}-{scatter_port_name}-{posixpath.relpath(ext_scatter_input, step_name)}-scatter-size-transformer",
                             )
                             ext_scatter_step = cast(
                                 ScatterStep,
-                                workflow.steps[scatter_inputs[j] + "-scatter"],
+                                workflow.steps[ext_scatter_input + "-scatter"],
                             )
                             scatter_transformer.add_size_port(
                                 ext_scatter_step.get_size_port()

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -2112,14 +2112,15 @@ class CWLTranslator:
                     gather_input_port = internal_output_ports[global_name]
                     for scatter_input in scatter_inputs:
                         scatter_port_name = posixpath.relpath(scatter_input, step_name)
-                        gather_steps.append(
-                            workflow.create_step(
-                                cls=GatherStep,
-                                name=global_name + "-gather-" + scatter_port_name,
-                            )
+                        scatter_step = cast(ScatterStep, workflow.steps[scatter_input + "-scatter"])
+                        gather_step = workflow.create_step(
+                            cls=GatherStep,
+                            name=global_name + "-gather-" + scatter_port_name,
+                            size_port=scatter_step.get_size_port()
                         )
-                        gather_steps[-1].add_input_port(port_name, gather_input_port)
-                        gather_steps[-1].add_output_port(
+                        gather_steps.append(gather_step)
+                        gather_step.add_input_port(port_name, gather_input_port)
+                        gather_step.add_output_port(
                             name=port_name,
                             port=(
                                 external_output_ports[global_name]
@@ -2132,6 +2133,7 @@ class CWLTranslator:
                     gather_step = workflow.create_step(
                         cls=GatherStep,
                         name=global_name + "-gather",
+                        size_port=cast(ScatterStep, workflow.steps[scatter_inputs[0] + "-scatter"]).get_size_port(),
                         depth=1
                         if scatter_method == "dotproduct"
                         else len(scatter_inputs),

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -2175,8 +2175,8 @@ class CWLTranslator:
                             ScatterStep,
                             workflow.steps[ext_scatter_input + "-scatter"],
                         )
-                        port_name = ext_scatter_step.get_input_port_name()
-                        ext_port_sizes[port_name] = ext_scatter_step.get_size_port()
+                        ext_port_name = ext_scatter_step.get_input_port_name()
+                        ext_port_sizes[ext_port_name] = ext_scatter_step.get_size_port()
                     size_ports_list = _create_nested_size_tag(
                         ext_port_sizes,
                         {

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -97,7 +97,7 @@ from streamflow.workflow.combinator import (
     DotProductCombinator,
     LoopCombinator,
     LoopTerminationCombinator,
-    ProductCombinator,
+    ProductCombinator
 )
 from streamflow.workflow.step import (
     Combinator,

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -2063,7 +2063,7 @@ class CWLTranslator:
                 scatter_step.add_input_port(port_name, input_ports[global_name])
                 input_ports[global_name] = workflow.create_port()
                 scatter_step.add_output_port(port_name, input_ports[global_name])
-                size_ports.append(scatter_step.get_size_port())
+                size_port = scatter_step.get_size_port()
             # If there is a scatter combinator, create a combinator step and add all inputs to it
             if scatter_combinator:
                 combinator_step = workflow.create_step(
@@ -2079,9 +2079,9 @@ class CWLTranslator:
                 if scatter_transformer:
                     for global_name in scatter_inputs:
                         port_name = posixpath.relpath(global_name, step_name)
-                        scatter_transformer.add_input_port(port_name, size_ports[-1])
-                    size_ports.append(workflow.create_port())
-                    scatter_transformer.add_output_port("__size__", size_ports[-1])
+                        scatter_transformer.add_input_port(port_name, size_port)
+                    size_port = workflow.create_port()
+                    scatter_transformer.add_output_port("__size__", size_port)
 
         # Process inputs again to attach ports to transformers
         input_ports = _process_transformers(
@@ -2153,7 +2153,7 @@ class CWLTranslator:
                     gather_step = workflow.create_step(
                         cls=GatherStep,
                         name=global_name + "-gather",
-                        size_port=size_ports[-1],
+                        size_port=size_port,
                         depth=1
                         if scatter_method == "dotproduct"
                         else len(scatter_inputs),

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -2112,11 +2112,13 @@ class CWLTranslator:
                     gather_input_port = internal_output_ports[global_name]
                     for scatter_input in scatter_inputs:
                         scatter_port_name = posixpath.relpath(scatter_input, step_name)
-                        scatter_step = cast(ScatterStep, workflow.steps[scatter_input + "-scatter"])
+                        scatter_step = cast(
+                            ScatterStep, workflow.steps[scatter_input + "-scatter"]
+                        )
                         gather_step = workflow.create_step(
                             cls=GatherStep,
                             name=global_name + "-gather-" + scatter_port_name,
-                            size_port=scatter_step.get_size_port()
+                            size_port=scatter_step.get_size_port(),
                         )
                         gather_steps.append(gather_step)
                         gather_step.add_input_port(port_name, gather_input_port)
@@ -2133,7 +2135,9 @@ class CWLTranslator:
                     gather_step = workflow.create_step(
                         cls=GatherStep,
                         name=global_name + "-gather",
-                        size_port=cast(ScatterStep, workflow.steps[scatter_inputs[0] + "-scatter"]).get_size_port(),
+                        size_port=cast(
+                            ScatterStep, workflow.steps[scatter_inputs[0] + "-scatter"]
+                        ).get_size_port(),
                         depth=1
                         if scatter_method == "dotproduct"
                         else len(scatter_inputs),

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -502,9 +502,9 @@ def _create_list_merger(
 def _create_nested_size_tag(
     size_ports: MutableMapping[str, Port],
     replicas_port: MutableMapping[str, Port],
-    step_name,
-    workflow,
-):
+    step_name: str,
+    workflow: Workflow,
+) -> MutableSequence[Port]:
     if len(size_ports) == 0:
         return [next(iter(replicas_port.values()))]
     new_replicas_port = {}

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -90,8 +90,7 @@ from streamflow.cwl.transformer import (
     ValueFromTransformer,
     DotProductSizeTransformer,
     CartesianProductSizeTransformer,
-    CloneListTokenTransformer,
-    ListTokenWrapTransformer,
+    CloneTransformer,
 )
 from streamflow.cwl.utils import LoadListing, SecondaryFile, resolve_dependencies
 from streamflow.deployment.utils import get_binding_config
@@ -2141,15 +2140,7 @@ class CWLTranslator:
                                 scatter_inputs[len(scatter_inputs) - i - 1] + "-scatter"
                             ],
                         )
-                        wrap_transformer = workflow.create_step(
-                            ListTokenWrapTransformer,
-                            name=scatter_input + "-wrap-transformer",
-                        )
-                        wrap_transformer.add_input_port(
-                            scatter_port_name, reverse_scatter_step.get_size_port()
-                        )
-                        size_port = workflow.create_port()
-                        wrap_transformer.add_output_port(scatter_port_name, size_port)
+                        size_port = reverse_scatter_step.get_size_port()
                         for ext_scatter_input in scatter_inputs[::-1]:
                             if ext_scatter_input == scatter_input:
                                 break
@@ -2161,7 +2152,7 @@ class CWLTranslator:
                                 ext_scatter_input, step_name
                             )
                             scatter_transformer = workflow.create_step(
-                                cls=CloneListTokenTransformer,
+                                cls=CloneTransformer,
                                 name=f"{step_name}-{scatter_port_name}-{ext_scatter_port_name}-scatter-size-transformer",
                                 size_port=ext_scatter_step.get_size_port(),
                             )

--- a/streamflow/workflow/combinator.py
+++ b/streamflow/workflow/combinator.py
@@ -299,24 +299,20 @@ class ProductCombinator(Combinator):
     ) -> AsyncIterable[MutableMapping[str, Token]]:
         # If port is associated to an inner combinator, call it and put schemas in their related list
         if c := self.get_combinator(port_name):
-            yield cast(
-                AsyncIterable,
-                c.combine(port_name, token),
-            )
-            # async for schema in cast(
-            #         AsyncIterable,
-            #         c.combine(port_name, token),
-            # ):
-            #     self._add_to_list(schema, c.name)
-            #     async for product in self._product():
-            #         yield product
+            async for schema in cast(
+                    AsyncIterable,
+                    c.combine(port_name, token),
+            ):
+                self._add_to_list(schema, c.name)
+                async for product in self._product():
+                    yield product
         # If port is associated directly with the current combinator, put the token in the list
         elif port_name in self.items:
             self._add_to_list(token, port_name)
             async for product in self._product():
                 yield product
-        # Otherwise throw Exception
-        else:
-            raise WorkflowExecutionException(
-                f"No item to combine for token '{port_name}'."
-            )
+        # # Otherwise throw Exception
+        # else:
+        #     raise WorkflowExecutionException(
+        #         f"No item to combine for token '{port_name}'."
+        #     )

--- a/streamflow/workflow/combinator.py
+++ b/streamflow/workflow/combinator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import functools
 from collections import deque
 from typing import Any, AsyncIterable, MutableMapping, MutableSequence, cast
 
@@ -9,7 +8,6 @@ from streamflow.core.context import StreamFlowContext
 from streamflow.core.exception import WorkflowExecutionException
 from streamflow.core.persistence import DatabaseLoadingContext
 from streamflow.core.workflow import Token, Workflow
-from streamflow.log_handler import logger
 from streamflow.workflow.step import Combinator
 from streamflow.workflow.token import IterationTerminationToken
 
@@ -234,85 +232,3 @@ class LoopTerminationCombinator(DotProductCombinator):
             **await super()._save_additional_params(context),
             **{"output_items": self.output_items},
         }
-
-
-class ProductCombinator(Combinator):
-    def __init__(self, name: str, workflow: Workflow, is_nested: bool = False):
-        super().__init__(name, workflow)
-        self.size_map: MutableMapping[str, int] = {}
-        self.token_values = {}
-        self._is_nested = is_nested
-
-    async def _product(self) -> AsyncIterable[MutableMapping[str, Token]]:
-        # Check if some complete input sets are available
-        for tag in list(self.token_values):
-            if len(self.token_values[tag]) == len(self.items):
-                num_items = min(len(i) for i in self.token_values[tag].values())
-                for _ in range(num_items):
-                    # Return the relative combination schema
-                    schema = {}
-                    for key, elements in self.token_values[tag].items():
-                        element = elements.pop()
-                        if key in self.combinators:
-                            schema = {**schema, **element}
-                        else:
-                            schema[key] = {
-                                "token": element,
-                                "input_ids": [element.persistent_id],
-                            }
-                    tokens = [t["token"] for t in schema.values()]
-                    tag = utils.get_tag(tokens)
-                    if self._is_nested:
-                        res = {
-                            k: {
-                                "token": Token(
-                                    functools.reduce(
-                                        lambda a, b: a * b, (t.value for t in tokens)
-                                    ),
-                                    tag=tag + f".{i}",
-                                ),
-                                "input_ids": [t.persistent_id for t in tokens],
-                            }
-                            for i, k in enumerate(schema.keys())
-                        }
-                    else:
-                        res = {
-                            "__size__": {
-                                "token": Token(
-                                    functools.reduce(
-                                        lambda a, b: a * b, (t.value for t in tokens)
-                                    ),
-                                    tag=tag,
-                                ),
-                                "input_ids": [t.persistent_id for t in tokens],
-                            }
-                        }
-                    for k, token in res.items():
-                        t = token["token"]
-                        logger.debug(
-                            f"Generated token {t.tag} with value {t.value} on port {k}"
-                        )
-                    yield res
-
-    async def combine(
-        self, port_name: str, token: Token
-    ) -> AsyncIterable[MutableMapping[str, Token]]:
-        # If port is associated to an inner combinator, call it and put schemas in their related list
-        if c := self.get_combinator(port_name):
-            async for schema in cast(
-                    AsyncIterable,
-                    c.combine(port_name, token),
-            ):
-                self._add_to_list(schema, c.name)
-                async for product in self._product():
-                    yield product
-        # If port is associated directly with the current combinator, put the token in the list
-        elif port_name in self.items:
-            self._add_to_list(token, port_name)
-            async for product in self._product():
-                yield product
-        # # Otherwise throw Exception
-        # else:
-        #     raise WorkflowExecutionException(
-        #         f"No item to combine for token '{port_name}'."
-        #     )

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -958,6 +958,7 @@ class GatherStep(BaseStep):
             tasks = unfinished
         # Gather all the token when the size is unknown
         for key in (k for k in self.token_map.keys() if k not in key_completed):
+            logger.debug(f"Step {self.name} forces gather on key {key}")
             await self._gather(key)
         # Terminate step
         await self.terminate(

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -1589,10 +1589,6 @@ class ScatterStep(BaseStep):
             Status.SKIPPED if output_port.empty() else Status.COMPLETED
         )
 
-    async def terminate(self, status: Status):
-        await super().terminate(status)
-        self.get_size_port().put(TerminationToken())
-
 
 class TransferStep(BaseStep, ABC):
     def __init__(self, name: str, workflow: Workflow, job_port: JobPort):

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -1498,6 +1498,9 @@ class ScatterStep(BaseStep):
         super().__init__(name, workflow)
         self.add_output_port("__size__", size_port or workflow.create_port())
 
+    def get_input_port_name(self):
+        return next(n for n in self.input_ports)
+
     def _get_output_port_name(self) -> str:
         return next(n for n in self.output_ports if n != "__size__")
 

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -933,11 +933,16 @@ class GatherStep(BaseStep):
                         )
                 else:
                     if task_name == "__size__":
-                        self.size_map[token.tag] = token.value
-                        port = size_port
-                        if len(self.token_map.setdefault(token.tag, [])) == token.value:
-                            await self._gather(token.tag)
-                            key_completed.add(token.tag)
+                        if isinstance(token, ListToken):
+                            sizes = token.value
+                        else:
+                            sizes = [token]
+                        for token in sizes:
+                            self.size_map[token.tag] = token.value
+                            port = size_port
+                            if len(self.token_map.setdefault(token.tag, [])) == token.value:
+                                await self._gather(token.tag)
+                                key_completed.add(token.tag)
                     else:
                         if logger.isEnabledFor(logging.DEBUG):
                             logger.debug(f"Step {self.name} received input {token.tag}")

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -916,7 +916,7 @@ class GatherStep(BaseStep):
                 input_port.get(posixpath.join(self.name, port_name)), name=port_name
             ),
         }
-        while True:
+        while tasks:
             finished, unfinished = await asyncio.wait(
                 tasks, return_when=asyncio.FIRST_COMPLETED
             )
@@ -953,8 +953,6 @@ class GatherStep(BaseStep):
                         )
                     )
             tasks = unfinished
-            if len(tasks) == 0:
-                break
         # Terminate step
         await self.terminate(
             Status.SKIPPED if self.get_output_port().empty() else Status.COMPLETED

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -1764,5 +1764,5 @@ class Transformer(BaseStep, ABC):
     @abstractmethod
     async def transform(
         self, inputs: MutableMapping[str, Token]
-    ) -> MutableMapping[str, Token]:
+    ) -> MutableMapping[str, Token | MutableSequence[Token]]:
         ...

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -834,7 +834,7 @@ class GatherStep(BaseStep):
         self.add_input_port("__size__", size_port)
 
     def _get_input_port_name(self):
-        return next((n for n in self.input_ports if n != "__size__"))
+        return next(n for n in self.input_ports if n != "__size__")
 
     async def _gather(self, key: str) -> None:
         output_port = self.get_output_port()
@@ -1488,10 +1488,10 @@ class ScheduleStep(BaseStep):
 class ScatterStep(BaseStep):
     def __init__(self, name: str, workflow: Workflow):
         super().__init__(name, workflow)
-        self.add_output_port("__size__", workflow.create_port(name="size_test"))
+        self.add_output_port("__size__", workflow.create_port())
 
     def _get_output_port_name(self):
-        return next((n for n in self.output_ports if n != "__size__"))
+        return next(n for n in self.output_ports if n != "__size__")
 
     async def _scatter(self, token: Token):
         if isinstance(token.value, Token):

--- a/tests/test_build_wf.py
+++ b/tests/test_build_wf.py
@@ -239,11 +239,11 @@ async def test_execute_step(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_gather_step(context: StreamFlowContext):
     """Test saving GatherStep on database and re-load it in a new Workflow"""
-    workflow = (await create_workflow(context, num_port=0))[0]
+    workflow, ports = await create_workflow(context, num_port=1)
     await _base_step_test_process(
         workflow,
         GatherStep,
-        {"name": utils.random_name() + "-gather", "depth": 1},
+        {"name": utils.random_name() + "-gather", "depth": 1, "size_port": ports[0]},
         context,
     )
 

--- a/tests/test_cwl_loop.py
+++ b/tests/test_cwl_loop.py
@@ -198,6 +198,7 @@ def test_loop_inside_scatter(capsys) -> None:
     captured = capsys.readouterr()
     assert json.loads(captured.out) == expected
 
+
 def test_scatter_inside_loop(capsys) -> None:
     """Test a loop workflow with inside a scatter step."""
     cwltool_version = cwltool.utils.versionstring().split(" ")[1]

--- a/tests/test_cwl_loop.py
+++ b/tests/test_cwl_loop.py
@@ -6,6 +6,8 @@ From https://github.com/common-workflow-language/cwltool/blob/6f0e1d941a61063828
 import json
 from typing import MutableMapping, MutableSequence
 
+import cwltool.utils
+import pytest
 from cwltool.tests.util import get_data
 
 from streamflow.cwl.runner import main
@@ -193,6 +195,20 @@ def test_loop_inside_scatter(capsys) -> None:
     ]
     main(params)
     expected = {"o1": [10, 10, 10, 10, 10]}
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == expected
+
+def test_scatter_inside_loop(capsys) -> None:
+    """Test a loop workflow with inside a scatter step."""
+    cwltool_version = cwltool.utils.versionstring().split(" ")[1]
+    if cwltool_version <= "3.1.20231207110929":
+        pytest.skip(f"Missing test in cwltool version used ({cwltool_version})")
+    params = [
+        get_data("tests/loop/scatter-inside-loop.cwl"),
+        get_data("tests/loop/loop-inside-scatter-job.yml"),
+    ]
+    main(params)
+    expected = {"o1": [10, 11, 12, 13, 14]}
     captured = capsys.readouterr()
     assert json.loads(captured.out) == expected
 

--- a/tests/test_cwl_loop.py
+++ b/tests/test_cwl_loop.py
@@ -6,8 +6,6 @@ From https://github.com/common-workflow-language/cwltool/blob/6f0e1d941a61063828
 import json
 from typing import MutableMapping, MutableSequence
 
-import cwltool.utils
-import pytest
 from cwltool.tests.util import get_data
 
 from streamflow.cwl.runner import main
@@ -201,9 +199,6 @@ def test_loop_inside_scatter(capsys) -> None:
 
 def test_scatter_inside_loop(capsys) -> None:
     """Test a loop workflow with inside a scatter step."""
-    cwltool_version = cwltool.utils.versionstring().split(" ")[1]
-    if cwltool_version <= "3.1.20231207110929":
-        pytest.skip(f"Missing test in cwltool version used ({cwltool_version})")
     params = [
         get_data("tests/loop/scatter-inside-loop.cwl"),
         get_data("tests/loop/loop-inside-scatter-job.yml"),

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -184,13 +184,14 @@ async def test_execute_step(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_gather_step(context: StreamFlowContext):
     """Test saving and loading GatherStep from database"""
-    workflow = Workflow(
-        context=context, type="cwl", name=utils.random_name(), config={}
-    )
+    workflow, ports = await create_workflow(context, num_port=1)
     await workflow.save(context)
 
     step = workflow.create_step(
-        cls=GatherStep, name=utils.random_name() + "-gather", depth=1
+        cls=GatherStep,
+        name=utils.random_name() + "-gather",
+        depth=1,
+        size_port=ports[0],
     )
     await save_load_and_test(step, context)
 

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -300,15 +300,20 @@ async def test_execute_step(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_gather_step(context: StreamFlowContext):
     """Test token provenance for GatherStep"""
-    workflow, (in_port, out_port) = await create_workflow(context)
-    token_list = [Token(i) for i in range(3)]
+    workflow, (in_port, out_port, size_port) = await create_workflow(
+        context, num_port=3
+    )
+    base_tag = "0"
+    token_list = [Token(i, tag=f"{base_tag}.{i}") for i in range(5)]
+    size_port.put(Token(len(token_list), tag=base_tag))
+    size_port.put(TerminationToken())
     await _general_test(
         context=context,
         workflow=workflow,
         in_port=in_port,
         out_port=out_port,
         step_cls=GatherStep,
-        kwargs_step={"name": utils.random_name() + "-gather"},
+        kwargs_step={"name": utils.random_name() + "-gather", "size_port": size_port},
         token_list=token_list,
     )
     assert len(out_port.token_list) == 2
@@ -318,6 +323,7 @@ async def test_gather_step(context: StreamFlowContext):
         context=context,
         expected_dependee=token_list,
     )
+    pass
 
 
 @pytest.mark.asyncio

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -323,7 +323,6 @@ async def test_gather_step(context: StreamFlowContext):
         context=context,
         expected_dependee=token_list,
     )
-    pass
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The CWL standard allows the execution of multiple instances of a step with different inputs; it is done using the `scatter` feature ([doc](https://www.commonwl.org/v1.0/Workflow.html#Scatter/gather)).
The `scatter` takes one or more lists and assigns the elements to multiple instances.

When there are two or more scatter inputs, combining them in different ways is possible.
There are three types of scatter methods: `dotproduct`, `flat_crossproduct` and `nested_crossproduct`.
With the scatter method, the number of inputs involved in the scatter, and how many elements have each input, it is possible to know how many elements we will have in the output.

# Current scatter implementation in StreamFlow
In StreamFlow, the scatter feature has three essential steps: `ScatterStep,` `CombinatorStep`, and `GatherStep.`
The number of these steps can change based on how many inputs are involved in the `scatter` and which method is used. 
In the base case with one scatter input, there are a single `ScatterStep` and a single `GatherStep`. 
With two or more scatter inputs, there are a `CombinatorStep`, one `ScatterStep` for each scatter input, and one `GatherStep` in the case of `dot_product` and `flat_crossproduct`, otherwise one `GatherStep` for each scatter input.

# Changes
We introduce in the `ScatterStep` a new output port called `__size__` where are put tokens with:
- value: the number of the elements in the scatter input list 
- tag: the same input tag.

Furthermore, we introduce a new input port in the `GatherStep` called `__size__` and add a new attribute called `self.size_map`. This attribute maps the tags with the number of elements expected.



## Single scatter input
In the case of a scatter on a single list in input, the `__size__` port of the `ScatterStep` is connected to the `__size__` port of the `GatherStep`.

## Multiple scatter inputs
### Dot product
In the case of `dot_product`, the scatter input lists must have the same lenght and in output the `scatter` gives a list with the same length.
We introduce a new class, called `DotProductSizeTransformer`, which extends the `ManyToOneTransformer` class. 
The `DotProductSizeTransformer` input ports are all the `__size__` port of the `ScatterStep` involved, and its output port is connected to the `__size__` port of the `GatherStep`.
It checks that all the input tokens have the same value and then puts a new token with that value in the output port and the same input tags.

### Flat crossproduct
This scatter method combines all the elements of the lists with the elements of the other lists.
The number of all the possible combinations is the product of the list lengths, which it is the number of elements in the output list.
We introduce a new class, called `CartesianProductSizeTransformer`, it is very similar to the `DotProductSizeTransformer` class. The difference is that it does check that the inputs have the same values. Moreover, it puts in output a token with the _product_ of the values and the same inputs tag.


### Nested crossproduct
Last but not least, the more complex case.
It is similar to the flat crossproduct, but in output it has a list of nested lists instead of a single (flat) list.
The order of the scatter input changes the result generated by the `CombinatorStep`.
Let consider a `scatter` with the `nested_crossproduct` method on two input lists.
```
in:
  in1: in1
  in2: in2
scatter: [in1, in2]
scatterMethod: nested_crossproduct
```
As we said, we will have two `ScatterStep` and two `GatherStep`.
The `GatherStep`s are executed as a pipeline; the first takes the outputs of the `ExecuteStep`, and the second takes the output of the first.
The gather operations are reversed from the input order, and each gather can have a different number of elements for each tag. 

In this case, with two scatter inputs, we know that the last gather will receive the same `__size__` of the first scatter input, so `in1`, and the first gather will receive the product of the `__size__` of the first and second scatter inputs.
However, we can not use simply the `CartesianProductSizeTransformer` because, with three or more scatter inputs, we have no information about how many elements each intermediate tag must be gathered.
It is necessary to generate the correct `__size__` token for each tag for each gather, so we introduce the `CloneTransformer` class, which extends the `ManyToOneTransformer` class.
The `CloneTransformer` class has two input ports: the port, which takes the tokens to clone, and the `__replicas__` port, which takes the size token of how many clones to create.
In the case with two scatter inputs, we use the `__size__` port of the first scatter input as `__replicas__`, and the `__size__` port of the second scatter input as the other input port.

With three or more scatter inputs, combining the intermediate level of the `CloneTransformer`s is necessary.
We combine the first `__size__` scatter input with all the other `__size__` scatter inputs, using it as `__replicas__`. 
So we create `scatter_input - 1` `CloneTransformer`s. Then, we combine the first `CloneTransformer` output as `__replicas__` with the other `CloneTransformer` outputs.
Finally, the `__size__` of the first scatter input and each `CloneTransformer` used to generate the next level are connected to the `__size__` of the `GatherStep` in reverse order.
[Here](https://datacloud.di.unito.it/index.php/apps/files_sharing/publicpreview/97xNy5ks95SmTf3?file=/&fileId=590383090&x=1920&y=1080&a=true&etag=b961159a480786fb416fc941b738fe20) an image of the structure with a nested crossproduct on three scatter inputs.
