### PR TITLE
Fix Codecov GitHub Action

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -278,5 +278,3 @@ jobs:
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Digging more deep in the error, it was caused by Dependabot not having access to the `CODECOV_TOKEN`. Therefore, this commit reverts the double token passing mechanism as it is not necessary.