### PR TITLE
Fix CWL Docker Requirement config example

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -147,7 +147,7 @@ jobs:
           python -m pip install -r docs/requirements.txt
       - name: "Build documentation and check for consistency"
         env:
-          CHECKSUM: "5967bdac60674474149bf785db832aa97b058acb825c4e495272d4d77ca1689c"
+          CHECKSUM: "46beb85aab29181530ce78d39b52e5c153e6223eec73e32682bd67dc0d4e22ff"
         run: |
           cd docs
           HASH="$(make checksum | tail -n1)"

--- a/docs/source/cwl/docker-requirement.rst
+++ b/docs/source/cwl/docker-requirement.rst
@@ -58,9 +58,9 @@ As an example, the following ``streamflow.yml`` file runs the above ``CommandLin
           file: processfile
           settings: jobfile
           docker:
-            step: /
-            deployment:
-              type: singularity
-              config: {}
+            - step: /
+              deployment:
+                type: singularity
+                config: {}
 
 In detail, StreamFlow instantiates a :ref:`SingularityCWLDockerTranslator <SingularityCWLDockerTranslator>` passing the content of the ``config`` field directly to the constructor. The translator is then in charge of generating a :ref:`SingularityConnector <SingularityConnector>` instance with the specified configuration for each CWL ``DockerRequirement`` configuration in the target subworkflow.


### PR DESCRIPTION
This commit fixes the CWL example in the CWL Docker Requriement configuration example. The `docker` keyword should contain an array of bindings, not a single one.