### PR TITLE
Refactor test_scheduler

### DIFF
--- a/tests/utils/connector.py
+++ b/tests/utils/connector.py
@@ -92,13 +92,12 @@ class FailureConnector(Connector):
 
 class ParameterizableHardwareConnector(LocalConnector):
     def __init__(
-        self,
-        deployment_name: str,
-        config_dir: str,
-        hardware: Hardware,
-        transferBufferSize: int = 2**16,
+        self, deployment_name: str, config_dir: str, transferBufferSize: int = 2**16
     ):
         super().__init__(deployment_name, config_dir, transferBufferSize)
+        self.hardware = None
+
+    def set_hardware(self, hardware: Hardware):
         self.hardware = hardware
 
     async def get_available_locations(

--- a/tests/utils/deployment.py
+++ b/tests/utils/deployment.py
@@ -25,6 +25,27 @@ from streamflow.deployment import DefaultDeploymentManager
 from tests.utils.data import get_data_path
 
 
+def get_deployment(_context: StreamFlowContext, deployment_t: str) -> str:
+    if deployment_t == "local":
+        return LOCAL_LOCATION
+    elif deployment_t == "docker":
+        return "alpine-docker"
+    elif deployment_t == "docker-compose":
+        return "alpine-docker-compose"
+    elif deployment_t == "kubernetes":
+        return "alpine-kubernetes"
+    elif deployment_t == "parameterizable_hardware":
+        return "custom-hardware"
+    elif deployment_t == "singularity":
+        return "alpine-singularity"
+    elif deployment_t == "slurm":
+        return "docker-slurm"
+    elif deployment_t == "ssh":
+        return "linuxserver-ssh"
+    else:
+        raise Exception(f"{deployment_t} deployment type not supported")
+
+
 async def get_deployment_config(
     _context: StreamFlowContext, deployment_t: str
 ) -> DeploymentConfig:
@@ -36,6 +57,8 @@ async def get_deployment_config(
         return get_docker_compose_deployment_config()
     elif deployment_t == "kubernetes":
         return get_kubernetes_deployment_config()
+    elif deployment_t == "parameterizable_hardware":
+        return get_parameterizable_hardware_deployment_config()
     elif deployment_t == "singularity":
         return get_singularity_deployment_config()
     elif deployment_t == "slurm":
@@ -44,16 +67,6 @@ async def get_deployment_config(
         return await get_ssh_deployment_config(_context)
     else:
         raise Exception(f"{deployment_t} deployment type not supported")
-
-
-def get_docker_deployment_config():
-    return DeploymentConfig(
-        name="alpine-docker",
-        type="docker",
-        config={"image": "alpine:3.16.2"},
-        external=False,
-        lazy=False,
-    )
 
 
 def get_docker_compose_deployment_config():
@@ -65,6 +78,16 @@ def get_docker_compose_deployment_config():
                 str(get_data_path("deployment", "docker-compose", "docker-compose.yml"))
             ]
         },
+        external=False,
+        lazy=False,
+    )
+
+
+def get_docker_deployment_config():
+    return DeploymentConfig(
+        name="alpine-docker",
+        type="docker",
+        config={"image": "alpine:3.16.2"},
         external=False,
         lazy=False,
     )
@@ -104,25 +127,6 @@ def get_local_deployment_config():
     )
 
 
-def get_deployment(_context: StreamFlowContext, deployment_t: str) -> str:
-    if deployment_t == "local":
-        return LOCAL_LOCATION
-    elif deployment_t == "docker":
-        return "alpine-docker"
-    elif deployment_t == "docker-compose":
-        return "alpine-docker-compose"
-    elif deployment_t == "kubernetes":
-        return "alpine-kubernetes"
-    elif deployment_t == "singularity":
-        return "alpine-singularity"
-    elif deployment_t == "slurm":
-        return "docker-slurm"
-    elif deployment_t == "ssh":
-        return "linuxserver-ssh"
-    else:
-        raise Exception(f"{deployment_t} deployment type not supported")
-
-
 async def get_location(
     _context: StreamFlowContext, deployment_t: str
 ) -> ExecutionLocation:
@@ -133,21 +137,32 @@ async def get_location(
     return next(iter(locations.values())).location
 
 
+def get_parameterizable_hardware_deployment_config():
+    return DeploymentConfig(
+        name="custom-hardware",
+        type="parameterizable_hardware",
+        config={},
+        external=True,
+        lazy=False,
+        workdir=os.path.realpath(tempfile.gettempdir()),
+    )
+
+
 def get_service(_context: StreamFlowContext, deployment_t: str) -> str | None:
-    if deployment_t == "local":
-        return None
-    elif deployment_t == "docker":
+    if deployment_t in (
+        "local",
+        "docker",
+        "parameterizable_hardware",
+        "singularity",
+        "ssh",
+    ):
         return None
     elif deployment_t == "docker-compose":
         return "alpine"
     elif deployment_t == "kubernetes":
         return "sf-test"
-    elif deployment_t == "singularity":
-        return None
     elif deployment_t == "slurm":
         return "test"
-    elif deployment_t == "ssh":
-        return None
     else:
         raise Exception(f"{deployment_t} deployment type not supported")
 

--- a/tests/utils/workflow.py
+++ b/tests/utils/workflow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import posixpath
 from typing import MutableSequence, TYPE_CHECKING
 
@@ -96,3 +97,8 @@ def get_nested_crossproduct():
     items = c1.get_items(False)
     combinator.add_combinator(c1, items)
     return combinator
+
+
+def random_job_name(step_name: str | None = None):
+    step_name = step_name or utils.random_name()
+    return os.path.join(posixpath.sep, step_name, "0.0")


### PR DESCRIPTION
This commit improves the readability of the tests on the `scheduler` component using the standard StreamFlow APIs. In particular, this commit introduces the following improvements:

- The `workdir` attribute of the `target` objects is populated with the deployment workdir (instead of  a random strings) 
- Jobs have the conventional name `/step_name/token_tag` (instead of a random string) 
- `ParameterizableHardwareConnector` objects are instantiated explicitly, instead of being injected in place of  the `LocalConnector` object
- `ReverseTargetsBindingFilter` objects are instantiated explicitly