### PR TITLE
Fixed provenance for the `size` tokens

### DIFF
--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -962,6 +962,9 @@ class GatherStep(BaseStep):
 
             # Update size_map with the current size
             self.size_map[key] = Token(value=len(self.token_map[key]), tag=key)
+            await self.size_map[key].save(
+                self.workflow.context, size_port.persistent_id
+            )
 
             await self._gather(key)
         # Terminate step

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -825,14 +825,18 @@ class GatherStep(BaseStep):
     def __init__(self, name: str, workflow: Workflow, size_port: Port, depth: int = 1):
         super().__init__(name, workflow)
         self.depth: int = depth
-        self.size_map: MutableMapping[str, int] = {}
+        self.size_map: MutableMapping[str, Token] = {}
         self.token_map: MutableMapping[str, MutableSequence[Token]] = {}
         self.add_input_port("__size__", size_port)
 
     def _get_input_port_name(self) -> str:
         return next(n for n in self.input_ports if n != "__size__")
 
-    async def _gather(self, key: str) -> None:
+    async def _gather(self, key: str, is_forced: bool = False) -> None:
+        input_tokens = []
+        input_tokens.extend(self.token_map[key])
+        if not is_forced:
+            input_tokens.append(self.size_map[key])
         output_port = self.get_output_port()
         output_port.put(
             await self._persist_token(
@@ -840,7 +844,7 @@ class GatherStep(BaseStep):
                     tag=key, value=sorted(self.token_map[key], key=lambda cur: cur.tag)
                 ),
                 port=output_port,
-                input_token_ids=_get_token_ids(self.token_map[key]),
+                input_token_ids=_get_token_ids(input_tokens),
             )
         )
 
@@ -929,7 +933,7 @@ class GatherStep(BaseStep):
                         )
                 else:
                     if task_name == "__size__":
-                        self.size_map[token.tag] = token.value
+                        self.size_map[token.tag] = token
                         port = size_port
                         if len(self.token_map.setdefault(token.tag, [])) == token.value:
                             await self._gather(token.tag)
@@ -940,9 +944,10 @@ class GatherStep(BaseStep):
                         key = ".".join(token.tag.split(".")[: -self.depth])
                         self.token_map.setdefault(key, []).append(token)
                         port = input_port
-                        if len(self.token_map.setdefault(key, [])) == self.size_map.get(
-                            key
-                        ):
+                        size_value = (
+                            self.size_map[key].value if key in self.size_map else None
+                        )
+                        if len(self.token_map.setdefault(key, [])) == size_value:
                             await self._gather(key)
                             keys_completed.add(key)
                     unfinished.add(
@@ -956,7 +961,7 @@ class GatherStep(BaseStep):
         for key in (k for k in self.token_map.keys() if k not in keys_completed):
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug(f"Step {self.name} forces gather on key {key}")
-            await self._gather(key)
+            await self._gather(key, is_forced=True)
         # Terminate step
         await self.terminate(
             Status.SKIPPED if self.get_output_port().empty() else Status.COMPLETED
@@ -1539,7 +1544,14 @@ class ScatterStep(BaseStep):
                     )
                 )
             size_token = Token(len(token.value), tag=token.tag)
-            self.get_size_port().put(size_token)
+            size_port = self.get_size_port()
+            size_port.put(
+                await self._persist_token(
+                    token=size_token,
+                    port=size_port,
+                    input_token_ids=_get_token_ids([token]),
+                )
+            )
         else:
             raise WorkflowDefinitionException("Scatter ports require iterable inputs")
 

--- a/tests/test_cwl_build_wf.py
+++ b/tests/test_cwl_build_wf.py
@@ -1,9 +1,11 @@
 import posixpath
+from typing import Type
 
 import pytest
 
 from streamflow.core import utils
 from streamflow.core.context import StreamFlowContext
+from streamflow.core.workflow import Step
 from streamflow.cwl.combinator import ListMergeCombinator
 from streamflow.cwl.processor import CWLTokenProcessor
 from streamflow.cwl.step import (
@@ -41,7 +43,7 @@ from tests.utils.workflow import create_workflow
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("step_cls", [CWLLoopOutputAllStep, CWLLoopOutputLastStep])
-async def test_cwl_loop_output(context: StreamFlowContext, step_cls):
+async def test_cwl_loop_output(context: StreamFlowContext, step_cls: Type[Step]):
     """Test saving CWLLoopOutputAllStep on database and re-load it in a new Workflow"""
     workflow = (await create_workflow(context, num_port=1))[0]
     await _base_step_test_process(
@@ -174,7 +176,9 @@ async def test_loop_value_from_transformer(context: StreamFlowContext):
     "transformer_cls",
     [AllNonNullTransformer, FirstNonNullTransformer, OnlyNonNullTransformer],
 )
-async def test_non_null_transformer(context: StreamFlowContext, transformer_cls):
+async def test_non_null_transformer(
+    context: StreamFlowContext, transformer_cls: Type[Step]
+):
     """Test saving All/First/Only NonNullTransformer on database and re-load it in a new Workflow"""
     workflow = (await create_workflow(context, num_port=1))[0]
     await _base_step_test_process(

--- a/tests/test_cwl_persistence.py
+++ b/tests/test_cwl_persistence.py
@@ -770,7 +770,7 @@ async def test_cwl_input_injector_step(context: StreamFlowContext):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("step_cls", [CWLLoopOutputAllStep, CWLLoopOutputLastStep])
-async def test_cwl_loop_output(context: StreamFlowContext, step_cls):
+async def test_cwl_loop_output(context: StreamFlowContext, step_cls: type[Step]):
     """Test saving and loading CWLLoopOutput from database"""
     workflow = Workflow(
         context=context, type="cwl", name=utils.random_name(), config={}

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -139,18 +139,20 @@ async def test_scatter_step(context: StreamFlowContext):
     """Test token provenance for ScatterStep"""
     workflow, (in_port, out_port) = await create_workflow(context)
     token_list = [ListToken([Token("a"), Token("b"), Token("c")])]
-    await _general_test(
-        context=context,
-        workflow=workflow,
-        in_port=in_port,
-        out_port=out_port,
-        step_cls=ScatterStep,
-        kwargs_step={"name": utils.random_name() + "-scatter"},
-        token_list=token_list,
+    step = cast(
+        ScatterStep,
+        await _general_test(
+            context=context,
+            workflow=workflow,
+            in_port=in_port,
+            out_port=out_port,
+            step_cls=ScatterStep,
+            kwargs_step={"name": utils.random_name() + "-scatter"},
+            token_list=token_list,
+        ),
     )
     assert len(out_port.token_list) == 4
 
-    step = cast(ScatterStep, next(iter(workflow.steps.values())))
     size_port = step.get_size_port()
     assert len(size_port.token_list) == 2
     assert isinstance(out_port.token_list[-1], TerminationToken)


### PR DESCRIPTION
This commit fixes the provenance for the size tokens introduced by PR #348. In particular, the size token was not saved as an output token of the `ScatterStep` as  an input token in the `GatherStep`.

Furthermore, provenance unit tests have been added for the  `DotProductSizeTransformer`, `CartesianProductSizeTransformer`, and `CloneTransformer` classes.