### PR TITLE
Fixed wrapped connector calls for `QueueManagerConnector` classes

### DIFF
--- a/streamflow/deployment/connector/queue_manager.py
+++ b/streamflow/deployment/connector/queue_manager.py
@@ -615,13 +615,13 @@ class SlurmConnector(QueueManagerConnector):
         ]
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(f"Running command {' '.join(command)}")
-        stdout, _ = await self.connector.run(
+        stdout, _ = await super().run(
             location=location,
             command=command,
             capture_output=True,
         )
         if output_path := stdout.strip():
-            stdout, _ = await self.connector.run(
+            stdout, _ = await super().run(
                 location=location, command=["cat", output_path], capture_output=True
             )
             return stdout.strip()
@@ -642,7 +642,7 @@ class SlurmConnector(QueueManagerConnector):
         ]
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(f"Running command {' '.join(command)}")
-        stdout, _ = await self.connector.run(
+        stdout, _ = await super().run(
             location=location,
             command=command,
             capture_output=True,
@@ -684,7 +684,7 @@ class SlurmConnector(QueueManagerConnector):
         ]
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(f"Running command {' '.join(command)}")
-        stdout, _ = await self.connector.run(
+        stdout, _ = await super().run(
             location=location,
             command=command,
             capture_output=True,
@@ -698,7 +698,7 @@ class SlurmConnector(QueueManagerConnector):
     async def _remove_jobs(
         self, location: ExecutionLocation, jobs: MutableSequence[str]
     ) -> None:
-        await self.connector.run(
+        await super().run(
             location=location,
             command=["scancel", " ".join(jobs)],
         )
@@ -836,7 +836,7 @@ class SlurmConnector(QueueManagerConnector):
                 batch_command.append(get_option("time", service.time))
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(f"Running command {' '.join(batch_command)}")
-        stdout, returncode = await self.connector.run(
+        stdout, returncode = await super().run(
             location=location, command=batch_command, capture_output=True
         )
         if returncode == 0:
@@ -863,7 +863,7 @@ class PBSConnector(QueueManagerConnector):
         if ":" in output_path:
             output_path = "".join(output_path.split(":")[1:])
         if output_path:
-            stdout, _ = await self.connector.run(
+            stdout, _ = await super().run(
                 location=location, command=["cat", output_path], capture_output=True
             )
             return stdout.strip()
@@ -889,7 +889,7 @@ class PBSConnector(QueueManagerConnector):
         ]
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(f"Running command {command}")
-        stdout, _ = await self.connector.run(
+        stdout, _ = await super().run(
             location=location,
             command=command,
             capture_output=True,
@@ -905,7 +905,7 @@ class PBSConnector(QueueManagerConnector):
     async def _remove_jobs(
         self, location: ExecutionLocation, jobs: MutableSequence[str]
     ) -> None:
-        await self.connector.run(location=location, command=["qdel", " ".join(jobs)])
+        await super().run(location=location, command=["qdel", " ".join(jobs)])
 
     async def _run_batch_command(
         self,
@@ -984,7 +984,7 @@ class PBSConnector(QueueManagerConnector):
                 get_option("l", ",".join([f"{k}={v}" for k, v in resources]))
             )
         batch_command.append("-")
-        stdout, returncode = await self.connector.run(
+        stdout, returncode = await super().run(
             location=location, command=batch_command, capture_output=True
         )
         if returncode == 0:
@@ -1003,7 +1003,7 @@ class PBSConnector(QueueManagerConnector):
         ]
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(f"Running command {command}")
-        stdout, _ = await self.connector.run(
+        stdout, _ = await super().run(
             location=location,
             command=command,
             capture_output=True,
@@ -1035,13 +1035,13 @@ class FluxConnector(QueueManagerConnector):
         ]
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(f"Running command {' '.join(command)}")
-        stdout, _ = await self.connector.run(
+        stdout, _ = await super().run(
             location=location,
             command=command,
             capture_output=True,
         )
         if output_path := stdout.strip():
-            stdout, _ = await self.connector.run(
+            stdout, _ = await super().run(
                 location=location, command=["cat", output_path], capture_output=True
             )
             return stdout.strip()
@@ -1059,7 +1059,7 @@ class FluxConnector(QueueManagerConnector):
         ]
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(f"Running command {' '.join(command)}")
-        stdout, _ = await self.connector.run(
+        stdout, _ = await super().run(
             location=location,
             command=command,
             capture_output=True,
@@ -1088,7 +1088,7 @@ class FluxConnector(QueueManagerConnector):
         ]
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(f"Running command {' '.join(command)}")
-        stdout, _ = await self.connector.run(
+        stdout, _ = await super().run(
             location=location,
             command=command,
             capture_output=True,
@@ -1103,7 +1103,7 @@ class FluxConnector(QueueManagerConnector):
     async def _remove_jobs(
         self, location: ExecutionLocation, jobs: MutableSequence[str]
     ) -> None:
-        await self.connector.run(
+        await super().run(
             location=location,
             command=["flux", "job", "cancel", " ".join(jobs)],
         )
@@ -1191,7 +1191,7 @@ class FluxConnector(QueueManagerConnector):
         batch_command.append(get_option("nodes", nodes))
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(f"Running command {' '.join(batch_command)}")
-        stdout, returncode = await self.connector.run(
+        stdout, returncode = await super().run(
             location=location, command=batch_command, capture_output=True
         )
         if returncode == 0:

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -64,13 +64,21 @@ async def test_connector_run_command(
     curr_location: ExecutionLocation,
 ) -> None:
     """Test connector run method"""
-    stdout, returncode = await curr_connector.run(
-        location=curr_location,
-        command=["ls"],
-        capture_output=True,
-        # job_name="job_test" # todo: fix SlurmConnector
+    _, returncode = await curr_connector.run(
+        location=curr_location, command=["ls"], capture_output=True, job_name="job_test"
     )
     assert returncode == 0
+
+
+@pytest.mark.asyncio
+async def test_connector_run_command_fails(
+    curr_connector: Connector, curr_location: ExecutionLocation
+):
+    """Test connector run method on a job with an invalid command"""
+    _, returncode = await curr_connector.run(
+        curr_location, ["ls -2"], capture_output=True, job_name="job_test"
+    )
+    assert returncode != 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This commit fixes a bug wrapping the `QueueManagerConnector` with any `Connector`.
Before this commit, the wrapped connector methods were called directly in the `QueueManagerConnector` methods, however they did not pass the right location (in particular, the `location` object  was passed in the methods instead of `location.wraps`).
Now, the `QueueManagerConnector` methods call their parent methods, i.e. `ConnectorWrapper` methods, which manages the right match between `Connector` and location.