### PR TITLE
Fixed `ValueFromTransformer`

### DIFF
--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -2496,9 +2496,9 @@ class CWLTranslator:
             schedule_step = workflow.create_step(
                 cls=ScheduleStep,
                 name=posixpath.join(
-                    global_name + inner_steps_prefix + "-injector", "__schedule__"
+                    global_name + inner_steps_prefix + "-value-from", "__schedule__"
                 ),
-                job_prefix=f"{global_name}-injector",
+                job_prefix=f"{global_name}-value-from",
                 connector_ports={target.deployment.name: deploy_step.get_output_port()},
                 input_directory=target.workdir or self.output_directory,
                 output_directory=target.workdir or self.output_directory,

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -1728,9 +1728,12 @@ class Transformer(BaseStep, ABC):
         try:
             if self.input_ports:
                 inputs_map = {}
+                input_ports = {
+                    k: v for k, v in self.get_input_ports().items() if k != "__job__"
+                }
                 while True:
                     # Retrieve input tokens
-                    inputs = await self._get_inputs(self.get_input_ports())
+                    inputs = await self._get_inputs(input_ports)
                     # Check for termination
                     if check_termination(inputs.values()):
                         break
@@ -1738,7 +1741,7 @@ class Transformer(BaseStep, ABC):
                     _group_by_tag(inputs, inputs_map)
                     # Process tags
                     for tag in list(inputs_map.keys()):
-                        if len(inputs_map[tag]) == len(self.input_ports):
+                        if len(inputs_map[tag]) == len(input_ports):
                             inputs = inputs_map.pop(tag)
                             # Check for iteration termination and propagate
                             if check_iteration_termination(inputs.values()):

--- a/tests/test_cwl_build_wf.py
+++ b/tests/test_cwl_build_wf.py
@@ -29,6 +29,7 @@ from streamflow.cwl.transformer import (
     OnlyNonNullTransformer,
     ValueFromTransformer,
 )
+from streamflow.workflow.port import JobPort
 from streamflow.workflow.step import CombinatorStep
 from tests.conftest import are_equals
 from tests.test_build_wf import (
@@ -142,6 +143,7 @@ async def test_list_to_element_transformer(context: StreamFlowContext):
 async def test_loop_value_from_transformer(context: StreamFlowContext):
     """Test saving LoopValueFromTransformer on database and re-load it in a new Workflow"""
     workflow, (port,) = await create_workflow(context, num_port=1)
+    job_port = workflow.create_port(JobPort)
     step, new_workflow, new_step = await _base_step_test_process(
         workflow,
         LoopValueFromTransformer,
@@ -154,6 +156,7 @@ async def test_loop_value_from_transformer(context: StreamFlowContext):
             "port_name": port.name,
             "full_js": True,
             "value_from": f"$(inputs.{port.name} + 1)",
+            "job_port": job_port,
         },
         context,
         test_are_eq=False,
@@ -195,6 +198,7 @@ async def test_non_null_transformer(
 async def test_value_from_transformer(context: StreamFlowContext):
     """Test saving ValueFromTransformer on database and re-load it in a new Workflow"""
     workflow, (port,) = await create_workflow(context, num_port=1)
+    job_port = workflow.create_port(JobPort)
     step, new_workflow, new_step = await _base_step_test_process(
         workflow,
         ValueFromTransformer,
@@ -207,6 +211,7 @@ async def test_value_from_transformer(context: StreamFlowContext):
             "port_name": port.name,
             "full_js": True,
             "value_from": f"$(inputs.{port.name} + 1)",
+            "job_port": job_port,
         },
         context,
         test_are_eq=False,

--- a/tests/test_cwl_persistence.py
+++ b/tests/test_cwl_persistence.py
@@ -49,6 +49,7 @@ from streamflow.cwl.transformer import (
     ValueFromTransformer,
 )
 from streamflow.cwl.utils import LoadListing, SecondaryFile
+from streamflow.workflow.port import JobPort
 from streamflow.workflow.step import CombinatorStep, ExecuteStep
 from tests.conftest import save_load_and_test
 
@@ -470,6 +471,7 @@ async def test_value_from_transformer(context: StreamFlowContext):
         context=context, type="cwl", name=utils.random_name(), config={}
     )
     port = workflow.create_port()
+    job_port = workflow.create_port(JobPort)
     await workflow.save(context)
 
     name = utils.random_name()
@@ -481,6 +483,7 @@ async def test_value_from_transformer(context: StreamFlowContext):
         expression_lib=True,
         full_js=False,
         value_from="$(1 + 1)",
+        job_port=job_port,
     )
     await save_load_and_test(transformer, context)
 
@@ -492,6 +495,7 @@ async def test_loop_value_from_transformer(context: StreamFlowContext):
         context=context, type="cwl", name=utils.random_name(), config={}
     )
     port = workflow.create_port()
+    job_port = workflow.create_port(JobPort)
     await workflow.save(context)
 
     name = utils.random_name()
@@ -503,6 +507,7 @@ async def test_loop_value_from_transformer(context: StreamFlowContext):
         expression_lib=True,
         full_js=False,
         value_from="$(1 + 1 == 0)",
+        job_port=job_port,
     )
     await save_load_and_test(transformer, context)
 

--- a/tests/test_cwl_provenance.py
+++ b/tests/test_cwl_provenance.py
@@ -224,6 +224,8 @@ async def test_cwl_token_transformer(context: StreamFlowContext):
 async def test_value_from_transformer(context: StreamFlowContext):
     """Test token provenance for ValueFromTransformer"""
     workflow, (in_port, out_port) = await create_workflow(context)
+    deploy_step = create_deploy_step(workflow)
+    schedule_step = create_schedule_step(workflow, [deploy_step])
     port_name = "test"
     token_list = [Token(10)]
     await _general_test(
@@ -241,6 +243,7 @@ async def test_value_from_transformer(context: StreamFlowContext):
             "port_name": in_port.name,
             "full_js": True,
             "value_from": f"$(inputs.{port_name} + 1)",
+            "job_port": schedule_step.get_output_port(),
         },
         token_list=token_list,
         port_name=port_name,
@@ -599,7 +602,8 @@ async def test_list_merge_combinator(context: StreamFlowContext):
 async def test_loop_value_from_transformer(context: StreamFlowContext):
     """Test token provenance for LoopValueFromTransformer"""
     workflow, (in_port, out_port) = await create_workflow(context)
-
+    deploy_step = create_deploy_step(workflow)
+    schedule_step = create_schedule_step(workflow, [deploy_step])
     name = utils.random_name()
     port_name = "test"
     transformer = workflow.create_step(
@@ -612,6 +616,7 @@ async def test_loop_value_from_transformer(context: StreamFlowContext):
         port_name=port_name,
         full_js=True,
         value_from=f"$(inputs.{port_name} + 1)",
+        job_port=schedule_step.get_output_port(),
     )
     loop_port = workflow.create_port()
     transformer.add_loop_input_port(port_name, in_port)


### PR DESCRIPTION
This commit fixes #399. Before this commit, the outputs of `ValueFromTransformer` were always a `Token` object. Instead, it is necessary to evaluate it, as happens in the `CWLInjectorInput` step, to create the appropriate `Token` class: `ObjectToken`, `ListToken`, `CWLFileToken` or `Token`.