### PR TITLE
Fixed glob on symbolic link path

### DIFF
--- a/streamflow/cwl/utils.py
+++ b/streamflow/cwl/utils.py
@@ -49,25 +49,25 @@ async def _check_glob_path(
     output_directory: str,
     tmp_directory: str,
     path: str,
-    effective_path: str,
+    realpath: str,
 ) -> None:
     # Cannot glob outside the job output folder
     if not (
-        effective_path.startswith(output_directory)
-        or effective_path.startswith(input_directory)
-        or effective_path.startswith(tmp_directory)
+        realpath.startswith(output_directory)
+        or realpath.startswith(input_directory)
+        or realpath.startswith(tmp_directory)
     ):
         path_processor = get_path_processor(connector)
-        relpath = path_processor.relpath(path, output_directory)
+        relative_path = path_processor.relpath(path, output_directory)
         base_path = (
-            path_processor.normpath(effective_path[: -len(relpath)])
-            if effective_path.endswith(relpath)
-            else path_processor.dirname(effective_path)
+            path_processor.normpath(realpath[: -len(relative_path)])
+            if realpath.endswith(relative_path)
+            else path_processor.dirname(realpath)
         )
         if not await search_in_parent_locations(
             context=workflow.context,
             connector=connector,
-            path=effective_path,
+            path=realpath,
             relpath=path_processor.relpath(path, output_directory),
             base_path=base_path,
         ):
@@ -455,7 +455,7 @@ async def expand_glob(
                     output_directory=output_directory,
                     tmp_directory=tmp_directory,
                     path=p,
-                    effective_path=ep or p,
+                    realpath=ep or p,
                 )
             )
             for p, ep in zip(paths, effective_paths)

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -1328,12 +1328,23 @@ class ScheduleStep(BaseStep):
         job.tmp_directory = _get_directory(
             path_processor, job.tmp_directory, allocation.target
         )
+
         # Create directories
         await remotepath.mkdirs(
             connector=connector,
             locations=locations,
             paths=[job.input_directory, job.output_directory, job.tmp_directory],
         )
+        job.input_directory = await remotepath.follow_symlink(
+            self.workflow.context, connector, locations[0], job.input_directory
+        )
+        job.output_directory = await remotepath.follow_symlink(
+            self.workflow.context, connector, locations[0], job.output_directory
+        )
+        job.tmp_directory = await remotepath.follow_symlink(
+            self.workflow.context, connector, locations[0], job.tmp_directory
+        )
+
         # Register paths
         for location in locations:
             for directory in (


### PR DESCRIPTION
This commit fixes an issue when checking glob on a step output that involves a symbolic link path. Before this commit, StreamFlow was just checking if the `dirname` of the output real path was the same of some `Job` directories.
However, if `Job` directories were containing a symbolic link path the check failed.

This commit ensures that all the directories stored in a `Job` object are real paths, without symbolic links. In this way, the glob checking never involves symbolic links, fixing the issue.