### PR TITLE
Refactor the `Location` class hierarchy

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -147,7 +147,7 @@ jobs:
           python -m pip install -r docs/requirements.txt
       - name: "Build documentation and check for consistency"
         env:
-          CHECKSUM: "46beb85aab29181530ce78d39b52e5c153e6223eec73e32682bd67dc0d4e22ff"
+          CHECKSUM: "54895f11932d3731fb1e2ecf61c64240951297407b4156f76ba7add52725b05c"
         run: |
           cd docs
           HASH="$(make checksum | tail -n1)"

--- a/docs/source/ext/connector.rst
+++ b/docs/source/ext/connector.rst
@@ -12,7 +12,7 @@ The ``streamflow.core.deployment`` module defines the ``Connector`` interface, w
         self,
         src: str,
         dst: str,
-        locations: MutableSequence[Location],
+        locations: MutableSequence[ExecutionLocation],
         read_only: bool = False,
     ) -> None:
         ...
@@ -21,7 +21,7 @@ The ``streamflow.core.deployment`` module defines the ``Connector`` interface, w
         self,
         src: str,
         dst: str,
-        locations: MutableSequence[Location],
+        locations: MutableSequence[ExecutionLocation],
         read_only: bool = False,
     ) -> None:
         ...
@@ -30,8 +30,8 @@ The ``streamflow.core.deployment`` module defines the ``Connector`` interface, w
         self,
         src: str,
         dst: str,
-        locations: MutableSequence[Location],
-        source_location: Location,
+        locations: MutableSequence[ExecutionLocation],
+        source_location: ExecutionLocation,
         source_connector: Connector | None = None,
         read_only: bool = False,
     ) -> None:
@@ -52,13 +52,13 @@ The ``streamflow.core.deployment`` module defines the ``Connector`` interface, w
         ...
 
     async def get_stream_reader(
-        self, location: Location, src: str
+        self, location: ExecutionLocation, src: str
     ) -> StreamWrapperContextManager:
         ...
 
     async def run(
         self,
-        location: Location,
+        location: ExecutionLocation,
         command: MutableSequence[str],
         environment: MutableMapping[str, str] = None,
         workdir: str | None = None,

--- a/docs/source/ext/data-manager.rst
+++ b/docs/source/ext/data-manager.rst
@@ -24,13 +24,13 @@ The ``DataManager`` interface performs data transfers to and from remote executi
         ...
 
     def invalidate_location(
-        self, location: Location, path: str
+        self, location: ExecutionLocation, path: str
     ) -> None:
         ...
 
     def register_path(
         self,
-        location: Location,
+        location: ExecutionLocation,
         path: str,
         relpath: str,
         data_type: DataType = DataType.PRIMARY,
@@ -44,9 +44,9 @@ The ``DataManager`` interface performs data transfers to and from remote executi
 
     async def transfer_data(
         self,
-        src_location: Location,
+        src_location: ExecutionLocation,
         src_path: str,
-        dst_locations: MutableSequence[Location],
+        dst_locations: MutableSequence[ExecutionLocation],
         dst_path: str,
         writable: bool = False,
     ) -> None:

--- a/docs/source/ext/scheduling.rst
+++ b/docs/source/ext/scheduling.rst
@@ -68,7 +68,7 @@ As discussed above, a scheduling attempt occurs whenever a ``Job`` reaches a fin
 Policy
 ======
 
-The ``Policy`` interface contains a single method ``get_location``, which returns the ``Location`` chosen for placement or ``None`` if there is no available location.
+The ``Policy`` interface contains a single method ``get_location``, which returns the ``AvailableLocation`` chosen for placement or ``None`` if there is no available location.
 
 .. code-block:: python
 
@@ -80,7 +80,7 @@ The ``Policy`` interface contains a single method ``get_location``, which return
         available_locations: MutableMapping[str, AvailableLocation],
         jobs: MutableMapping[str, JobAllocation],
         locations: MutableMapping[str, MutableMapping[str, LocationAllocation]],
-    ) -> Location | None:
+    ) -> AvailableLocation | None:
         ...
 
 The ``get_location`` method receives much information about the current execution context, enabling it to cover a broad class of potential scheduling strategies. In particular, the ``context`` parameter can query all the StreamFlow's relevant data structures, such as the :ref:`Database <Database>`, the :ref:`DataManager <DataManager>`, and the :ref:`DeploymentManager <DeploymentManager>`.

--- a/streamflow/core/deployment.py
+++ b/streamflow/core/deployment.py
@@ -50,6 +50,12 @@ class ExecutionLocation:
         self.service: str | None = service
         self.wraps: ExecutionLocation | None = wraps
 
+    def __str__(self) -> str:
+        if self.service:
+            return posixpath.join(self.deployment, self.service, self.name)
+        else:
+            return posixpath.join(self.deployment, self.name)
+
 
 class BindingFilter(SchemaEntity):
     @abstractmethod

--- a/streamflow/core/deployment.py
+++ b/streamflow/core/deployment.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from streamflow.core.workflow import Job
     from typing import MutableSequence, MutableMapping, Any
 
+
 LOCAL_LOCATION = "__LOCAL__"
 
 
@@ -30,26 +31,24 @@ def _init_workdir(deployment_name: str) -> str:
         return os.path.join(os.path.realpath(tempfile.gettempdir()), "streamflow")
 
 
-class Location:
-    __slots__ = ("name", "deployment", "service", "wraps")
+class ExecutionLocation:
+    __slots__ = ("deployment", "environment", "hostname", "name", "service", "wraps")
 
     def __init__(
         self,
         name: str,
         deployment: str,
+        environment: MutableMapping[str, str] | None = None,
+        hostname: str | None = None,
         service: str | None = None,
-        wraps: Location | None = None,
+        wraps: ExecutionLocation | None = None,
     ):
-        self.name: str = name
         self.deployment: str = deployment
+        self.environment: MutableMapping[str, str] = environment or {}
+        self.hostname: str | None = hostname
+        self.name: str = name
         self.service: str | None = service
-        self.wraps: Location | None = wraps
-
-    def __str__(self) -> str:
-        if self.service:
-            return posixpath.join(self.deployment, self.service, self.name)
-        else:
-            return posixpath.join(self.deployment, self.name)
+        self.wraps: ExecutionLocation | None = wraps
 
 
 class BindingFilter(SchemaEntity):
@@ -70,7 +69,7 @@ class Connector(SchemaEntity):
         self,
         src: str,
         dst: str,
-        locations: MutableSequence[Location],
+        locations: MutableSequence[ExecutionLocation],
         read_only: bool = False,
     ) -> None: ...
 
@@ -79,7 +78,7 @@ class Connector(SchemaEntity):
         self,
         src: str,
         dst: str,
-        locations: MutableSequence[Location],
+        locations: MutableSequence[ExecutionLocation],
         read_only: bool = False,
     ) -> None: ...
 
@@ -88,8 +87,8 @@ class Connector(SchemaEntity):
         self,
         src: str,
         dst: str,
-        locations: MutableSequence[Location],
-        source_location: Location,
+        locations: MutableSequence[ExecutionLocation],
+        source_location: ExecutionLocation,
         source_connector: Connector | None = None,
         read_only: bool = False,
     ) -> None: ...
@@ -109,7 +108,7 @@ class Connector(SchemaEntity):
     @abstractmethod
     async def run(
         self,
-        location: Location,
+        location: ExecutionLocation,
         command: MutableSequence[str],
         environment: MutableMapping[str, str] = None,
         workdir: str | None = None,
@@ -126,7 +125,7 @@ class Connector(SchemaEntity):
 
     @abstractmethod
     async def get_stream_reader(
-        self, location: Location, src: str
+        self, location: ExecutionLocation, src: str
     ) -> StreamWrapperContextManager: ...
 
 

--- a/streamflow/core/utils.py
+++ b/streamflow/core/utils.py
@@ -15,10 +15,11 @@ from typing import (
     MutableSequence,
     TYPE_CHECKING,
 )
+
 from streamflow.core.exception import WorkflowExecutionException
 
 if TYPE_CHECKING:
-    from streamflow.core.deployment import Connector, Location
+    from streamflow.core.deployment import Connector, ExecutionLocation
     from streamflow.core.workflow import Token
     from typing import Iterable
 
@@ -162,7 +163,7 @@ def get_date_from_ns(timestamp: int) -> str:
 
 
 async def get_local_to_remote_destination(
-    dst_connector: Connector, dst_location: Location, src: str, dst: str
+    dst_connector: Connector, dst_location: ExecutionLocation, src: str, dst: str
 ):
     is_dst_dir, status = await dst_connector.run(
         location=dst_location,
@@ -201,10 +202,10 @@ def get_option(
 
 async def get_remote_to_remote_write_command(
     src_connector: Connector,
-    src_location: Location,
+    src_location: ExecutionLocation,
     src: str,
     dst_connector: Connector,
-    dst_locations: MutableSequence[Location],
+    dst_locations: MutableSequence[ExecutionLocation],
     dst: str,
 ) -> MutableSequence[str]:
     is_dst_dir, status = await dst_connector.run(

--- a/streamflow/core/workflow.py
+++ b/streamflow/core/workflow.py
@@ -17,7 +17,7 @@ from streamflow.core.persistence import (
 )
 
 if TYPE_CHECKING:
-    from streamflow.core.deployment import Connector, Location, Target
+    from streamflow.core.deployment import Connector, ExecutionLocation, Target
     from streamflow.core.context import StreamFlowContext
     from typing import Any
 
@@ -85,13 +85,12 @@ class CommandOutputProcessor(ABC):
 
     async def _get_locations(
         self, connector: Connector | None, job: Job
-    ) -> MutableSequence[Location]:
+    ) -> MutableSequence[ExecutionLocation]:
         if self.target:
-            return list(
-                (
-                    await connector.get_available_locations(service=self.target.service)
-                ).values()
+            available_locations = await connector.get_available_locations(
+                service=self.target.service
             )
+            return [loc.location for loc in available_locations.values()]
         else:
             return self.workflow.context.scheduler.get_locations(job.name)
 

--- a/streamflow/cwl/command.py
+++ b/streamflow/cwl/command.py
@@ -420,7 +420,7 @@ class CWLBaseCommand(Command, ABC):
                         base_path, path_processor.basename(src_path)
                     )
                     await self.step.workflow.context.data_manager.transfer_data(
-                        src_location=selected_location,
+                        src_location=selected_location.location,
                         src_path=src_path,
                         dst_locations=locations,
                         dst_path=dest_path,

--- a/streamflow/cwl/processor.py
+++ b/streamflow/cwl/processor.py
@@ -9,7 +9,11 @@ from rdflib import Graph
 from schema_salad.exceptions import ValidationException
 
 from streamflow.core.context import StreamFlowContext
-from streamflow.core.deployment import Connector, LOCAL_LOCATION, Target
+from streamflow.core.deployment import (
+    Connector,
+    LOCAL_LOCATION,
+    Target,
+)
 from streamflow.core.exception import (
     WorkflowDefinitionException,
     WorkflowExecutionException,
@@ -229,7 +233,7 @@ class CWLTokenProcessor(TokenProcessor):
                 token_value = await utils.update_file_token(
                     context=self.workflow.context,
                     connector=connector,
-                    location=data_location,
+                    location=data_location.location,
                     token_value=token_value,
                     load_contents=self.load_contents,
                     load_listing=self.load_listing,
@@ -249,7 +253,7 @@ class CWLTokenProcessor(TokenProcessor):
                                         utils.update_file_token(
                                             context=self.workflow.context,
                                             connector=connector,
-                                            location=data_location,
+                                            location=data_location.location,
                                             token_value=sf,
                                             load_contents=self.load_contents,
                                             load_listing=self.load_listing,
@@ -272,7 +276,7 @@ class CWLTokenProcessor(TokenProcessor):
                         full_js=self.full_js,
                         expression_lib=self.expression_lib,
                         connector=connector,
-                        locations=[data_location],
+                        locations=[data_location.location],
                         token_value=token_value,
                         load_contents=self.load_contents,
                         load_listing=self.load_listing,
@@ -285,7 +289,7 @@ class CWLTokenProcessor(TokenProcessor):
                 await utils.register_data(
                     context=self.workflow.context,
                     connector=connector,
-                    locations=[data_location],
+                    locations=[data_location.location],
                     token_value=token_value,
                     base_path=base_path,
                 )

--- a/streamflow/cwl/step.py
+++ b/streamflow/cwl/step.py
@@ -457,7 +457,7 @@ class CWLTransferStep(TransferStep):
             )
             # Perform and transfer
             await self.workflow.context.data_manager.transfer_data(
-                src_location=selected_location,
+                src_location=selected_location.location,
                 src_path=selected_location.path,
                 dst_locations=dst_locations,
                 dst_path=filepath,

--- a/streamflow/cwl/token.py
+++ b/streamflow/cwl/token.py
@@ -19,14 +19,16 @@ async def _get_file_token_weight(context: StreamFlowContext, value: Any):
                 path=path, data_type=DataType.PRIMARY
             )
             if data_locations:
-                location = list(data_locations)[0]
+                data_location = list(data_locations)[0]
                 connector = context.deployment_manager.get_connector(
-                    location.deployment
+                    data_location.deployment
                 )
                 real_path = await remotepath.follow_symlink(
-                    context, connector, location, location.path
+                    context, connector, data_location.location, data_location.path
                 )
-                weight = await remotepath.size(connector, location, real_path)
+                weight = await remotepath.size(
+                    connector, data_location.location, real_path
+                )
     if "secondaryFiles" in value:
         weight += sum(
             await asyncio.gather(

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -28,9 +28,9 @@ from streamflow.core.config import BindingConfig
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.deployment import (
     DeploymentConfig,
+    ExecutionLocation,
     LOCAL_LOCATION,
     LocalTarget,
-    Location,
     Target,
 )
 from streamflow.core.exception import WorkflowDefinitionException
@@ -2592,14 +2592,16 @@ class CWLTranslator:
         # Register data locations for config files
         path = _get_path(self.cwl_definition.tool["id"])
         self.context.data_manager.register_path(
-            location=Location(deployment=LOCAL_LOCATION, name=LOCAL_LOCATION),
+            location=ExecutionLocation(deployment=LOCAL_LOCATION, name=LOCAL_LOCATION),
             path=path,
             relpath=os.path.basename(path),
         )
         if self.cwl_inputs:
             path = _get_path(self.cwl_inputs["id"])
             self.context.data_manager.register_path(
-                location=Location(deployment=LOCAL_LOCATION, name=LOCAL_LOCATION),
+                location=ExecutionLocation(
+                    deployment=LOCAL_LOCATION, name=LOCAL_LOCATION
+                ),
                 path=path,
                 relpath=os.path.basename(path),
             )

--- a/streamflow/cwl/utils.py
+++ b/streamflow/cwl/utils.py
@@ -25,7 +25,7 @@ from cwltool.utils import CONTENT_LIMIT
 
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.data import DataLocation, DataType, FileType
-from streamflow.core.deployment import Connector, Location
+from streamflow.core.deployment import Connector, ExecutionLocation
 from streamflow.core.exception import (
     WorkflowDefinitionException,
     WorkflowExecutionException,
@@ -44,7 +44,7 @@ from streamflow.workflow.utils import get_token_value
 async def _check_glob_path(
     connector: Connector,
     workflow: Workflow,
-    location: Location | None,
+    location: ExecutionLocation | None,
     input_directory: str,
     output_directory: str,
     tmp_directory: str,
@@ -88,7 +88,7 @@ async def _check_glob_path(
 async def _process_secondary_file(
     context: StreamFlowContext,
     connector: Connector,
-    locations: MutableSequence[Location],
+    locations: MutableSequence[ExecutionLocation],
     secondary_file: Any,
     token_value: MutableMapping[str, Any],
     from_expression: bool,
@@ -173,7 +173,7 @@ def _process_sf_path(
 async def _register_path(
     context: StreamFlowContext,
     connector: Connector,
-    location: Location,
+    location: ExecutionLocation,
     path: str,
     relpath: str,
     data_type: DataType = DataType.PRIMARY,
@@ -247,7 +247,7 @@ async def build_token_value(
     expression_lib: MutableSequence[str] | None,
     secondary_files: MutableSequence[SecondaryFile] | None,
     connector: Connector,
-    locations: MutableSequence[Location],
+    locations: MutableSequence[ExecutionLocation],
     token_value: Any,
     load_contents: bool,
     load_listing: LoadListing,
@@ -429,7 +429,7 @@ def eval_expression(
 async def expand_glob(
     connector: Connector,
     workflow: Workflow,
-    location: Location | None,
+    location: ExecutionLocation | None,
     input_directory: str,
     output_directory: str,
     tmp_directory: str,
@@ -483,7 +483,7 @@ async def get_class_from_path(
 async def get_file_token(
     context: StreamFlowContext,
     connector: Connector,
-    locations: MutableSequence[Location],
+    locations: MutableSequence[ExecutionLocation],
     token_class: str,
     filepath: str,
     file_format: str | None = None,
@@ -542,7 +542,7 @@ async def get_file_token(
 async def get_listing(
     context: StreamFlowContext,
     connector: Connector,
-    locations: MutableSequence[Location],
+    locations: MutableSequence[ExecutionLocation],
     dirpath: str,
     load_contents: bool,
     recursive: bool,
@@ -711,7 +711,7 @@ async def process_secondary_files(
     full_js: bool,
     expression_lib: MutableSequence[str] | None,
     connector: Connector,
-    locations: MutableSequence[Location],
+    locations: MutableSequence[ExecutionLocation],
     token_value: Any,
     load_contents: bool | None = None,
     load_listing: LoadListing | None = None,
@@ -807,7 +807,7 @@ async def process_secondary_files(
 async def register_data(
     context: StreamFlowContext,
     connector: Connector,
-    locations: MutableSequence[Location],
+    locations: MutableSequence[ExecutionLocation],
     base_path: str | None,
     token_value: MutableSequence[MutableMapping[str, Any]] | MutableMapping[str, Any],
 ):
@@ -933,7 +933,7 @@ async def search_in_parent_locations(
                     if current_location := await _register_path(
                         context=context,
                         connector=data_connector,
-                        location=data_location,
+                        location=data_location.location,
                         path=data_path,
                         relpath=relpath,
                         data_type=data_location.data_type,
@@ -983,7 +983,7 @@ class SecondaryFile:
 async def update_file_token(
     context: StreamFlowContext,
     connector: Connector,
-    location: Location,
+    location: ExecutionLocation,
     token_value: MutableMapping[str, Any],
     load_contents: bool | None,
     load_listing: LoadListing | None = None,

--- a/streamflow/data/manager.py
+++ b/streamflow/data/manager.py
@@ -7,22 +7,22 @@ from typing import TYPE_CHECKING
 from importlib_resources import files
 
 from streamflow.core.data import DataLocation, DataManager, DataType
-from streamflow.core.deployment import Connector, Location
 from streamflow.data import remotepath
 from streamflow.deployment.connector.local import LocalConnector
 from streamflow.deployment.utils import get_path_processor
 
 if TYPE_CHECKING:
     from streamflow.core.context import StreamFlowContext
+    from streamflow.core.deployment import Connector, ExecutionLocation
     from typing import MutableMapping, MutableSequence
 
 
 async def _copy(
     src_connector: Connector | None,
-    src_location: Location | None,
+    src_location: ExecutionLocation | None,
     src: str,
     dst_connector: Connector | None,
-    dst_locations: MutableSequence[Location] | None,
+    dst_locations: MutableSequence[ExecutionLocation] | None,
     dst: str,
     writable: False,
 ) -> None:
@@ -122,25 +122,22 @@ class DefaultDataManager(DataManager):
         else:
             return None
 
-    def invalidate_location(self, location: Location, path: str) -> None:
+    def invalidate_location(self, location: ExecutionLocation, path: str) -> None:
         self.path_mapper.invalidate_location(location, path)
 
     def register_path(
         self,
-        location: Location,
+        location: ExecutionLocation,
         path: str,
         relpath: str | None = None,
         data_type: DataType = DataType.PRIMARY,
     ) -> DataLocation:
         data_location = DataLocation(
+            location=location,
             path=path,
             relpath=relpath or path,
-            deployment=location.deployment,
-            service=location.service,
-            name=location.name,
             data_type=data_type,
             available=True,
-            wraps=location.wraps,
         )
         self.path_mapper.put(path=path, data_location=data_location, recursive=True)
         self.context.checkpoint_manager.register(data_location)
@@ -156,9 +153,9 @@ class DefaultDataManager(DataManager):
 
     async def transfer_data(
         self,
-        src_location: Location,
+        src_location: ExecutionLocation,
         src_path: str,
-        dst_locations: MutableSequence[Location],
+        dst_locations: MutableSequence[ExecutionLocation],
         dst_path: str,
         writable: bool = False,
     ) -> None:
@@ -206,11 +203,8 @@ class DefaultDataManager(DataManager):
                             location_type=DataType.SYMBOLIC_LINK,
                             src_path=src_path,
                             dst_path=dst_path,
-                            dst_deployment=dst_connector.deployment_name,
-                            dst_service=dst_location.service,
-                            dst_location=dst_location.name,
+                            dst_location=dst_location,
                             available=True,
-                            wraps=dst_location.wraps,
                         )
                     # Otherwise, perform a copy operation
                     else:
@@ -231,16 +225,13 @@ class DefaultDataManager(DataManager):
                             self.path_mapper.put(
                                 path=dst_path,
                                 data_location=DataLocation(
+                                    location=dst_location,
                                     path=dst_path,
                                     relpath=list(self.path_mapper.get(src_path))[
                                         0
                                     ].relpath,
-                                    deployment=dst_connector.deployment_name,
-                                    service=dst_location.service,
                                     data_type=DataType.PRIMARY,
-                                    name=dst_location.name,
                                     available=False,
-                                    wraps=dst_location.wraps,
                                 ),
                             )
                         )
@@ -258,14 +249,11 @@ class DefaultDataManager(DataManager):
                         self.path_mapper.put(
                             path=dst_path,
                             data_location=DataLocation(
+                                location=dst_location,
                                 path=dst_path,
                                 relpath=list(self.path_mapper.get(src_path))[0].relpath,
-                                deployment=dst_connector.deployment_name,
                                 data_type=DataType.PRIMARY,
-                                service=dst_location.service,
-                                name=dst_location.name,
                                 available=False,
-                                wraps=dst_location.wraps,
                             ),
                         )
                     )
@@ -275,10 +263,7 @@ class DefaultDataManager(DataManager):
                             location_type=DataType.PRIMARY,
                             src_path=src_path,
                             dst_path=dst_path,
-                            dst_deployment=dst_connector.deployment_name,
-                            dst_service=dst_location.service,
-                            dst_location=dst_location.name,
-                            wraps=dst_location.wraps,
+                            dst_location=dst_location,
                         )
                     )
         # Perform all the copy operations
@@ -328,22 +313,16 @@ class RemotePathMapper:
         location_type: DataType,
         src_path: str,
         dst_path: str,
-        dst_deployment: str,
-        dst_service: str | None,
-        dst_location: str | None,
+        dst_location: ExecutionLocation,
         available: bool = False,
-        wraps: Location | None = None,
     ) -> DataLocation:
         data_locations = self.get(src_path)
         dst_data_location = DataLocation(
+            location=dst_location,
             path=dst_path,
             relpath=list(data_locations)[0].relpath,
-            deployment=dst_deployment,
-            service=dst_service,
             data_type=location_type,
-            name=dst_location,
             available=available,
-            wraps=wraps,
         )
         for data_location in list(data_locations):
             self.put(data_location.path, dst_data_location)
@@ -378,7 +357,7 @@ class RemotePathMapper:
                 )
         return result
 
-    def invalidate_location(self, location: Location, path: str) -> None:
+    def invalidate_location(self, location: ExecutionLocation, path: str) -> None:
         path = PurePosixPath(Path(path).as_posix())
         node = self._filesystem
         for token in path.parts:
@@ -415,18 +394,15 @@ class RemotePathMapper:
                 location = data_location
             else:
                 location = DataLocation(
+                    location=data_location.location,
                     path=node_path,
                     relpath=(
                         relpath
                         if relpath and node_path.endswith(relpath)
                         else path_processor.basename(node_path)
                     ),
-                    deployment=data_location.deployment,
-                    service=data_location.service,
                     data_type=DataType.PRIMARY,
-                    name=data_location.name,
                     available=True,
-                    wraps=data_location.wraps,
                 )
             node_location = node.locations.setdefault(
                 location.deployment, {}
@@ -442,7 +418,7 @@ class RemotePathMapper:
         # Return location
         return data_location
 
-    def remove_location(self, location: Location):
+    def remove_location(self, location: DataLocation):
         data_locations = self._filesystem.locations.setdefault(
             location.deployment, {}
         ).get(location.name)

--- a/streamflow/data/remotepath.py
+++ b/streamflow/data/remotepath.py
@@ -20,11 +20,11 @@ from streamflow.core.exception import WorkflowExecutionException
 from streamflow.deployment.connector.local import LocalConnector
 
 if TYPE_CHECKING:
-    from streamflow.core.deployment import Connector, Location
+    from streamflow.core.deployment import Connector, ExecutionLocation
 
 
 def _check_status(
-    command: MutableSequence[str], location: Location, result: str, status: int
+    command: MutableSequence[str], location: ExecutionLocation, result: str, status: int
 ):
     if status != 0:
         raise WorkflowExecutionException(
@@ -69,7 +69,7 @@ def _listdir_local(path: str, file_type: FileType | None) -> MutableSequence[str
 async def checksum(
     context: StreamFlowContext,
     connector: Connector,
-    location: Location | None,
+    location: ExecutionLocation | None,
     path: str,
 ) -> str | None:
     if isinstance(connector, LocalConnector):
@@ -96,7 +96,7 @@ async def checksum(
 
 async def download(
     connector: Connector,
-    locations: MutableSequence[Location] | None,
+    locations: MutableSequence[ExecutionLocation] | None,
     url: str,
     parent_dir: str,
 ) -> str:
@@ -142,7 +142,9 @@ async def download(
     return filepath
 
 
-async def exists(connector: Connector, location: Location | None, path: str) -> bool:
+async def exists(
+    connector: Connector, location: ExecutionLocation | None, path: str
+) -> bool:
     if isinstance(connector, LocalConnector):
         return os.path.exists(path)
     else:
@@ -163,7 +165,7 @@ async def exists(connector: Connector, location: Location | None, path: str) -> 
 async def follow_symlink(
     context: StreamFlowContext,
     connector: Connector,
-    location: Location | None,
+    location: ExecutionLocation | None,
     path: str,
 ) -> str:
     if isinstance(connector, LocalConnector):
@@ -200,7 +202,7 @@ async def follow_symlink(
 
 
 async def head(
-    connector: Connector, location: Location | None, path: str, num_bytes: int
+    connector: Connector, location: ExecutionLocation | None, path: str, num_bytes: int
 ) -> str:
     if isinstance(connector, LocalConnector):
         with open(path, "rb") as f:
@@ -214,7 +216,9 @@ async def head(
         return result.strip()
 
 
-async def isdir(connector: Connector, location: Location | None, path: str) -> bool:
+async def isdir(
+    connector: Connector, location: ExecutionLocation | None, path: str
+) -> bool:
     if isinstance(connector, LocalConnector):
         return os.path.isdir(path)
     else:
@@ -232,7 +236,9 @@ async def isdir(connector: Connector, location: Location | None, path: str) -> b
             return not status
 
 
-async def isfile(connector: Connector, location: Location | None, path: str) -> bool:
+async def isfile(
+    connector: Connector, location: ExecutionLocation | None, path: str
+) -> bool:
     if isinstance(connector, LocalConnector):
         return os.path.isfile(path)
     else:
@@ -250,7 +256,9 @@ async def isfile(connector: Connector, location: Location | None, path: str) -> 
             return not status
 
 
-async def islink(connector: Connector, location: Location | None, path: str) -> bool:
+async def islink(
+    connector: Connector, location: ExecutionLocation | None, path: str
+) -> bool:
     if isinstance(connector, LocalConnector):
         return os.path.islink(path)
     else:
@@ -270,7 +278,7 @@ async def islink(connector: Connector, location: Location | None, path: str) -> 
 
 async def listdir(
     connector: Connector,
-    location: Location | None,
+    location: ExecutionLocation | None,
     path: str,
     file_type: FileType | None = None,
 ) -> MutableSequence[str]:
@@ -296,14 +304,16 @@ async def listdir(
 
 
 async def mkdir(
-    connector: Connector, locations: MutableSequence[Location] | None, path: str
+    connector: Connector,
+    locations: MutableSequence[ExecutionLocation] | None,
+    path: str,
 ) -> None:
     return await mkdirs(connector, locations, [path])
 
 
 async def mkdirs(
     connector: Connector,
-    locations: MutableSequence[Location] | None,
+    locations: MutableSequence[ExecutionLocation] | None,
     paths: MutableSequence[str],
 ) -> None:
     if isinstance(connector, LocalConnector):
@@ -320,7 +330,9 @@ async def mkdirs(
         )
 
 
-async def read(connector: Connector, location: Location | None, path: str) -> str:
+async def read(
+    connector: Connector, location: ExecutionLocation | None, path: str
+) -> str:
     if isinstance(connector, LocalConnector):
         with open(path, "rb") as f:
             return f.read().decode("utf-8")
@@ -334,7 +346,7 @@ async def read(connector: Connector, location: Location | None, path: str) -> st
 
 
 async def resolve(
-    connector: Connector, location: Location | None, pattern: str
+    connector: Connector, location: ExecutionLocation | None, pattern: str
 ) -> MutableSequence[str] | None:
     if isinstance(connector, LocalConnector):
         return sorted(glob.glob(pattern))
@@ -362,7 +374,7 @@ async def resolve(
 
 async def rm(
     connector: Connector,
-    location: Location | None,
+    location: ExecutionLocation | None,
     path: str | MutableSequence[str],
 ) -> None:
     if isinstance(connector, LocalConnector):
@@ -393,7 +405,7 @@ async def rm(
 
 async def size(
     connector: Connector,
-    location: Location | None,
+    location: ExecutionLocation | None,
     path: str | MutableSequence[str],
 ) -> int:
     if not path:
@@ -430,7 +442,7 @@ async def size(
 
 
 async def symlink(
-    connector: Connector, location: Location | None, src: str, path: str
+    connector: Connector, location: ExecutionLocation | None, src: str, path: str
 ) -> None:
     if isinstance(connector, LocalConnector):
         src = os.path.abspath(src)
@@ -448,7 +460,7 @@ async def symlink(
 
 
 async def write(
-    connector: Connector, location: Location | None, path: str, content: str
+    connector: Connector, location: ExecutionLocation | None, path: str, content: str
 ) -> None:
     if isinstance(connector, LocalConnector):
         with open(path, "w") as f:

--- a/streamflow/deployment/connector/local.py
+++ b/streamflow/deployment/connector/local.py
@@ -10,7 +10,11 @@ from typing import MutableMapping, MutableSequence
 import psutil
 from importlib_resources import files
 
-from streamflow.core.deployment import Connector, LOCAL_LOCATION, Location
+from streamflow.core.deployment import (
+    Connector,
+    ExecutionLocation,
+    LOCAL_LOCATION,
+)
 from streamflow.core.scheduling import AvailableLocation, Hardware
 from streamflow.deployment.connector.base import BaseConnector
 
@@ -30,7 +34,7 @@ class LocalConnector(BaseConnector):
         self.memory = float(psutil.virtual_memory().available / 2**20)
 
     def _get_run_command(
-        self, command: str, location: Location, interactive: bool = False
+        self, command: str, location: ExecutionLocation, interactive: bool = False
     ):
         if sys.platform == "win32":
             return f"{self._get_shell()} /C '{command}'"
@@ -49,8 +53,8 @@ class LocalConnector(BaseConnector):
         self,
         src: str,
         dst: str,
-        locations: MutableSequence[Location],
-        source_location: Location,
+        locations: MutableSequence[ExecutionLocation],
+        source_location: ExecutionLocation,
         source_connector: Connector | None = None,
         read_only: bool = False,
     ) -> None:

--- a/streamflow/deployment/connector/occam.py
+++ b/streamflow/deployment/connector/occam.py
@@ -12,7 +12,7 @@ from importlib_resources import files
 from ruamel.yaml import YAML
 
 from streamflow.core import utils
-from streamflow.core.deployment import Location
+from streamflow.core.deployment import ExecutionLocation
 from streamflow.core.exception import WorkflowExecutionException
 from streamflow.core.scheduling import AvailableLocation
 from streamflow.core.utils import get_option
@@ -52,10 +52,10 @@ class OccamConnector(SSHConnector):
 
     def _get_effective_locations(
         self,
-        locations: MutableSequence[Location],
+        locations: MutableSequence[ExecutionLocation],
         dest_path: str,
-        source_location: Location,
-    ) -> MutableSequence[Location]:
+        source_location: ExecutionLocation,
+    ) -> MutableSequence[ExecutionLocation]:
         # If destination path is in a shared location, transfer only on the first location
         for shared_path in self.sharedPaths:
             if dest_path.startswith(shared_path):
@@ -125,8 +125,8 @@ class OccamConnector(SSHConnector):
         self,
         src: str,
         dst: str,
-        locations: MutableSequence[Location],
-        source_location: Location,
+        locations: MutableSequence[ExecutionLocation],
+        source_location: ExecutionLocation,
         source_connector: str | None = None,
         read_only: bool = False,
     ) -> None:
@@ -176,8 +176,8 @@ class OccamConnector(SSHConnector):
         self,
         src: str,
         dst: str,
-        location: Location,
-        source_location: Location,
+        location: ExecutionLocation,
+        source_location: ExecutionLocation,
         temp_dir: str | None,
         read_only: bool = False,
     ) -> None:
@@ -192,7 +192,7 @@ class OccamConnector(SSHConnector):
         self,
         src: str,
         dst: str,
-        locations: MutableSequence[Location],
+        locations: MutableSequence[ExecutionLocation],
         read_only: bool = False,
     ) -> None:
         effective_locations = self._get_effective_locations(locations, dst)
@@ -236,7 +236,7 @@ class OccamConnector(SSHConnector):
         self,
         src: str,
         dst: str,
-        location: Location,
+        location: ExecutionLocation,
         temp_dir: str | None,
         read_only: bool = False,
     ) -> None:
@@ -251,7 +251,7 @@ class OccamConnector(SSHConnector):
             await self.run(location, copy_command)
 
     async def _copy_remote_to_local(
-        self, src: str, dst: str, location: Location, read_only: bool = False
+        self, src: str, dst: str, location: ExecutionLocation, read_only: bool = False
     ) -> None:
         shared_path = self._get_shared_path(location.name, src)
         if shared_path is not None:
@@ -417,7 +417,7 @@ class OccamConnector(SSHConnector):
 
     async def run(
         self,
-        location: Location,
+        location: ExecutionLocation,
         command: MutableSequence[str],
         environment: MutableMapping[str, str] = None,
         workdir: str | None = None,

--- a/streamflow/deployment/future.py
+++ b/streamflow/deployment/future.py
@@ -5,7 +5,7 @@ import logging
 from abc import ABCMeta
 from typing import Any, MutableMapping, MutableSequence, TYPE_CHECKING
 
-from streamflow.core.deployment import Connector, Location
+from streamflow.core.deployment import Connector, ExecutionLocation
 from streamflow.core.exception import WorkflowExecutionException
 from streamflow.core.scheduling import AvailableLocation
 from streamflow.log_handler import logger
@@ -43,7 +43,7 @@ class FutureConnector(Connector):
         self,
         src: str,
         dst: str,
-        locations: MutableSequence[Location],
+        locations: MutableSequence[ExecutionLocation],
         read_only: bool = False,
     ) -> None:
         if self.connector is None:
@@ -63,7 +63,7 @@ class FutureConnector(Connector):
         self,
         src: str,
         dst: str,
-        locations: MutableSequence[Location],
+        locations: MutableSequence[ExecutionLocation],
         read_only: bool = False,
     ) -> None:
         if self.connector is None:
@@ -83,8 +83,8 @@ class FutureConnector(Connector):
         self,
         src: str,
         dst: str,
-        locations: MutableSequence[Location],
-        source_location: Location,
+        locations: MutableSequence[ExecutionLocation],
+        source_location: ExecutionLocation,
         source_connector: Connector | None = None,
         read_only: bool = False,
     ) -> None:
@@ -144,7 +144,7 @@ class FutureConnector(Connector):
         )
 
     async def get_stream_reader(
-        self, location: Location, src: str
+        self, location: ExecutionLocation, src: str
     ) -> StreamWrapperContextManager:
         if self.connector is None:
             if not self.deploying:
@@ -159,7 +159,7 @@ class FutureConnector(Connector):
 
     async def run(
         self,
-        location: Location,
+        location: ExecutionLocation,
         command: MutableSequence[str],
         environment: MutableMapping[str, str] = None,
         workdir: str | None = None,

--- a/streamflow/deployment/utils.py
+++ b/streamflow/deployment/utils.py
@@ -10,9 +10,9 @@ from typing import Any, MutableMapping, MutableSequence, TYPE_CHECKING
 from streamflow.core.config import BindingConfig
 from streamflow.core.deployment import (
     DeploymentConfig,
+    ExecutionLocation,
     FilterConfig,
     LocalTarget,
-    Location,
     Target,
     WrapsConfig,
 )
@@ -82,7 +82,7 @@ def get_binding_config(
         return BindingConfig(targets=[LocalTarget()])
 
 
-def get_inner_location(location: Location) -> Location:
+def get_inner_location(location: ExecutionLocation) -> ExecutionLocation:
     if location.wraps is None:
         raise WorkflowExecutionException(
             f"Location {location.name} does not wrap any inner location"
@@ -91,8 +91,8 @@ def get_inner_location(location: Location) -> Location:
 
 
 def get_inner_locations(
-    locations: MutableSequence[Location],
-) -> MutableSequence[Location]:
+    locations: MutableSequence[ExecutionLocation],
+) -> MutableSequence[ExecutionLocation]:
     return list({get_inner_location(loc) for loc in locations})
 
 

--- a/streamflow/deployment/wrapper.py
+++ b/streamflow/deployment/wrapper.py
@@ -5,7 +5,7 @@ from abc import ABC
 from typing import Any, MutableMapping, MutableSequence
 
 from streamflow.core.data import StreamWrapperContextManager
-from streamflow.core.deployment import Connector, Location
+from streamflow.core.deployment import Connector, ExecutionLocation
 from streamflow.core.scheduling import AvailableLocation
 from streamflow.deployment.future import FutureAware
 from streamflow.deployment.utils import get_inner_location, get_inner_locations
@@ -28,7 +28,7 @@ class ConnectorWrapper(Connector, FutureAware, ABC):
         self,
         src: str,
         dst: str,
-        locations: MutableSequence[Location],
+        locations: MutableSequence[ExecutionLocation],
         read_only: bool = False,
     ) -> None:
         await self.connector.copy_local_to_remote(
@@ -42,7 +42,7 @@ class ConnectorWrapper(Connector, FutureAware, ABC):
         self,
         src: str,
         dst: str,
-        locations: MutableSequence[Location],
+        locations: MutableSequence[ExecutionLocation],
         read_only: bool = False,
     ) -> None:
         await self.connector.copy_remote_to_local(
@@ -56,8 +56,8 @@ class ConnectorWrapper(Connector, FutureAware, ABC):
         self,
         src: str,
         dst: str,
-        locations: MutableSequence[Location],
-        source_location: Location,
+        locations: MutableSequence[ExecutionLocation],
+        source_location: ExecutionLocation,
         source_connector: Connector | None = None,
         read_only: bool = False,
     ) -> None:
@@ -88,13 +88,13 @@ class ConnectorWrapper(Connector, FutureAware, ABC):
         )
 
     async def get_stream_reader(
-        self, location: Location, src: str
+        self, location: ExecutionLocation, src: str
     ) -> StreamWrapperContextManager:
         return await self.connector.get_stream_reader(get_inner_location(location), src)
 
     async def run(
         self,
-        location: Location,
+        location: ExecutionLocation,
         command: MutableSequence[str],
         environment: MutableMapping[str, str] = None,
         workdir: str | None = None,

--- a/streamflow/ext/utils.py
+++ b/streamflow/ext/utils.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import json
 import logging
 import sys
-from importlib_metadata import entry_points
 from pathlib import PurePosixPath
 from typing import Any, MutableMapping, MutableSequence
 
+from importlib_metadata import entry_points
 from referencing._core import Resolver, Resource
 
 from streamflow.config.schema import SfSchema

--- a/streamflow/persistence/loading_context.py
+++ b/streamflow/persistence/loading_context.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import MutableMapping
 
 from streamflow.core.context import StreamFlowContext

--- a/streamflow/recovery/checkpoint_manager.py
+++ b/streamflow/recovery/checkpoint_manager.py
@@ -9,7 +9,7 @@ from importlib_resources import files
 
 from streamflow.core import utils
 from streamflow.core.data import DataLocation
-from streamflow.core.deployment import LOCAL_LOCATION, Location
+from streamflow.core.deployment import ExecutionLocation, LOCAL_LOCATION
 from streamflow.core.recovery import CheckpointManager
 from streamflow.core.utils import random_name
 
@@ -33,9 +33,11 @@ class DefaultCheckpointManager(CheckpointManager):
         parent_directory = os.path.join(self.checkpoint_dir, random_name())
         local_path = os.path.join(parent_directory, data_location.relpath)
         await self.context.data_manager.transfer_data(
-            src_location=data_location,
+            src_location=data_location.location,
             src_path=data_location.path,
-            dst_locations=[Location(deployment=LOCAL_LOCATION, name=LOCAL_LOCATION)],
+            dst_locations=[
+                ExecutionLocation(deployment=LOCAL_LOCATION, name=LOCAL_LOCATION)
+            ],
             dst_path=local_path,
         )
 

--- a/streamflow/recovery/failure_manager.py
+++ b/streamflow/recovery/failure_manager.py
@@ -7,7 +7,7 @@ from typing import MutableMapping, cast
 from importlib_resources import files
 
 from streamflow.core.context import StreamFlowContext
-from streamflow.core.deployment import Connector, Location
+from streamflow.core.deployment import Connector, ExecutionLocation
 from streamflow.core.exception import (
     FailureHandlingException,
     UnrecoverableTokenException,
@@ -28,7 +28,7 @@ from streamflow.workflow.step import ExecuteStep
 
 
 async def _cleanup_dir(
-    connector: Connector, location: Location, directory: str
+    connector: Connector, location: ExecutionLocation, directory: str
 ) -> None:
     await remotepath.rm(
         connector, location, await remotepath.listdir(connector, location, directory)

--- a/streamflow/scheduling/policy/data_locality.py
+++ b/streamflow/scheduling/policy/data_locality.py
@@ -7,7 +7,6 @@ from importlib_resources import files
 
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.data import DataType
-from streamflow.core.deployment import Location
 from streamflow.core.exception import WorkflowExecutionException
 from streamflow.core.scheduling import Hardware, JobAllocation, Policy
 from streamflow.workflow.token import FileToken
@@ -27,7 +26,7 @@ class DataLocalityPolicy(Policy):
         available_locations: MutableMapping[str, AvailableLocation],
         jobs: MutableMapping[str, JobAllocation],
         locations: MutableMapping[str, MutableMapping[str, LocationAllocation]],
-    ) -> Location | None:
+    ) -> AvailableLocation | None:
         valid_locations = list(available_locations.keys())
         deployments = {loc.deployment for loc in available_locations.values()}
         if len(deployments) > 1:

--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -8,7 +8,12 @@ from typing import MutableSequence, TYPE_CHECKING
 from importlib_resources import files
 
 from streamflow.core.config import BindingConfig, Config
-from streamflow.core.deployment import BindingFilter, FilterConfig, Location, Target
+from streamflow.core.deployment import (
+    BindingFilter,
+    ExecutionLocation,
+    FilterConfig,
+    Target,
+)
 from streamflow.core.scheduling import (
     Hardware,
     JobAllocation,
@@ -53,7 +58,7 @@ class DefaultScheduler(Scheduler):
         self,
         job: Job,
         hardware: Hardware,
-        selected_locations: MutableSequence[Location],
+        selected_locations: MutableSequence[ExecutionLocation],
         target: Target,
     ):
         if logger.isEnabledFor(logging.DEBUG):
@@ -135,7 +140,7 @@ class DefaultScheduler(Scheduler):
         locations: int,
         scheduling_policy: Policy,
         available_locations: MutableMapping[str, AvailableLocation],
-    ) -> MutableSequence[Location] | None:
+    ) -> MutableSequence[ExecutionLocation] | None:
         selected_locations = []
         for _ in range(locations):
             selected_location = await scheduling_policy.get_location(
@@ -155,15 +160,7 @@ class DefaultScheduler(Scheduler):
                 }
             else:
                 return None
-        return [
-            Location(
-                name=loc.name,
-                deployment=loc.deployment,
-                service=loc.service,
-                wraps=loc.wraps,
-            )
-            for loc in selected_locations
-        ]
+        return [loc.location for loc in selected_locations]
 
     def _get_policy(self, config: Config):
         if config.name not in self.policy_map:

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -20,7 +20,12 @@ from streamflow.core import utils
 from streamflow.core.config import BindingConfig
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.data import DataType
-from streamflow.core.deployment import Connector, DeploymentConfig, Location, Target
+from streamflow.core.deployment import (
+    Connector,
+    DeploymentConfig,
+    ExecutionLocation,
+    Target,
+)
 from streamflow.core.exception import (
     FailureHandlingException,
     WorkflowDefinitionException,
@@ -1306,7 +1311,10 @@ class ScheduleStep(BaseStep):
         )
 
     async def _propagate_job(
-        self, connector: Connector, locations: MutableSequence[Location], job: Job
+        self,
+        connector: Connector,
+        locations: MutableSequence[ExecutionLocation],
+        job: Job,
     ):
         # Set job directories
         allocation = self.workflow.context.scheduler.get_allocation(job.name)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -9,7 +9,7 @@ import pytest
 import pytest_asyncio
 
 from streamflow.core.context import StreamFlowContext
-from streamflow.core.deployment import Connector, Location
+from streamflow.core.deployment import Connector, ExecutionLocation
 from streamflow.core.exception import WorkflowExecutionException
 from streamflow.deployment.connector import SSHConnector
 
@@ -30,7 +30,7 @@ def _get_future_connector_methods() -> MutableSequence[Callable]:
 
 
 def _get_connector_method_params(method_name: str) -> MutableSequence[Any]:
-    loc = Location("test-location", "failure-test")
+    loc = ExecutionLocation("test-location", "failure-test")
     if method_name in ("copy_remote_to_local", "copy_local_to_remote"):
         return ["test_src", "test_dst", [loc]]
     elif method_name in ("deploy", "undeploy"):
@@ -48,7 +48,7 @@ def _get_connector_method_params(method_name: str) -> MutableSequence[Any]:
 
 
 @pytest_asyncio.fixture(scope="module")
-async def curr_location(context, deployment_src) -> Location:
+async def curr_location(context, deployment_src) -> ExecutionLocation:
     return await get_location(context, deployment_src)
 
 
@@ -59,7 +59,9 @@ def curr_connector(context, curr_location) -> Connector:
 
 @pytest.mark.asyncio
 async def test_connector_run_command(
-    context: StreamFlowContext, curr_connector: Connector, curr_location: Location
+    context: StreamFlowContext,
+    curr_connector: Connector,
+    curr_location: ExecutionLocation,
 ) -> None:
     """Test connector run method"""
     stdout, returncode = await curr_connector.run(

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -8,14 +8,14 @@ import pytest_asyncio
 
 from streamflow.core import utils
 from streamflow.core.data import DataType
-from streamflow.core.deployment import Connector, Location
+from streamflow.core.deployment import Connector, ExecutionLocation
 from streamflow.data import remotepath
 from streamflow.deployment.connector import LocalConnector
 from tests.utils.deployment import get_location
 
 
 @pytest_asyncio.fixture(scope="module")
-async def src_location(context, deployment_src) -> Location:
+async def src_location(context, deployment_src) -> ExecutionLocation:
     return await get_location(context, deployment_src)
 
 
@@ -25,7 +25,7 @@ def src_connector(context, src_location) -> Connector:
 
 
 @pytest_asyncio.fixture(scope="module")
-async def dst_location(context, deployment_dst) -> Location:
+async def dst_location(context, deployment_dst) -> ExecutionLocation:
     return await get_location(context, deployment_dst)
 
 

--- a/tests/test_remotepath.py
+++ b/tests/test_remotepath.py
@@ -6,7 +6,7 @@ import pytest_asyncio
 
 from streamflow.core import utils
 from streamflow.core.data import FileType
-from streamflow.core.deployment import Connector, Location
+from streamflow.core.deployment import Connector, ExecutionLocation
 from streamflow.data import remotepath
 from streamflow.deployment.connector import LocalConnector
 from streamflow.deployment.utils import get_path_processor
@@ -14,7 +14,7 @@ from tests.utils.deployment import get_location
 
 
 @pytest_asyncio.fixture(scope="module")
-async def location(context, deployment_src) -> Location:
+async def location(context, deployment_src) -> ExecutionLocation:
     return await get_location(context, deployment_src)
 
 

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -8,7 +8,7 @@ import pytest_asyncio
 
 from streamflow.core import utils
 from streamflow.core.data import DataType, FileType
-from streamflow.core.deployment import Connector, Location
+from streamflow.core.deployment import Connector, ExecutionLocation
 from streamflow.data import remotepath
 from streamflow.deployment.connector import LocalConnector
 from streamflow.deployment.utils import get_path_processor
@@ -119,7 +119,7 @@ async def _create_tmp_dir(context, connector, location, root=None, lvl=None, n_f
 
 
 @pytest_asyncio.fixture(scope="module")
-async def src_location(context, deployment_src) -> Location:
+async def src_location(context, deployment_src) -> ExecutionLocation:
     return await get_location(context, deployment_src)
 
 
@@ -129,7 +129,7 @@ def src_connector(context, src_location) -> Connector:
 
 
 @pytest_asyncio.fixture(scope="module")
-async def dst_location(context, deployment_dst) -> Location:
+async def dst_location(context, deployment_dst) -> ExecutionLocation:
     return await get_location(context, deployment_dst)
 
 

--- a/tests/utils/connector.py
+++ b/tests/utils/connector.py
@@ -6,8 +6,8 @@ from typing import MutableSequence, MutableMapping, Any
 from streamflow.core.data import StreamWrapperContextManager
 from streamflow.core.deployment import (
     Connector,
-    Location,
     LOCAL_LOCATION,
+    ExecutionLocation,
 )
 from streamflow.core.scheduling import AvailableLocation, Hardware
 from streamflow.deployment.connector import LocalConnector
@@ -27,7 +27,7 @@ class FailureConnector(Connector):
         self,
         src: str,
         dst: str,
-        locations: MutableSequence[Location],
+        locations: MutableSequence[ExecutionLocation],
         read_only: bool = False,
     ) -> None:
         raise FailureConnectorException("FailureConnector copy_local_to_remote")
@@ -36,7 +36,7 @@ class FailureConnector(Connector):
         self,
         src: str,
         dst: str,
-        locations: MutableSequence[Location],
+        locations: MutableSequence[ExecutionLocation],
         read_only: bool = False,
     ) -> None:
         raise FailureConnectorException("FailureConnector copy_remote_to_local")
@@ -45,8 +45,8 @@ class FailureConnector(Connector):
         self,
         src: str,
         dst: str,
-        locations: MutableSequence[Location],
-        source_location: Location,
+        locations: MutableSequence[ExecutionLocation],
+        source_location: ExecutionLocation,
         source_connector: Connector | None = None,
         read_only: bool = False,
     ) -> None:
@@ -68,7 +68,7 @@ class FailureConnector(Connector):
 
     async def run(
         self,
-        location: Location,
+        location: ExecutionLocation,
         command: MutableSequence[str],
         environment: MutableMapping[str, str] = None,
         workdir: str | None = None,
@@ -85,7 +85,7 @@ class FailureConnector(Connector):
         raise FailureConnectorException("FailureConnector undeploy")
 
     async def get_stream_reader(
-        self, location: Location, src: str
+        self, location: ExecutionLocation, src: str
     ) -> StreamWrapperContextManager:
         raise FailureConnectorException("FailureConnector get_stream_reader")
 

--- a/tests/utils/deployment.py
+++ b/tests/utils/deployment.py
@@ -14,8 +14,8 @@ from streamflow.core import utils
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.deployment import (
     DeploymentConfig,
+    ExecutionLocation,
     LOCAL_LOCATION,
-    Location,
     WrapsConfig,
     BindingFilter,
     Target,
@@ -123,17 +123,14 @@ def get_deployment(_context: StreamFlowContext, deployment_t: str) -> str:
         raise Exception(f"{deployment_t} deployment type not supported")
 
 
-async def get_location(_context: StreamFlowContext, deployment_t: str) -> Location:
+async def get_location(
+    _context: StreamFlowContext, deployment_t: str
+) -> ExecutionLocation:
     deployment = get_deployment(_context, deployment_t)
     service = get_service(_context, deployment_t)
     connector = _context.deployment_manager.get_connector(deployment)
     locations = await connector.get_available_locations(service=service)
-    return Location(
-        deployment=deployment,
-        service=service,
-        name=next(iter(locations.keys())),
-        wraps=next(iter(locations.values())).wraps,
-    )
+    return next(iter(locations.values())).location
 
 
 def get_service(_context: StreamFlowContext, deployment_t: str) -> str | None:

--- a/tests/utils/workflow.py
+++ b/tests/utils/workflow.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import posixpath
-from typing import MutableSequence, cast, TYPE_CHECKING
+from typing import MutableSequence, TYPE_CHECKING
 
 from streamflow.core import utils
 from streamflow.core.deployment import Target
@@ -62,7 +62,7 @@ def create_schedule_step(
 
 async def create_workflow(
     context: StreamFlowContext, num_port: int = 2
-) -> tuple[Workflow, tuple[Port]]:
+) -> tuple[Workflow, tuple[Port, ...]]:
     workflow = Workflow(
         context=context, type="cwl", name=utils.random_name(), config={}
     )
@@ -70,7 +70,7 @@ async def create_workflow(
     for _ in range(num_port):
         ports.append(workflow.create_port())
     await workflow.save(context)
-    return workflow, tuple(cast(MutableSequence[Port], ports))
+    return workflow, tuple(ports)
 
 
 def get_dot_combinator():


### PR DESCRIPTION
This commit implements a huge refactor in the `Location` class hierarchy. In particular:

- It removes the `Location` base class, making `AvailableLocation` and `DataLocation` two independent classes
- It adds a new `ExecutionLocation` class to represent locations to which commands are actually offloaded by a `Connector`
- The new `ExecutionLocation` class also supports the possibility to pass environment variables from the StreamFlow runtime to affect the remote execution logic
- Documentation has been updated according to the new classes