### PR TITLE
Removed `scheduling_policy` attribute in `Target` class

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -147,7 +147,7 @@ jobs:
           python -m pip install -r docs/requirements.txt
       - name: "Build documentation and check for consistency"
         env:
-          CHECKSUM: "5779fa47cef4264d5c279196c77b1cc18eb9eb798f9d4d53b4d33a4b71ebd085"
+          CHECKSUM: "87841b34d0df353e95ee8f0e3167d0eca69de59567f79f378b0dce73b7d3aaf2"
         run: |
           cd docs
           HASH="$(make checksum | tail -n1)"

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -147,7 +147,7 @@ jobs:
           python -m pip install -r docs/requirements.txt
       - name: "Build documentation and check for consistency"
         env:
-          CHECKSUM: "87841b34d0df353e95ee8f0e3167d0eca69de59567f79f378b0dce73b7d3aaf2"
+          CHECKSUM: "86926f0f7803887a8f947c738f923b6fee1439a08efb5527530fa2eccb9f1604"
         run: |
           cd docs
           HASH="$(make checksum | tail -n1)"

--- a/docs/source/ext/scheduling.rst
+++ b/docs/source/ext/scheduling.rst
@@ -59,7 +59,7 @@ Type        Class
 default     streamflow.scheduling.scheduler.DefaultScheduler
 =======     ================================================
 
-In the ``DefaultScheduler`` implementation, scheduling attempts follow a simple First Come, First Served (FCFS) approach. The ``schedule`` method demands the allocation strategy to a ``Policy`` object specified in the StreamFlow file's ``bindings`` section through a ``target`` object's ``policy`` directive.  If no available allocation configuration can be found for a given ``Job``, it is queued until the next scheduling attempt.
+In the ``DefaultScheduler`` implementation, scheduling attempts follow a simple First Come, First Served (FCFS) approach. The ``schedule`` method demands the allocation strategy to a ``Policy`` object specified in the StreamFlow file's ``deployments`` section through the ``deployment`` object's ``policy`` directive.  If no available allocation configuration can be found for a given ``Job``, it is queued until the next scheduling attempt.
 
 As discussed above, a scheduling attempt occurs whenever a ``Job`` reaches a final state. Plus, to account for dynamic resource creation and deletion in remote execution environments (e.g., through the Kubernetes `HorizontalPodAutoscaler <https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/>`_) the ``DefaultScheduler`` can automatically perform a scheduling attempt for each queued ``Job`` at regular intervals. The duration of such intervals can be configured through the ``retry_delay`` parameter. A value of ``0`` (the default) turns off this behaviour.
 

--- a/docs/source/ext/scheduling.rst
+++ b/docs/source/ext/scheduling.rst
@@ -59,7 +59,7 @@ Type        Class
 default     streamflow.scheduling.scheduler.DefaultScheduler
 =======     ================================================
 
-In the ``DefaultScheduler`` implementation, scheduling attempts follow a simple First Come, First Served (FCFS) approach. The ``schedule`` method demands the allocation strategy to a ``Policy`` object specified in the StreamFlow file's ``deployments`` section through the ``deployment`` object's ``policy`` directive.  If no available allocation configuration can be found for a given ``Job``, it is queued until the next scheduling attempt.
+In the ``DefaultScheduler`` implementation, scheduling attempts follow a simple First Come, First Served (FCFS) approach. The ``schedule`` method demands the allocation strategy to a ``Policy`` object specified in the StreamFlow file's ``deployments`` section through the ``deployment`` object's ``scheduling_policy`` directive.  If no available allocation configuration can be found for a given ``Job``, it is queued until the next scheduling attempt.
 
 As discussed above, a scheduling attempt occurs whenever a ``Job`` reaches a final state. Plus, to account for dynamic resource creation and deletion in remote execution environments (e.g., through the Kubernetes `HorizontalPodAutoscaler <https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/>`_) the ``DefaultScheduler`` can automatically perform a scheduling attempt for each queued ``Job`` at regular intervals. The duration of such intervals can be configured through the ``retry_delay`` parameter. A value of ``0`` (the default) turns off this behaviour.
 

--- a/streamflow/config/config.py
+++ b/streamflow/config/config.py
@@ -46,6 +46,11 @@ class WorkflowConfig(Config):
                         "The `models` keyword is deprecated and will be removed in StreamFlow 0.3.0. "
                         "Use `deployments` instead."
                     )
+        for deployment_config in self.deployments.values():
+            policy = deployment_config.get("policy", "__DEFAULT__")
+            if policy not in self.policies:
+                raise WorkflowDefinitionException(f"Policy {policy} is not defined")
+            deployment_config["policy"] = self.policies[policy]
         self.scheduling_groups: MutableMapping[str, MutableSequence[str]] = {}
         for name, deployment in self.deployments.items():
             deployment["name"] = name
@@ -65,16 +70,6 @@ class WorkflowConfig(Config):
             if isinstance(binding["target"], MutableSequence)
             else [binding["target"]]
         )
-        for target in targets:
-            policy = target.get(
-                "policy",
-                self.deployments[target.get("deployment", target.get("model", {}))].get(
-                    "policy", "__DEFAULT__"
-                ),
-            )
-            if policy not in self.policies:
-                raise WorkflowDefinitionException(f"Policy {policy} is not defined")
-            target["policy"] = self.policies[policy]
         target_type = "step" if "step" in binding else "port"
         if target_type == "port" and "workdir" not in binding["target"]:
             raise WorkflowDefinitionException(

--- a/streamflow/config/config.py
+++ b/streamflow/config/config.py
@@ -47,10 +47,10 @@ class WorkflowConfig(Config):
                         "Use `deployments` instead."
                     )
         for deployment_config in self.deployments.values():
-            policy = deployment_config.get("policy", "__DEFAULT__")
+            policy = deployment_config.get("scheduling_policy", "__DEFAULT__")
             if policy not in self.policies:
                 raise WorkflowDefinitionException(f"Policy {policy} is not defined")
-            deployment_config["policy"] = self.policies[policy]
+            deployment_config["scheduling_policy"] = self.policies[policy]
         self.scheduling_groups: MutableMapping[str, MutableSequence[str]] = {}
         for name, deployment in self.deployments.items():
             deployment["name"] = name

--- a/streamflow/config/schemas/v1.0/config_schema.json
+++ b/streamflow/config/schemas/v1.0/config_schema.json
@@ -165,7 +165,7 @@
           "description": "If true, a model is deployed only when it becomes necessary for transfers or executions. If false, a DeployStep will deploy its related model as soon as it becomes fireable",
           "default": true
         },
-        "policy": {
+        "scheduling_policy": {
           "type": "string",
           "description": "The scheduling policy to be used with this deployment.",
           "default": "data_locality"

--- a/streamflow/config/schemas/v1.0/config_schema.json
+++ b/streamflow/config/schemas/v1.0/config_schema.json
@@ -296,11 +296,6 @@
           "description": "If greater than one, the STREAMFLOW_HOSTS variable contains the comma-separated list of nodes allocated for the task",
           "default": 1
         },
-        "policy": {
-          "type": "string",
-          "description": "The scheduling policy to be used with this target. Overrides the deployment policy when present.",
-          "default": "data_locality"
-        },
         "service": {
           "type": "string"
         },

--- a/streamflow/core/deployment.py
+++ b/streamflow/core/deployment.py
@@ -156,7 +156,16 @@ class DeploymentManager(SchemaEntity):
 
 
 class DeploymentConfig(PersistableEntity):
-    __slots__ = ("name", "type", "config", "external", "lazy", "workdir", "wraps")
+    __slots__ = (
+        "name",
+        "type",
+        "config",
+        "external",
+        "lazy",
+        "scheduling_policy",
+        "workdir",
+        "wraps",
+    )
 
     def __init__(
         self,
@@ -165,6 +174,7 @@ class DeploymentConfig(PersistableEntity):
         config: MutableMapping[str, Any],
         external: bool = False,
         lazy: bool = True,
+        scheduling_policy: Config | None = None,
         workdir: str | None = None,
         wraps: WrapsConfig | None = None,
     ) -> None:
@@ -174,6 +184,9 @@ class DeploymentConfig(PersistableEntity):
         self.config: MutableMapping[str, Any] = config or {}
         self.external: bool = external
         self.lazy: bool = lazy
+        self.scheduling_policy: Config | None = scheduling_policy or Config(
+            name="__DEFAULT__", type="data_locality", config={}
+        )
         self.workdir: str | None = workdir
         self.wraps: WrapsConfig | None = wraps
 
@@ -222,7 +235,6 @@ class Target(PersistableEntity):
         locations: int = 1,
         service: str | None = None,
         scheduling_group: str | None = None,
-        scheduling_policy: Config | None = None,
         workdir: str | None = None,
     ):
         super().__init__()
@@ -230,9 +242,6 @@ class Target(PersistableEntity):
         self.locations: int = locations
         self.service: str | None = service
         self.scheduling_group: str | None = scheduling_group
-        self.scheduling_policy: Config | None = scheduling_policy or Config(
-            name="__DEFAULT__", type="data_locality", config={}
-        )
         self.workdir: str = (
             workdir or self.deployment.workdir or _init_workdir(deployment.name)
         )

--- a/streamflow/deployment/manager.py
+++ b/streamflow/deployment/manager.py
@@ -137,6 +137,7 @@ class DefaultDeploymentManager(DeploymentManager):
                     config=inner_config["config"],
                     external=inner_config.get("external", False),
                     lazy=inner_config.get("lazy", True),
+                    scheduling_policy=inner_config["policy"],
                     workdir=inner_config.get("workdir"),
                     wraps=get_wraps_config(inner_config.get("wraps")),
                 )
@@ -161,6 +162,7 @@ class DefaultDeploymentManager(DeploymentManager):
                 },
                 external=deployment_config.external,
                 lazy=deployment_config.lazy,
+                scheduling_policy=deployment_config.scheduling_policy,
                 wraps=deployment_config.wraps,
             )
         # If it is not a ConnectorWrapper, do nothing

--- a/streamflow/deployment/manager.py
+++ b/streamflow/deployment/manager.py
@@ -137,7 +137,7 @@ class DefaultDeploymentManager(DeploymentManager):
                     config=inner_config["config"],
                     external=inner_config.get("external", False),
                     lazy=inner_config.get("lazy", True),
-                    scheduling_policy=inner_config["policy"],
+                    scheduling_policy=inner_config["scheduling_policy"],
                     workdir=inner_config.get("workdir"),
                     wraps=get_wraps_config(inner_config.get("wraps")),
                 )

--- a/streamflow/deployment/utils.py
+++ b/streamflow/deployment/utils.py
@@ -60,6 +60,7 @@ def get_binding_config(
                 config=target_deployment["config"],
                 external=target_deployment.get("external", False),
                 lazy=target_deployment.get("lazy", True),
+                scheduling_policy=target_deployment["policy"],
                 workdir=target_deployment.get("workdir"),
                 wraps=get_wraps_config(target_deployment.get("wraps")),
             )

--- a/streamflow/deployment/utils.py
+++ b/streamflow/deployment/utils.py
@@ -60,7 +60,7 @@ def get_binding_config(
                 config=target_deployment["config"],
                 external=target_deployment.get("external", False),
                 lazy=target_deployment.get("lazy", True),
-                scheduling_policy=target_deployment["policy"],
+                scheduling_policy=target_deployment["scheduling_policy"],
                 workdir=target_deployment.get("workdir"),
                 wraps=get_wraps_config(target_deployment.get("wraps")),
             )

--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -281,7 +281,7 @@ class DefaultScheduler(Scheduler):
                                         hardware_requirement=hardware_requirement,
                                         locations=target.locations,
                                         scheduling_policy=self._get_policy(
-                                            target.scheduling_policy
+                                            target.deployment.scheduling_policy
                                         ),
                                         available_locations=valid_locations,
                                     )
@@ -306,7 +306,7 @@ class DefaultScheduler(Scheduler):
                                 hardware_requirement=hardware_requirement,
                                 locations=target.locations,
                                 scheduling_policy=self._get_policy(
-                                    target.scheduling_policy
+                                    target.deployment.scheduling_policy
                                 ),
                                 available_locations=valid_locations,
                             )

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -83,7 +83,6 @@ def test_ext_support():
                             "deployment": "example",
                             "service": "example",
                             "locations": 2,
-                            "policy": "data_locality",
                             "workdir": "/path/to/workdir",
                         },
                     }
@@ -103,6 +102,7 @@ def test_ext_support():
             "example": {
                 "type": "slurm",
                 "config": {"maxConcurrentJobs": 10},
+                "policy": "data_locality",
             }
         },
         "deploymentManager": {"type": "default", "config": {}},

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -102,7 +102,7 @@ def test_ext_support():
             "example": {
                 "type": "slurm",
                 "config": {"maxConcurrentJobs": 10},
-                "policy": "data_locality",
+                "scheduling_policy": "data_locality",
             }
         },
         "deploymentManager": {"type": "default", "config": {}},


### PR DESCRIPTION
This commit moves the `scheduling_policy` attribute from the `Target` class to the `DeploymentConfig` class. This change will be helpful to implement future features into the `Scheduler` class.