### PR TITLE
Changed propagation of failure termination

### DIFF
--- a/streamflow/recovery/failure_manager.py
+++ b/streamflow/recovery/failure_manager.py
@@ -271,9 +271,17 @@ class DummyFailureManager(FailureManager):
     async def handle_exception(
         self, job: Job, step: Step, exception: BaseException
     ) -> CommandOutput:
+        logger.warning(
+            f"Job {job.name} failure can not be recovered. Fault tolerance manager not enable"
+        )
         raise exception
 
     async def handle_failure(
         self, job: Job, step: Step, command_output: CommandOutput
     ) -> CommandOutput:
-        raise FailureHandlingException("Fault tolerance not implemented.")
+        logger.warning(
+            f"Job {job.name} failure can not be recovered. Fault tolerance manager not enable"
+        )
+        raise FailureHandlingException(
+            f"FAILED Job {job.name} with error:\n\t{command_output.value}"
+        )

--- a/streamflow/recovery/failure_manager.py
+++ b/streamflow/recovery/failure_manager.py
@@ -273,7 +273,7 @@ class DummyFailureManager(FailureManager):
     ) -> CommandOutput:
         if logger.isEnabledFor(logging.WARNING):
             logger.warning(
-                f"Job {job.name} failure can not be recovered. Fault tolerance manager not enable"
+                f"Job {job.name} failure can not be recovered. Failure manager is not enabled."
             )
         raise exception
 
@@ -282,7 +282,7 @@ class DummyFailureManager(FailureManager):
     ) -> CommandOutput:
         if logger.isEnabledFor(logging.WARNING):
             logger.warning(
-                f"Job {job.name} failure can not be recovered. Fault tolerance manager not enable"
+                f"Job {job.name} failure can not be recovered. Failure manager is not enabled."
             )
         raise FailureHandlingException(
             f"FAILED Job {job.name} with error:\n\t{command_output.value}"

--- a/streamflow/recovery/failure_manager.py
+++ b/streamflow/recovery/failure_manager.py
@@ -276,4 +276,4 @@ class DummyFailureManager(FailureManager):
     async def handle_failure(
         self, job: Job, step: Step, command_output: CommandOutput
     ) -> CommandOutput:
-        return command_output
+        raise FailureHandlingException("Fault tolerance not implemented.")

--- a/streamflow/recovery/failure_manager.py
+++ b/streamflow/recovery/failure_manager.py
@@ -271,17 +271,19 @@ class DummyFailureManager(FailureManager):
     async def handle_exception(
         self, job: Job, step: Step, exception: BaseException
     ) -> CommandOutput:
-        logger.warning(
-            f"Job {job.name} failure can not be recovered. Fault tolerance manager not enable"
-        )
+        if logger.isEnabledFor(logging.WARNING):
+            logger.warning(
+                f"Job {job.name} failure can not be recovered. Fault tolerance manager not enable"
+            )
         raise exception
 
     async def handle_failure(
         self, job: Job, step: Step, command_output: CommandOutput
     ) -> CommandOutput:
-        logger.warning(
-            f"Job {job.name} failure can not be recovered. Fault tolerance manager not enable"
-        )
+        if logger.isEnabledFor(logging.WARNING):
+            logger.warning(
+                f"Job {job.name} failure can not be recovered. Fault tolerance manager not enable"
+            )
         raise FailureHandlingException(
             f"FAILED Job {job.name} with error:\n\t{command_output.value}"
         )

--- a/streamflow/workflow/executor.py
+++ b/streamflow/workflow/executor.py
@@ -129,12 +129,9 @@ class StreamFlowExecutor(Executor):
                         name=port_name,
                     )
                 while not self.closed:
-                    output_tokens = await self._handle_exception(
-                        asyncio.create_task(
-                            self._wait_outputs(output_consumer, output_tokens)
-                        )
+                    output_tokens = await self._wait_outputs(
+                        output_consumer, output_tokens
                     )
-
             # Otherwise simply wait for all tasks to finish
             else:
                 await asyncio.gather(*self.executions)

--- a/streamflow/workflow/executor.py
+++ b/streamflow/workflow/executor.py
@@ -53,7 +53,6 @@ class StreamFlowExecutor(Executor):
             self.output_tasks.values(), return_when=asyncio.FIRST_COMPLETED
         )
         self.output_tasks = {t.get_name(): t for t in unfinished}
-        workflow_failed = False
         for task in finished:
             if task.cancelled():
                 continue
@@ -67,7 +66,7 @@ class StreamFlowExecutor(Executor):
                     self.closed = True
                     for t in unfinished:
                         t.cancel()
-                    workflow_failed = True
+                    return output_tokens
                 else:
                     self.received.append(task_name)
                     # When the last port terminates, the entire executor terminates
@@ -98,8 +97,6 @@ class StreamFlowExecutor(Executor):
                     name=port_name,
                 )
                 self.closed = False
-        if workflow_failed:
-            raise WorkflowExecutionException("Workflow failed")
         # Return output tokens
         return output_tokens
 

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -731,12 +731,9 @@ class ExecuteStep(BaseStep):
         # When receiving a CancelledError, mark the step as Cancelled
         except asyncio.CancelledError:
             command_output.status = Status.CANCELLED
-            # await self.terminate(command_output.status)
         # When receiving a FailureHandling exception, mark the step as Failed
         except FailureHandlingException:
-            # command_output.status = Status.FAILED
-            # await self.terminate(command_output.status)
-            pass
+            command_output.status = Status.FAILED
         # When receiving a generic exception, try to handle it
         except Exception as e:
             logger.exception(e)
@@ -751,7 +748,6 @@ class ExecuteStep(BaseStep):
                 if ie != e:
                     logger.exception(ie)
                 command_output.status = Status.FAILED
-                # await self.terminate(command_output.status)
         finally:
             # Notify completion to scheduler
             await self.workflow.context.scheduler.notify_status(

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -1155,6 +1155,8 @@ class LoopCombinatorStep(CombinatorStep):
                             logger.debug(
                                 f"Step {self.name} received termination token for port {task_name}"
                             )
+                        if token.value != Status.COMPLETED:
+                            self.iteration_termination_checklist.get(task_name).clear()
                         terminated.append(task_name)
                     # If an IterationTerminationToken is received, mark the corresponding iteration as terminated
                     elif check_iteration_termination(token):

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -645,18 +645,14 @@ class ExecuteStep(BaseStep):
                 job, command_output, connector
             )
         ) is not None:
+            job_token = get_job_token(
+                job.name, self.get_input_port("__job__").token_list
+            )
             output_port.put(
                 await self._persist_token(
                     token=token,
                     port=output_port,
-                    input_token_ids=_get_token_ids(
-                        list(job.inputs.values())
-                        + [
-                            get_job_token(
-                                job.name, self.get_input_port("__job__").token_list
-                            )
-                        ]
-                    ),
+                    input_token_ids=_get_token_ids((*job.inputs.values(), job_token)),
                 )
             )
 
@@ -723,8 +719,9 @@ class ExecuteStep(BaseStep):
             # await self.terminate(command_output.status)
         # When receiving a FailureHandling exception, mark the step as Failed
         except FailureHandlingException:
-            command_output.status = Status.FAILED
+            # command_output.status = Status.FAILED
             # await self.terminate(command_output.status)
+            pass
         # When receiving a generic exception, try to handle it
         except Exception as e:
             logger.exception(e)

--- a/streamflow/workflow/token.py
+++ b/streamflow/workflow/token.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from typing import Any, MutableMapping, MutableSequence
 
 from streamflow.core.context import StreamFlowContext
+from streamflow.core.exception import WorkflowExecutionException
 from streamflow.core.persistence import DatabaseLoadingContext
 from streamflow.core.workflow import Job, Token, Status
 
@@ -162,6 +163,10 @@ class TerminationToken(Token):
     __slots__ = ()
 
     def __init__(self, value: Any = Status.COMPLETED):
+        if not isinstance(value, Status):
+            raise WorkflowExecutionException(
+                f"Termination token received an invalid value type {type(value)}. Accepted only Status."
+            )
         super().__init__(value)
 
     def get_weight(self, context: StreamFlowContext):

--- a/streamflow/workflow/token.py
+++ b/streamflow/workflow/token.py
@@ -165,7 +165,7 @@ class TerminationToken(Token):
     def __init__(self, value: Any = Status.COMPLETED):
         if not isinstance(value, Status):
             raise WorkflowExecutionException(
-                f"Termination token received an invalid value type {type(value)}. Accepted only Status."
+                f"Termination token received an invalid value type {type(value)}: it should be of type `Status`."
             )
         super().__init__(value)
 

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -295,7 +295,7 @@ async def test_object_token(context: StreamFlowContext):
 
 @pytest.mark.asyncio
 async def test_termination_token(context: StreamFlowContext):
-    """Test saving and loading IterationTerminationToken from database"""
+    """Test saving and loading TerminationToken from database"""
     token = TerminationToken()
     await save_load_and_test(token, context)
 


### PR DESCRIPTION
This commit changes how StreamFlow propagates the failure termination into the workflow steps.

# Before this commit
The steps propagate SKIPPED status because the ports are empties.


# New `TerminationToken` value 
We use the 'TerminationToken' value, which was not used, to propagate the `Step` exit status. This way, the following steps know if they can continue the execution or terminate immediately.

The possible step exit statuses are: `CANCELLED`, `FAILED`, `COMPLETED` and `SKIPPED`.

The step takes the exit status based on the exit status of all its jobs, combining them.
In general, the job statuses are unified. `FAILED` and `CANCELLED` absorbs all the other statuses, instead `COMPLETED` absorbs `SKIPPED`.
Some examples:
- [ `COMPLETED`, `COMPLETED`, `COMPLETED`, `COMPLETED` ] => `COMPLETED`
- [ `COMPLETED`, `FAILED`, `COMPLETED`, `CANCELLED` ] => `FAILED`
- [ `CANCELLED`, `FAILED`, `COMPLETED`, `COMPLETED` ] => `CANCELLED`
- [ `COMPLETED`, `SKIPPED`, `COMPLETED`, `SKIPPED` ] => `COMPLETED`
- [ `SKIPPED`, `SKIPPED`, `SKIPPED`, `SKIPPED` ] => `SKIPPED`


# Forced Termination
First, a digression about how StreamFlow works. StreamFlow executes its entites as individual tasks, using the `asyncio.Task` corountine. So each manager and each `Step` is a task.
When a step fails, as said before, the `TerminationToken` is propagated to next steps and they terminate with `FAILED` status too. However, there are some StreamFlow entities which not receive the `TerminationToken`.

These entities are cancelled by the StreamFlow executor:
- some `Step` instances. In the case of the `scatter` feature, a `job` of the `ExecuteStep` can fail, so the other jobs are cancelled. The `ExecuteStep` propagates the `TerminationToken` with `FAILED` value. However, before the `ExecuteStep` can be other alive `Step` objects as `TransferStep`, `ScheduleStep`. They do not receive the `TerminationToken` with `FAILED` value, so they keep their activities until the StreamFlow `executor` will cancel all the `asyncio.Task` included the task in charge of these `Step` runs.
- the `Scheduler`. While the `TerminationToken` with `FAILED` value is propagated, the `Scheduler` continues its work. Meanwhile, the deployments are undeployed and can happens that the `Scheduler` was communicating with the location and its communication is interrupted.