### PR TITLE
Remove SSH deployment from MacOS CI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,9 +68,9 @@ def pytest_generate_tests(metafunc):
 
 
 def all_deployment_types():
-    deployments_ = ["local", "docker", "docker-compose", "slurm", "ssh"]
+    deployments_ = ["local", "docker", "docker-compose", "slurm"]
     if platform.system() == "Linux":
-        deployments_.extend(["kubernetes", "singularity"])
+        deployments_.extend(["kubernetes", "singularity", "ssh"])
     return deployments_
 
 


### PR DESCRIPTION
The `ssh` deployment is showing unsustainable instability on Github Actions pipeline, which are not due to the StreamFlow implementation, but on the underlying virtual infrastructure (Colima+Docker). For this reason, this commit temporarily disables SSH-related tests on the MacOS environment, as long as a more stable solution is implemented.