### PR TITLE
Support for nested Location objects

### DIFF
--- a/streamflow/core/data.py
+++ b/streamflow/core/data.py
@@ -31,8 +31,9 @@ class DataLocation(Location):
         data_type: DataType,
         service: str | None = None,
         available: bool = False,
+        wraps: Location | None = None,
     ):
-        super().__init__(name, deployment, service)
+        super().__init__(name=name, deployment=deployment, service=service, wraps=wraps)
         self.path: str = path
         self.relpath: str = relpath
         self.data_type: DataType = data_type

--- a/streamflow/core/deployment.py
+++ b/streamflow/core/deployment.py
@@ -31,12 +31,19 @@ def _init_workdir(deployment_name: str) -> str:
 
 
 class Location:
-    __slots__ = ("name", "deployment", "service")
+    __slots__ = ("name", "deployment", "service", "wraps")
 
-    def __init__(self, name: str, deployment: str, service: str | None = None):
+    def __init__(
+        self,
+        name: str,
+        deployment: str,
+        service: str | None = None,
+        wraps: Location | None = None,
+    ):
         self.name: str = name
         self.deployment: str = deployment
         self.service: str | None = service
+        self.wraps: Location | None = wraps
 
     def __eq__(self, other):
         if not isinstance(other, Location):

--- a/streamflow/core/scheduling.py
+++ b/streamflow/core/scheduling.py
@@ -148,8 +148,9 @@ class AvailableLocation(Location):
         service: str | None = None,
         slots: int = 1,
         hardware: Hardware | None = None,
+        wraps: Location | None = None,
     ):
-        super().__init__(name, deployment, service)
+        super().__init__(name=name, deployment=deployment, service=service, wraps=wraps)
         self.hostname: str = hostname
         self.slots: int = slots
         self.hardware: Hardware | None = hardware

--- a/streamflow/data/manager.py
+++ b/streamflow/data/manager.py
@@ -140,6 +140,7 @@ class DefaultDataManager(DataManager):
             name=location.name,
             data_type=data_type,
             available=True,
+            wraps=location.wraps,
         )
         self.path_mapper.put(path=path, data_location=data_location, recursive=True)
         self.context.checkpoint_manager.register(data_location)
@@ -209,6 +210,7 @@ class DefaultDataManager(DataManager):
                             dst_service=dst_location.service,
                             dst_location=dst_location.name,
                             available=True,
+                            wraps=dst_location.wraps,
                         )
                     # Otherwise, perform a copy operation
                     else:
@@ -238,6 +240,7 @@ class DefaultDataManager(DataManager):
                                     data_type=DataType.PRIMARY,
                                     name=dst_location.name,
                                     available=False,
+                                    wraps=dst_location.wraps,
                                 ),
                             )
                         )
@@ -262,6 +265,7 @@ class DefaultDataManager(DataManager):
                                 service=dst_location.service,
                                 name=dst_location.name,
                                 available=False,
+                                wraps=dst_location.wraps,
                             ),
                         )
                     )
@@ -274,6 +278,7 @@ class DefaultDataManager(DataManager):
                             dst_deployment=dst_connector.deployment_name,
                             dst_service=dst_location.service,
                             dst_location=dst_location.name,
+                            wraps=dst_location.wraps,
                         )
                     )
         # Perform all the copy operations
@@ -327,6 +332,7 @@ class RemotePathMapper:
         dst_service: str | None,
         dst_location: str | None,
         available: bool = False,
+        wraps: Location | None = None,
     ) -> DataLocation:
         data_locations = self.get(src_path)
         dst_data_location = DataLocation(
@@ -337,6 +343,7 @@ class RemotePathMapper:
             data_type=location_type,
             name=dst_location,
             available=available,
+            wraps=wraps,
         )
         for data_location in list(data_locations):
             self.put(data_location.path, dst_data_location)
@@ -419,6 +426,7 @@ class RemotePathMapper:
                     data_type=DataType.PRIMARY,
                     name=data_location.name,
                     available=True,
+                    wraps=data_location.wraps,
                 )
             node_location = node.locations.setdefault(
                 location.deployment, {}

--- a/streamflow/deployment/utils.py
+++ b/streamflow/deployment/utils.py
@@ -5,16 +5,18 @@ import os
 import posixpath
 from pathlib import PurePosixPath
 from types import ModuleType
-from typing import Any, MutableMapping, TYPE_CHECKING
+from typing import Any, MutableMapping, MutableSequence, TYPE_CHECKING
 
 from streamflow.core.config import BindingConfig
 from streamflow.core.deployment import (
     DeploymentConfig,
     FilterConfig,
     LocalTarget,
+    Location,
     Target,
     WrapsConfig,
 )
+from streamflow.core.exception import WorkflowExecutionException
 from streamflow.deployment.connector import LocalConnector
 from streamflow.log_handler import logger
 
@@ -78,6 +80,20 @@ def get_binding_config(
         )
     else:
         return BindingConfig(targets=[LocalTarget()])
+
+
+def get_inner_location(location: Location) -> Location:
+    if location.wraps is None:
+        raise WorkflowExecutionException(
+            f"Location {location.name} does not wrap any inner location"
+        )
+    return location.wraps
+
+
+def get_inner_locations(
+    locations: MutableSequence[Location],
+) -> MutableSequence[Location]:
+    return list({get_inner_location(loc) for loc in locations})
 
 
 def get_path_processor(connector: Connector) -> ModuleType:

--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -155,7 +155,15 @@ class DefaultScheduler(Scheduler):
                 }
             else:
                 return None
-        return selected_locations
+        return [
+            Location(
+                name=loc.name,
+                deployment=loc.deployment,
+                service=loc.service,
+                wraps=loc.wraps,
+            )
+            for loc in selected_locations
+        ]
 
     def _get_policy(self, config: Config):
         if config.name not in self.policy_map:

--- a/tests/utils/deployment.py
+++ b/tests/utils/deployment.py
@@ -117,6 +117,7 @@ async def get_location(_context: StreamFlowContext, deployment_t: str) -> Locati
         deployment=deployment,
         service=service,
         name=next(iter(locations.keys())),
+        wraps=next(iter(locations.values())).wraps,
     )
 
 


### PR DESCRIPTION
When using `ConnectorWrapper` instances, a `Location` object can wrap another `Location` object from the inner `Connector`. This information is now stored on each `Location` object through the `wraps` field and propagated to all the derived `Location` objects in the StreamFlow logic.