### PR TITLE
Add `__slots__` attribute to `Token` objects

### DIFF
--- a/streamflow/core/deployment.py
+++ b/streamflow/core/deployment.py
@@ -163,7 +163,7 @@ class DeploymentManager(SchemaEntity):
     async def undeploy_all(self): ...
 
 
-class DeploymentConfig(Config, PersistableEntity):
+class DeploymentConfig(PersistableEntity):
     __slots__ = ("name", "type", "config", "external", "lazy", "workdir", "wraps")
 
     def __init__(
@@ -176,8 +176,10 @@ class DeploymentConfig(Config, PersistableEntity):
         workdir: str | None = None,
         wraps: WrapsConfig | None = None,
     ) -> None:
-        Config.__init__(self, name, type, config)
-        PersistableEntity.__init__(self)
+        super().__init__()
+        self.name: str = name
+        self.type: str = type
+        self.config: MutableMapping[str, Any] = config or {}
         self.external: bool = external
         self.lazy: bool = lazy
         self.workdir: str | None = workdir
@@ -317,10 +319,14 @@ class LocalTarget(Target):
         return cls(workdir=row["workdir"])
 
 
-class FilterConfig(Config, PersistableEntity):
+class FilterConfig(PersistableEntity):
+    __slots__ = ("name", "type", "config")
+
     def __init__(self, name: str, type: str, config: MutableMapping[str, Any]):
-        Config.__init__(self, name, type, config)
-        PersistableEntity.__init__(self)
+        super().__init__()
+        self.name: str = name
+        self.type: str = type
+        self.config: MutableMapping[str, Any] = config or {}
 
     @classmethod
     async def load(

--- a/streamflow/core/persistence.py
+++ b/streamflow/core/persistence.py
@@ -57,6 +57,8 @@ class DatabaseLoadingContext(ABC):
 
 
 class PersistableEntity:
+    __slots__ = ("persistent_id", "persistence_lock")
+
     def __init__(self):
         self.persistent_id: int | None = None
         self.persistence_lock: Lock = Lock()

--- a/streamflow/cwl/token.py
+++ b/streamflow/cwl/token.py
@@ -52,6 +52,8 @@ async def _is_file_token_available(context: StreamFlowContext, value: Any) -> bo
 
 
 class CWLFileToken(FileToken):
+    __slots__ = ()
+
     async def get_paths(self, context: StreamFlowContext) -> MutableSequence[str]:
         paths = []
         if isinstance(self.value, MutableSequence):

--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -8,7 +8,7 @@ from typing import MutableSequence, TYPE_CHECKING
 from importlib_resources import files
 
 from streamflow.core.config import BindingConfig, Config
-from streamflow.core.deployment import BindingFilter, Location, Target
+from streamflow.core.deployment import BindingFilter, FilterConfig, Location, Target
 from streamflow.core.scheduling import (
     Hardware,
     JobAllocation,
@@ -121,7 +121,7 @@ class DefaultScheduler(Scheduler):
                     ", ".join([str(loc) for loc in job_allocation.locations])
                 )
 
-    def _get_binding_filter(self, config: Config):
+    def _get_binding_filter(self, config: FilterConfig):
         if config.name not in self.binding_filter_map:
             self.binding_filter_map[config.name] = binding_filter_classes[config.type](
                 **config.config

--- a/streamflow/workflow/token.py
+++ b/streamflow/workflow/token.py
@@ -11,6 +11,8 @@ from streamflow.core.workflow import Job, Token
 
 
 class IterationTerminationToken(Token):
+    __slots__ = ()
+
     def __init__(self, tag: str):
         super().__init__(None, tag)
 
@@ -34,11 +36,15 @@ class IterationTerminationToken(Token):
 
 
 class FileToken(Token, ABC):
+    __slots__ = ()
+
     @abstractmethod
     async def get_paths(self, context: StreamFlowContext) -> MutableSequence[str]: ...
 
 
 class JobToken(Token):
+    __slots__ = ()
+
     async def _save_value(self, context: StreamFlowContext):
         return {"job": await self.value.save(context)}
 
@@ -57,6 +63,8 @@ class JobToken(Token):
 
 
 class ListToken(Token):
+    __slots__ = ()
+
     @classmethod
     async def _load(
         cls,
@@ -97,6 +105,8 @@ class ListToken(Token):
 
 
 class ObjectToken(Token):
+    __slots__ = ()
+
     @classmethod
     async def _load(
         cls,
@@ -149,6 +159,8 @@ class ObjectToken(Token):
 
 
 class TerminationToken(Token):
+    __slots__ = ()
+
     def __init__(self):
         super().__init__(None)
 
@@ -167,5 +179,5 @@ class TerminationToken(Token):
         context: StreamFlowContext,
         row: MutableMapping[str, Any],
         loading_context: DatabaseLoadingContext,
-    ) -> IterationTerminationToken:
+    ) -> TerminationToken:
         return cls()

--- a/tests/test_build_wf.py
+++ b/tests/test_build_wf.py
@@ -315,8 +315,8 @@ async def test_schedule_step(context: StreamFlowContext):
     ):
         # Config are read-only so workflows can share the same
         assert original_filter.persistent_id == new_filter.persistent_id
-        _set_to_none(original_filter, id_to_none=True, wf_to_none=True)
-        _set_to_none(new_filter, id_to_none=True, wf_to_none=True)
+        _set_to_none(original_filter, id_to_none=True, wf_to_none=False)
+        _set_to_none(new_filter, id_to_none=True, wf_to_none=False)
     _set_to_none(step, id_to_none=True, wf_to_none=True)
     _set_to_none(new_step, id_to_none=True, wf_to_none=True)
     assert are_equals(step, new_step)


### PR DESCRIPTION
This commit optimizes the StreamFlow memory footprint by adding the `__slots__` attribute to all `Token` objects. Indeed, if the `__slots__` attribute is not added to a subclass (even when empty), that class is built with the standard `__dict__` field.

Plus, this commit adds the `__slots__` field to the `PersistableEntity` class, because otherwise all classes inheriting from it will have the `__dict__` field, too. Since Python does not support multiple inheritance when two or more classes define the `__slots__` attribute, this commit also refactors the `DeploymentConfig` and `FilterConfig` classes to inherit only from `PersistableEntity`.