### PR TITLE
Removed `scheduling_groups` attribute

### DIFF
--- a/streamflow/config/config.py
+++ b/streamflow/config/config.py
@@ -4,7 +4,6 @@ import logging
 from pathlib import PurePosixPath
 from typing import MutableSequence, TYPE_CHECKING
 
-from streamflow.core import utils
 from streamflow.core.config import Config
 from streamflow.core.exception import WorkflowDefinitionException
 from streamflow.log_handler import logger
@@ -51,17 +50,11 @@ class WorkflowConfig(Config):
             if policy not in self.policies:
                 raise WorkflowDefinitionException(f"Policy {policy} is not defined")
             deployment_config["scheduling_policy"] = self.policies[policy]
-        self.scheduling_groups: MutableMapping[str, MutableSequence[str]] = {}
         for name, deployment in self.deployments.items():
             deployment["name"] = name
         self.filesystem = {"children": {}}
         for binding in workflow_config.get("bindings", []):
-            if isinstance(binding, MutableSequence):
-                for b in binding:
-                    self._process_binding(b)
-                self.scheduling_groups[utils.random_name()] = binding
-            else:
-                self._process_binding(binding)
+            self._process_binding(binding)
         set_targets(self.filesystem, None)
 
     def _process_binding(self, binding: MutableMapping[str, Any]):

--- a/streamflow/config/schemas/v1.0/config_schema.json
+++ b/streamflow/config/schemas/v1.0/config_schema.json
@@ -368,19 +368,8 @@
         "bindings": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "$ref": "#/$defs/binding"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "$ref": "#/$defs/binding"
-                }
-              }
-            ]
+            "type": "object",
+            "$ref": "#/$defs/binding"
           },
           "uniqueItems": true
         }

--- a/streamflow/core/deployment.py
+++ b/streamflow/core/deployment.py
@@ -234,14 +234,12 @@ class Target(PersistableEntity):
         deployment: DeploymentConfig,
         locations: int = 1,
         service: str | None = None,
-        scheduling_group: str | None = None,
         workdir: str | None = None,
     ):
         super().__init__()
         self.deployment: DeploymentConfig = deployment
         self.locations: int = locations
         self.service: str | None = service
-        self.scheduling_group: str | None = scheduling_group
         self.workdir: str = (
             workdir or self.deployment.workdir or _init_workdir(deployment.name)
         )


### PR DESCRIPTION
This commit removes the `scheduling_groups` attribute in the `Target` and `Scheduler` classes. It is a feature that has never been fully implemented