### PR TITLE
Added `retries` and `retryDelay` parameters in the `SSHConnector` configuration

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -147,7 +147,7 @@ jobs:
           python -m pip install -r docs/requirements.txt
       - name: "Build documentation and check for consistency"
         env:
-          CHECKSUM: "3cecd445a73422c87ea1a37d014b3657e15d18cdf784fb4cc8466b2d05ae8230"
+          CHECKSUM: "aa8ffc58425dc72de707eb1d491845e7344dde62153dc1d0cf4d28456f764f27"
         run: |
           cd docs/
           HASH="$(make checksum | tail -n1)"

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -147,7 +147,7 @@ jobs:
           python -m pip install -r docs/requirements.txt
       - name: "Build documentation and check for consistency"
         env:
-          CHECKSUM: "aa8ffc58425dc72de707eb1d491845e7344dde62153dc1d0cf4d28456f764f27"
+          CHECKSUM: "1f5c98f122144af7a7f721831bce13df9ecb25a80dfbc098c76dd99c03dfd287"
         run: |
           cd docs/
           HASH="$(make checksum | tail -n1)"

--- a/streamflow/deployment/connector/schemas/ssh.json
+++ b/streamflow/deployment/connector/schemas/ssh.json
@@ -115,6 +115,16 @@
       "type": "string",
       "description": "Path to a file containing the password to use for authentication"
     },
+    "retry": {
+      "type": "integer",
+      "description": "Maximum number of attempts to connect before to fail",
+      "default": 3
+    },
+    "retryDelay": {
+      "type": "integer",
+      "description": "Sleep this amount of time before each retry to connect",
+      "default": 5
+    },
     "services": {
       "type": "object",
       "patternProperties": {

--- a/streamflow/deployment/connector/schemas/ssh.json
+++ b/streamflow/deployment/connector/schemas/ssh.json
@@ -115,14 +115,14 @@
       "type": "string",
       "description": "Path to a file containing the password to use for authentication"
     },
-    "retry": {
+    "retries": {
       "type": "integer",
-      "description": "Maximum number of attempts to connect before to fail",
+      "description": "Number of consecutive connection errors to consider the connection failed",
       "default": 3
     },
     "retryDelay": {
       "type": "integer",
-      "description": "Sleep this amount of time before each retry to connect",
+      "description": "Time (in seconds) to wait before retrying to connect",
       "default": 5
     },
     "services": {

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -10,7 +10,7 @@ from pathlib import PurePosixPath
 from typing import Any, MutableMapping, MutableSequence
 
 import asyncssh
-from asyncssh import ChannelOpenError
+from asyncssh import ChannelOpenError, ConnectionLost
 from cachetools import Cache, LRUCache
 from importlib_resources import files
 
@@ -56,7 +56,7 @@ class SSHContext:
                 self._connecting = True
                 try:
                     self._ssh_connection = await self._get_connection(self._config)
-                except ConnectionError as e:
+                except (ConnectionError, ConnectionLost) as e:
                     logger.exception(
                         f"Impossible to connect to {self._config.hostname}: {e}"
                     )

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -69,6 +69,9 @@ class SSHContext:
                             )
                             self.close()
                             raise
+                    except asyncssh.Error:
+                        self.close()
+                        raise
                     await asyncio.sleep(self._retry_delay)
                 self._connect_event.set()
             else:

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -10,7 +10,7 @@ from pathlib import PurePosixPath
 from typing import Any, MutableMapping, MutableSequence
 
 import asyncssh
-from asyncssh import ChannelOpenError, ConnectionLost
+from asyncssh import ChannelOpenError
 from cachetools import Cache, LRUCache
 from importlib_resources import files
 
@@ -62,7 +62,7 @@ class SSHContext:
                     try:
                         self._ssh_connection = await self._get_connection(self._config)
                         break
-                    except (ConnectionError, ConnectionLost) as e:
+                    except (ConnectionError, asyncssh.Error) as e:
                         if i == self._retry - 1:
                             logger.exception(
                                 f"Impossible to connect to {self._config.hostname}: {e}"


### PR DESCRIPTION
This commit adds two new configuration parameters to the `SSHConnector` class: `retries` and `retryDelay`. These parameters implement fault tolerance when a connection is created: `retries` attempts are performed with a `retryDelay` sleep between each consecutive attempt. 
Furthermore, the `ConnectionLost` exception from the `asyncssh` package is now captured, too.