### PR TITLE
Remove `__eq__` and `__hash__` from `Location`

### DIFF
--- a/streamflow/core/data.py
+++ b/streamflow/core/data.py
@@ -41,20 +41,6 @@ class DataLocation(Location):
         if available:
             self.available.set()
 
-    def __eq__(self, other):
-        if not isinstance(other, DataLocation):
-            return False
-        else:
-            return (
-                self.deployment == other.deployment
-                and self.name == other.name
-                and self.service == other.service
-                and self.path == other.path
-            )
-
-    def __hash__(self):
-        return hash((self.deployment, self.service, self.name, self.path))
-
 
 class DataManager(SchemaEntity):
     def __init__(self, context: StreamFlowContext):

--- a/streamflow/core/deployment.py
+++ b/streamflow/core/deployment.py
@@ -45,19 +45,6 @@ class Location:
         self.service: str | None = service
         self.wraps: Location | None = wraps
 
-    def __eq__(self, other):
-        if not isinstance(other, Location):
-            return False
-        else:
-            return (
-                self.deployment == other.deployment
-                and self.service == other.service
-                and self.name == other.name
-            )
-
-    def __hash__(self):
-        return hash((self.deployment, self.service, self.name))
-
     def __str__(self) -> str:
         if self.service:
             return posixpath.join(self.deployment, self.service, self.name)

--- a/streamflow/core/scheduling.py
+++ b/streamflow/core/scheduling.py
@@ -155,19 +155,6 @@ class AvailableLocation(Location):
         self.slots: int = slots
         self.hardware: Hardware | None = hardware
 
-    def __eq__(self, other):
-        if not isinstance(other, AvailableLocation):
-            return False
-        else:
-            return (
-                self.deployment == other.deployment
-                and self.service == other.service
-                and self.name == other.name
-            )
-
-    def __hash__(self):
-        return hash((self.deployment, self.service, self.name))
-
 
 class LocationAllocation:
     __slots__ = ("name", "deployment", "jobs")

--- a/streamflow/deployment/connector/base.py
+++ b/streamflow/deployment/connector/base.py
@@ -155,7 +155,9 @@ class BaseConnector(Connector, FutureAware):
         read_only: bool = False,
     ) -> None:
         source_connector = source_connector or self
-        if source_connector == self and source_location in locations:
+        if source_connector == self and source_location.name in (
+            loc.name for loc in locations
+        ):
             if src != dst:
                 command = ["/bin/cp", "-rf", src, dst]
                 await self.run(source_location, command)

--- a/streamflow/deployment/connector/kubernetes.py
+++ b/streamflow/deployment/connector/kubernetes.py
@@ -294,7 +294,9 @@ class BaseKubernetesConnector(BaseConnector, ABC):
     ) -> None:
         source_connector = source_connector or self
         locations = await self._get_effective_locations(locations, dst)
-        if source_connector == self and source_location in locations:
+        if source_connector == self and source_location.name in (
+            loc.name for loc in locations
+        ):
             if src != dst:
                 command = ["/bin/cp", "-rf", src, dst]
                 await self.run(source_location, command)


### PR DESCRIPTION
This commit removes the custom `__eq__` and `__hash__` methods from `Location` and its derived classes. Indeed, these methods are not needed anymore (the last occurrences have been substituted by checks on the `name` attribute) and their logic was flawed.

Plus, falling back to default implementations improves performance and maintainability.