### PR TITLE
Fix Codecov GitHub action

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -277,5 +277,4 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
THis commit restores the `token` parameter in the Codecov GitHub action, instead of passing it to the executable as an environment variable. Indeed, this path was leading to spurious failures in the CI pipeline.