### PR TITLE
Fix Codecov GitHub Action

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -278,3 +278,5 @@ jobs:
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The new version of Codecov GitHub Action does not always find the token parameter, failig repeatedly. This commit passes the token in both the recommended ways, trying to fix the instable behaviour.