### PR TITLE
Fixed input ports of `DotProductSizeTransformer`

### DIFF
--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -1,0 +1,56 @@
+import argparse
+import json
+import tempfile
+from typing import MutableMapping
+
+import pytest
+
+from streamflow.core.context import StreamFlowContext
+from streamflow.core.exception import WorkflowExecutionException
+from streamflow.cwl import runner
+
+from cwltool.tests.util import get_data
+
+
+def _get_args(
+    cwltool_definition_relpath: str,
+    cwltool_config_relpath: str | None = None,
+    inline_config: MutableMapping | None = None,
+) -> argparse.Namespace:
+    temp_dir = tempfile.TemporaryDirectory()
+
+    cwl_definition_abspath = get_data(cwltool_definition_relpath)
+    if (cwltool_config_relpath and inline_config) or (
+        not cwltool_config_relpath and not inline_config
+    ):
+        raise Exception(
+            f"cwltool_config_relpath and inline_config parameters are mutually exclusive. Define just one of them. Current values: {cwltool_config_relpath, inline_config}"
+        )
+    elif cwltool_config_relpath:
+        cwl_config_abspath = get_data(cwltool_config_relpath)
+    elif inline_config:
+        temp_config = tempfile.NamedTemporaryFile(delete=False)
+        cwl_config_abspath = temp_config.name
+        with open(cwl_config_abspath, "w") as fd:
+            fd.write(json.dumps(inline_config))
+
+    return runner.parser.parse_args(
+        [
+            cwl_definition_abspath,
+            cwl_config_abspath,
+            "--debug",
+            "--outdir",
+            temp_dir.name,
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_dot_product_transformer_raise_error(context: StreamFlowContext) -> None:
+    """Test DotProductSizeTransformer which must raise an exception because the size tokens have different values"""
+    args = _get_args(
+        "tests/wf/scatter-wf4.cwl",
+        inline_config={"inp1": ["one", "two", "extra"], "inp2": ["three", "four"]},
+    )
+    with pytest.raises(WorkflowExecutionException):
+        await runner._async_main(args)

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -1,58 +1,29 @@
 from __future__ import annotations
 
-import argparse
 import json
 import tempfile
-from typing import MutableMapping
+from typing import MutableMapping, Any
 
 import pytest
 
 from streamflow.core.context import StreamFlowContext
-from streamflow.core.exception import WorkflowExecutionException
-from streamflow.cwl import runner
+from streamflow.cwl.runner import main
 
 from cwltool.tests.util import get_data
 
 
-def _get_args(
-    cwltool_definition_relpath: str,
-    cwltool_config_relpath: str | None = None,
-    inline_config: MutableMapping | None = None,
-) -> argparse.Namespace:
-    temp_dir = tempfile.TemporaryDirectory()
-
-    cwl_definition_abspath = get_data(cwltool_definition_relpath)
-    if (cwltool_config_relpath and inline_config) or (
-        not cwltool_config_relpath and not inline_config
-    ):
-        raise Exception(
-            f"cwltool_config_relpath and inline_config parameters are mutually exclusive. Define just one of them. Current values: {cwltool_config_relpath, inline_config}"
-        )
-    elif cwltool_config_relpath:
-        cwl_config_abspath = get_data(cwltool_config_relpath)
-    elif inline_config:
-        temp_config = tempfile.NamedTemporaryFile(delete=False)
-        cwl_config_abspath = temp_config.name
-        with open(cwl_config_abspath, "w") as fd:
-            fd.write(json.dumps(inline_config))
-
-    return runner.parser.parse_args(
-        [
-            cwl_definition_abspath,
-            cwl_config_abspath,
-            "--debug",
-            "--outdir",
-            temp_dir.name,
-        ]
-    )
+def _create_file(content: MutableMapping[Any, Any]) -> str:
+    temp_config = tempfile.NamedTemporaryFile(delete=False)
+    with open(temp_config.name, "w") as fd:
+        fd.write(json.dumps(content))
+    return temp_config.name
 
 
 @pytest.mark.asyncio
-async def test_dot_product_transformer_raise_error(context: StreamFlowContext) -> None:
+def test_dot_product_transformer_raises_error(context: StreamFlowContext) -> None:
     """Test DotProductSizeTransformer which must raise an exception because the size tokens have different values"""
-    args = _get_args(
-        "tests/wf/scatter-wf4.cwl",
-        inline_config={"inp1": ["one", "two", "extra"], "inp2": ["three", "four"]},
-    )
-    with pytest.raises(WorkflowExecutionException):
-        await runner._async_main(args)
+    params = [
+        get_data("tests/wf/scatter-wf4.cwl"),
+        _create_file({"inp1": ["one", "two", "extra"], "inp2": ["three", "four"]}),
+    ]
+    assert main(params) == 1

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import json
 import tempfile


### PR DESCRIPTION
This commit fixes the matching of the size port, mostly in the case of `dot_product`. Before this commit, in the `DotProductSizeTransformer` the exception was not raised if the sizes were different 