### PR TITLE
Fixed scheduler timeout in Python<3.11

### DIFF
--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -287,7 +287,7 @@ class DefaultScheduler(Scheduler):
                     await asyncio.wait_for(
                         self.wait_queues[deployment].wait(), timeout=self.retry_interval
                     )
-                except TimeoutError:
+                except (TimeoutError, asyncio.exceptions.TimeoutError):
                     if logger.isEnabledFor(logging.DEBUG):
                         target_name = (
                             "/".join([target.deployment.name, target.service])


### PR DESCRIPTION
This commit fixes a bug using the timeout feature of the scheduler with Python version older than 3.11.
The `asyncio.wait_for` method raises two different `Timeout` exceptions depending on the Python version (see [doc](https://docs.python.org/3/library/asyncio-task.html#asyncio.wait_for)). Starting from Python 3.11, `Timeout` built-in exception is raised, while `asyncio.exceptions.Timeout` exception is raised with previous Python versions.
