### PR TITLE
Changed retrieval of location hardware in the `SSHConnector` class

### DIFF
--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -47,9 +47,9 @@ async def test_scheduling(
         name=utils.random_name(),
         workflow_id=0,
         inputs={},
-        input_directory=utils.random_name(),
-        output_directory=utils.random_name(),
-        tmp_directory=utils.random_name(),
+        input_directory=deployment_config.workdir,
+        output_directory=deployment_config.workdir,
+        tmp_directory=deployment_config.workdir,
     )
     hardware_requirement = Hardware(cores=1)
     target = Target(


### PR DESCRIPTION
This commit introduces some changes in the `SSHConnector` class:
- remove the `hardwareCache` attribute
- improve the performance creating tasks through the `asyncio.create_task` function to retrieve the hardware of each location. Before this commit, the hardware retrieval of each location was done sequentially.
- reduce the number of remote communications to retrieve location hardware. Before this commit, there were **five** communications, now only one.
- reduce the number of remote communications to check for existing directories in one communication, instead of initiating a dedicated communication for each directory