### PR TITLE
Fixed `asyncio.Event` synchronizations when an exception occurs

### DIFF
--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -67,6 +67,7 @@ class SSHContext:
                             logger.exception(
                                 f"Impossible to connect to {self._config.hostname}: {e}"
                             )
+                            self._connect_event.set()
                             self.close()
                             raise
                         if logger.isEnabledFor(logging.WARNING):
@@ -75,6 +76,7 @@ class SSHContext:
                                 f"Waiting {self._retry_delay} seconds for the next attempt."
                             )
                     except asyncssh.Error:
+                        self._connect_event.set()
                         self.close()
                         raise
                     await asyncio.sleep(self._retry_delay)

--- a/streamflow/deployment/future.py
+++ b/streamflow/deployment/future.py
@@ -34,6 +34,7 @@ class FutureConnector(Connector):
     async def _safe_deploy_event_wait(self):
         await self.deploy_event.wait()
         if self.connector is None:
+            logger.error(f"Deploying of {self.deployment_name} failed")
             raise WorkflowExecutionException(
                 f"Deploying of {self.deployment_name} failed"
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,10 +10,13 @@ from typing import Collection
 import pytest
 import pytest_asyncio
 
+import streamflow.deployment.connector
+
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.persistence import PersistableEntity
 from streamflow.main import build_context
 from streamflow.persistence.loading_context import DefaultDatabaseLoadingContext
+from tests.utils.connector import FailureConnector
 from tests.utils.deployment import get_deployment_config
 
 
@@ -40,6 +43,12 @@ def pytest_addoption(parser):
         type=csvtype(all_deployment_types()),
         default=all_deployment_types(),
         help=f"List of deployments to deploy. Use the comma as delimiter e.g. --deploys local,docker. (default: {all_deployment_types()})",
+    )
+
+
+def pytest_configure(config):
+    streamflow.deployment.connector.connector_classes.update(
+        {"failure": FailureConnector}
     )
 
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -138,5 +138,5 @@ async def test_ssh_connector_multiple_request_fail(context: StreamFlowContext) -
     ):
         assert isinstance(result, (ConnectionError, asyncssh.Error)) or (
             isinstance(result, WorkflowExecutionException)
-            and result.args[0] == "Impossible to connect to 127.0.0.1:2222"
+            and result.args[0] == "Impossible to connect to .*"
         )

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+import pytest_asyncio
+
+from streamflow.core.context import StreamFlowContext
+from streamflow.core.deployment import Connector, Location
+from streamflow.core.exception import WorkflowExecutionException
+
+from streamflow.deployment.future import FutureConnector
+from tests.utils.connector import FailureConnector, FailureConnectorException
+from tests.utils.deployment import get_failure_deployment_config, get_location
+
+
+def _get_task(connector: Connector, method: str) -> asyncio.Task:
+    loc = Location("test-location", "failure-test")
+    if method == "copy_local_to_remote":
+        return asyncio.create_task(
+            connector.copy_local_to_remote("test_src", "test_dst", [loc])
+        )
+    elif method == "copy_remote_to_local":
+        return asyncio.create_task(
+            connector.copy_remote_to_local("test_src", "test_dst", [loc])
+        )
+    elif method == "copy_remote_to_remote":
+        return asyncio.create_task(
+            connector.copy_remote_to_remote("test_src", "test_dst", [loc], loc)
+        )
+    elif method == "get_available_locations":
+        return asyncio.create_task(connector.get_available_locations())
+    elif method == "get_stream_reader":
+        return asyncio.create_task(connector.get_stream_reader(loc, "test_src"))
+    elif method == "run":
+        return asyncio.create_task(connector.run(loc, ["ls"]))
+    else:
+        raise pytest.fail(f"Unknown method: {method}")
+
+
+@pytest_asyncio.fixture(scope="module")
+async def curr_location(context, deployment_src) -> Location:
+    return await get_location(context, deployment_src)
+
+
+@pytest.fixture(scope="module")
+def curr_connector(context, curr_location) -> Connector:
+    return context.deployment_manager.get_connector(curr_location.deployment)
+
+
+@pytest.mark.asyncio
+async def test_connector_run_command(
+    context: StreamFlowContext, curr_connector: Connector, curr_location: Location
+) -> None:
+    """Test connector run method"""
+    stdout, returncode = await curr_connector.run(
+        location=curr_location,
+        command=["ls"],
+        capture_output=True,
+        # job_name="job_test" # todo: fix SlurmConnector
+    )
+    assert returncode == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "method",
+    [
+        "copy_local_to_remote",
+        "copy_remote_to_local",
+        "copy_remote_to_remote",
+        "get_available_locations",
+        "get_stream_reader",
+        "run",
+    ],
+)
+async def test_future_connector_multiple_request_fail(
+    context: StreamFlowContext, method: str
+) -> None:
+    """Test FutureConnector with multiple requests but the deployment fails"""
+    deployment_name = "failure-test"
+    deployment_config = get_failure_deployment_config()
+    connector = FutureConnector(
+        name=deployment_name,
+        config_dir=os.path.dirname(context.config["path"]),
+        connector_type=FailureConnector,
+        external=deployment_config.external,
+        **deployment_config.config,
+    )
+
+    for result in await asyncio.gather(
+        *(_get_task(connector, method) for _ in range(3)),
+        return_exceptions=True,
+    ):
+        assert isinstance(result, FailureConnectorException) or (
+            isinstance(result, WorkflowExecutionException)
+            and result.args[0] == "Deploying of failure-test failed"
+        )
+
+
+@pytest.mark.asyncio
+async def test_deployment_manager_deploy_fails(context: StreamFlowContext) -> None:
+    """Test DeploymentManager deploy method with multiple requests but they fail"""
+    deployment_config = get_failure_deployment_config()
+    deployment_config.lazy = False
+    for result in await asyncio.gather(
+        *(context.deployment_manager.deploy(deployment_config) for _ in range(3)),
+        return_exceptions=True,
+    ):
+        assert isinstance(result, FailureConnectorException) or (
+            isinstance(result, WorkflowExecutionException)
+            and result.args[0] == "Deploying of failure-test failed"
+        )

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -36,6 +36,7 @@ async def service(context, deployment) -> str | None:
     return get_service(context, deployment)
 
 
+# todo: move CustomConnector into utils/connector.py
 class CustomConnector(LocalConnector):
     def __init__(
         self,

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-from typing import MutableMapping, MutableSequence
 
 import pytest
 import pytest_asyncio
@@ -10,19 +9,19 @@ from streamflow.core import utils
 from streamflow.core.config import BindingConfig, Config
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.deployment import (
-    BindingFilter,
     DeploymentConfig,
     LOCAL_LOCATION,
     LocalTarget,
     Target,
 )
-from streamflow.core.scheduling import AvailableLocation, Hardware
+from streamflow.core.scheduling import Hardware
 from streamflow.core.workflow import Job, Status
-from streamflow.deployment.connector import LocalConnector
+from tests.utils.connector import ParameterizableHardwareConnector
 from tests.utils.deployment import (
     get_docker_deployment_config,
     get_service,
     get_deployment_config,
+    ReverseTargetsBindingFilter,
 )
 
 
@@ -34,48 +33,6 @@ async def deployment_config(context, deployment) -> DeploymentConfig:
 @pytest_asyncio.fixture(scope="module")
 async def service(context, deployment) -> str | None:
     return get_service(context, deployment)
-
-
-# todo: move CustomConnector into utils/connector.py
-class CustomConnector(LocalConnector):
-    def __init__(
-        self,
-        deployment_name: str,
-        config_dir: str,
-        hardware: Hardware,
-        transferBufferSize: int = 2**16,
-    ):
-        super().__init__(deployment_name, config_dir, transferBufferSize)
-        self.hardware = hardware
-
-    async def get_available_locations(
-        self,
-        service: str | None = None,
-        input_directory: str | None = None,
-        output_directory: str | None = None,
-        tmp_directory: str | None = None,
-    ) -> MutableMapping[str, AvailableLocation]:
-        return {
-            LOCAL_LOCATION: AvailableLocation(
-                name=LOCAL_LOCATION,
-                deployment=self.deployment_name,
-                service=service,
-                hostname="localhost",
-                slots=1,
-                hardware=self.hardware,
-            )
-        }
-
-
-class CustomBindingFilter(BindingFilter):
-    async def get_targets(
-        self, job: Job, targets: MutableSequence[Target]
-    ) -> MutableSequence[Target]:
-        return targets[::-1]
-
-    @classmethod
-    def get_schema(cls) -> str:
-        return ""
 
 
 @pytest.mark.asyncio
@@ -121,11 +78,13 @@ async def test_single_env_few_resources(context: StreamFlowContext):
 
     # inject custom connector to manipulate available resources
     conn = context.deployment_manager.get_connector(LOCAL_LOCATION)
-    context.deployment_manager.deployments_map[LOCAL_LOCATION] = CustomConnector(
-        deployment_name=conn.deployment_name,
-        config_dir=conn.config_dir,
-        transferBufferSize=conn.transferBufferSize,
-        hardware=machine_hardware,
+    context.deployment_manager.deployments_map[LOCAL_LOCATION] = (
+        ParameterizableHardwareConnector(
+            deployment_name=conn.deployment_name,
+            config_dir=conn.config_dir,
+            transferBufferSize=conn.transferBufferSize,
+            hardware=machine_hardware,
+        )
     )
 
     # Create fake jobs and schedule them
@@ -196,11 +155,13 @@ async def test_single_env_enough_resources(context: StreamFlowContext):
 
     # Inject custom connector to manipulate available resources
     conn = context.deployment_manager.get_connector(LOCAL_LOCATION)
-    context.deployment_manager.deployments_map[LOCAL_LOCATION] = CustomConnector(
-        deployment_name=conn.deployment_name,
-        config_dir=conn.config_dir,
-        transferBufferSize=conn.transferBufferSize,
-        hardware=machine_hardware,
+    context.deployment_manager.deployments_map[LOCAL_LOCATION] = (
+        ParameterizableHardwareConnector(
+            deployment_name=conn.deployment_name,
+            config_dir=conn.config_dir,
+            transferBufferSize=conn.transferBufferSize,
+            hardware=machine_hardware,
+        )
     )
 
     # Create fake jobs and schedule them
@@ -253,11 +214,13 @@ async def test_multi_env(context: StreamFlowContext):
     # Inject custom connector to manipulate available resources
     machine_hardware = Hardware(cores=1)
     conn = context.deployment_manager.get_connector(LOCAL_LOCATION)
-    context.deployment_manager.deployments_map[LOCAL_LOCATION] = CustomConnector(
-        deployment_name=conn.deployment_name,
-        config_dir=conn.config_dir,
-        transferBufferSize=conn.transferBufferSize,
-        hardware=machine_hardware,
+    context.deployment_manager.deployments_map[LOCAL_LOCATION] = (
+        ParameterizableHardwareConnector(
+            deployment_name=conn.deployment_name,
+            config_dir=conn.config_dir,
+            transferBufferSize=conn.transferBufferSize,
+            hardware=machine_hardware,
+        )
     )
 
     # Create fake jobs with two different env and schedule them
@@ -317,11 +280,13 @@ async def test_multi_targets_one_job(context: StreamFlowContext):
     # Inject custom connector to manipulate available resources
     machine_hardware = Hardware(cores=1)
     conn = context.deployment_manager.get_connector(LOCAL_LOCATION)
-    context.deployment_manager.deployments_map[LOCAL_LOCATION] = CustomConnector(
-        deployment_name=conn.deployment_name,
-        config_dir=conn.config_dir,
-        transferBufferSize=conn.transferBufferSize,
-        hardware=machine_hardware,
+    context.deployment_manager.deployments_map[LOCAL_LOCATION] = (
+        ParameterizableHardwareConnector(
+            deployment_name=conn.deployment_name,
+            config_dir=conn.config_dir,
+            transferBufferSize=conn.transferBufferSize,
+            hardware=machine_hardware,
+        )
     )
 
     # Create fake job with two targets and schedule it
@@ -381,11 +346,13 @@ async def test_multi_targets_two_jobs(context: StreamFlowContext):
     # Inject custom connector to manipulate available resources
     machine_hardware = Hardware(cores=1)
     conn = context.deployment_manager.get_connector(LOCAL_LOCATION)
-    context.deployment_manager.deployments_map[LOCAL_LOCATION] = CustomConnector(
-        deployment_name=conn.deployment_name,
-        config_dir=conn.config_dir,
-        transferBufferSize=conn.transferBufferSize,
-        hardware=machine_hardware,
+    context.deployment_manager.deployments_map[LOCAL_LOCATION] = (
+        ParameterizableHardwareConnector(
+            deployment_name=conn.deployment_name,
+            config_dir=conn.config_dir,
+            transferBufferSize=conn.transferBufferSize,
+            hardware=machine_hardware,
+        )
     )
 
     # Create fake jobs with two same targets and schedule them
@@ -471,7 +438,9 @@ async def test_binding_filter(context: StreamFlowContext):
     binding_config = BindingConfig(
         targets=[local_target, docker_target], filters=[filter_config]
     )
-    context.scheduler.binding_filter_map[filter_config_name] = CustomBindingFilter()
+    context.scheduler.binding_filter_map[filter_config_name] = (
+        ReverseTargetsBindingFilter()
+    )
 
     # Schedule the job
     task_pending = [

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -4,7 +4,6 @@ import json
 import tempfile
 from typing import MutableMapping, Any
 
-import pytest
 
 from streamflow.core.context import StreamFlowContext
 from streamflow.cwl.runner import main
@@ -19,7 +18,6 @@ def _create_file(content: MutableMapping[Any, Any]) -> str:
     return temp_config.name
 
 
-@pytest.mark.asyncio
 def test_dot_product_transformer_raises_error(context: StreamFlowContext) -> None:
     """Test DotProductSizeTransformer which must raise an exception because the size tokens have different values"""
     params = [

--- a/tests/utils/connector.py
+++ b/tests/utils/connector.py
@@ -14,36 +14,6 @@ from streamflow.deployment.connector import LocalConnector
 from streamflow.log_handler import logger
 
 
-class ParameterizableHardwareConnector(LocalConnector):
-    def __init__(
-        self,
-        deployment_name: str,
-        config_dir: str,
-        hardware: Hardware,
-        transferBufferSize: int = 2**16,
-    ):
-        super().__init__(deployment_name, config_dir, transferBufferSize)
-        self.hardware = hardware
-
-    async def get_available_locations(
-        self,
-        service: str | None = None,
-        input_directory: str | None = None,
-        output_directory: str | None = None,
-        tmp_directory: str | None = None,
-    ) -> MutableMapping[str, AvailableLocation]:
-        return {
-            LOCAL_LOCATION: AvailableLocation(
-                name=LOCAL_LOCATION,
-                deployment=self.deployment_name,
-                service=service,
-                hostname="localhost",
-                slots=1,
-                hardware=self.hardware,
-            )
-        }
-
-
 class FailureConnectorException(Exception):
     pass
 
@@ -118,3 +88,33 @@ class FailureConnector(Connector):
         self, location: Location, src: str
     ) -> StreamWrapperContextManager:
         raise FailureConnectorException("FailureConnector get_stream_reader")
+
+
+class ParameterizableHardwareConnector(LocalConnector):
+    def __init__(
+        self,
+        deployment_name: str,
+        config_dir: str,
+        hardware: Hardware,
+        transferBufferSize: int = 2**16,
+    ):
+        super().__init__(deployment_name, config_dir, transferBufferSize)
+        self.hardware = hardware
+
+    async def get_available_locations(
+        self,
+        service: str | None = None,
+        input_directory: str | None = None,
+        output_directory: str | None = None,
+        tmp_directory: str | None = None,
+    ) -> MutableMapping[str, AvailableLocation]:
+        return {
+            LOCAL_LOCATION: AvailableLocation(
+                name=LOCAL_LOCATION,
+                deployment=self.deployment_name,
+                service=service,
+                hostname="localhost",
+                slots=1,
+                hardware=self.hardware,
+            )
+        }

--- a/tests/utils/connector.py
+++ b/tests/utils/connector.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import asyncio
+from typing import MutableSequence, MutableMapping, Any
+
+from streamflow.core.data import StreamWrapperContextManager
+from streamflow.core.deployment import (
+    Connector,
+    Location,
+)
+from streamflow.core.scheduling import AvailableLocation
+from streamflow.log_handler import logger
+
+
+class FailureConnectorException(Exception):
+    pass
+
+
+class FailureConnector(Connector):
+    @classmethod
+    def get_schema(cls) -> str:
+        pass
+
+    async def copy_local_to_remote(
+        self,
+        src: str,
+        dst: str,
+        locations: MutableSequence[Location],
+        read_only: bool = False,
+    ) -> None:
+        raise FailureConnectorException("FailureConnector copy_local_to_remote")
+
+    async def copy_remote_to_local(
+        self,
+        src: str,
+        dst: str,
+        locations: MutableSequence[Location],
+        read_only: bool = False,
+    ) -> None:
+        raise FailureConnectorException("FailureConnector copy_remote_to_local")
+
+    async def copy_remote_to_remote(
+        self,
+        src: str,
+        dst: str,
+        locations: MutableSequence[Location],
+        source_location: Location,
+        source_connector: Connector | None = None,
+        read_only: bool = False,
+    ) -> None:
+        raise FailureConnectorException("FailureConnector copy_remote_to_remote")
+
+    async def deploy(self, external: bool) -> None:
+        await asyncio.sleep(5)
+        logger.info("FailureConnector deploy")
+        raise FailureConnectorException("FailureConnector deploy")
+
+    async def get_available_locations(
+        self,
+        service: str | None = None,
+        input_directory: str | None = None,
+        output_directory: str | None = None,
+        tmp_directory: str | None = None,
+    ) -> MutableMapping[str, AvailableLocation]:
+        raise FailureConnectorException("FailureConnector get_available_locations")
+
+    async def run(
+        self,
+        location: Location,
+        command: MutableSequence[str],
+        environment: MutableMapping[str, str] = None,
+        workdir: str | None = None,
+        stdin: int | str | None = None,
+        stdout: int | str = asyncio.subprocess.STDOUT,
+        stderr: int | str = asyncio.subprocess.STDOUT,
+        capture_output: bool = False,
+        timeout: int | None = None,
+        job_name: str | None = None,
+    ) -> tuple[Any | None, int] | None:
+        raise FailureConnectorException("FailureConnector run")
+
+    async def undeploy(self, external: bool) -> None:
+        raise FailureConnectorException("FailureConnector undeploy")
+
+    async def get_stream_reader(
+        self, location: Location, src: str
+    ) -> StreamWrapperContextManager:
+        raise FailureConnectorException("FailureConnector get_stream_reader")

--- a/tests/utils/connector.py
+++ b/tests/utils/connector.py
@@ -7,9 +7,41 @@ from streamflow.core.data import StreamWrapperContextManager
 from streamflow.core.deployment import (
     Connector,
     Location,
+    LOCAL_LOCATION,
 )
-from streamflow.core.scheduling import AvailableLocation
+from streamflow.core.scheduling import AvailableLocation, Hardware
+from streamflow.deployment.connector import LocalConnector
 from streamflow.log_handler import logger
+
+
+class ParameterizableHardwareConnector(LocalConnector):
+    def __init__(
+        self,
+        deployment_name: str,
+        config_dir: str,
+        hardware: Hardware,
+        transferBufferSize: int = 2**16,
+    ):
+        super().__init__(deployment_name, config_dir, transferBufferSize)
+        self.hardware = hardware
+
+    async def get_available_locations(
+        self,
+        service: str | None = None,
+        input_directory: str | None = None,
+        output_directory: str | None = None,
+        tmp_directory: str | None = None,
+    ) -> MutableMapping[str, AvailableLocation]:
+        return {
+            LOCAL_LOCATION: AvailableLocation(
+                name=LOCAL_LOCATION,
+                deployment=self.deployment_name,
+                service=service,
+                hostname="localhost",
+                slots=1,
+                hardware=self.hardware,
+            )
+        }
 
 
 class FailureConnectorException(Exception):

--- a/tests/utils/deployment.py
+++ b/tests/utils/deployment.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import os
 import tempfile
+from typing import cast
 
 import asyncssh
 import asyncssh.public_key
@@ -17,6 +18,7 @@ from streamflow.core.deployment import (
     Location,
     WrapsConfig,
 )
+from streamflow.deployment import DefaultDeploymentManager
 from tests.utils.data import get_data_path
 
 
@@ -186,6 +188,10 @@ async def get_slurm_deployment_config(_context: StreamFlowContext):
 
 
 async def get_ssh_deployment_config(_context: StreamFlowContext):
+    if config := cast(
+        DefaultDeploymentManager, _context.deployment_manager
+    ).config_map.get("linuxserver-ssh"):
+        return config
     skey = asyncssh.public_key.generate_private_key(
         alg_name="ssh-rsa",
         comment="streamflow-test",

--- a/tests/utils/deployment.py
+++ b/tests/utils/deployment.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import os
 import tempfile
-from typing import cast
+from typing import cast, MutableSequence
 
 import asyncssh
 import asyncssh.public_key
@@ -17,7 +17,10 @@ from streamflow.core.deployment import (
     LOCAL_LOCATION,
     Location,
     WrapsConfig,
+    BindingFilter,
+    Target,
 )
+from streamflow.core.workflow import Job
 from streamflow.deployment import DefaultDeploymentManager
 from tests.utils.data import get_data_path
 
@@ -231,3 +234,14 @@ async def get_ssh_deployment_config(_context: StreamFlowContext):
         external=False,
         lazy=False,
     )
+
+
+class ReverseTargetsBindingFilter(BindingFilter):
+    async def get_targets(
+        self, job: Job, targets: MutableSequence[Target]
+    ) -> MutableSequence[Target]:
+        return targets[::-1]
+
+    @classmethod
+    def get_schema(cls) -> str:
+        return ""

--- a/tests/utils/deployment.py
+++ b/tests/utils/deployment.py
@@ -65,6 +65,16 @@ def get_docker_compose_deployment_config():
     )
 
 
+def get_failure_deployment_config():
+    return DeploymentConfig(
+        name="failure-test",
+        type="failure",
+        config={"transferBufferSize": 0},
+        external=False,
+        lazy=True,
+    )
+
+
 def get_kubernetes_deployment_config():
     template = Template(files(__package__).joinpath("pod.jinja2").read_text("utf-8"))
     with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:


### PR DESCRIPTION
This commit introduces a mechanism to awake pending executions on the `asyncio.Event`.
When there are concurrent tasks that want to deploy a location, only one task makes the deployment, while the others wait for the first to terminate. However, if the first gets an exception, all the other tasks must be awakened and raise a `WorkflowExecutionException`.