### PR TITLE
Added `NoContainerCWLDockerTranslator`

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -147,7 +147,7 @@ jobs:
           python -m pip install -r docs/requirements.txt
       - name: "Build documentation and check for consistency"
         env:
-          CHECKSUM: "1ec60f9c4b89bfa0892207c6f909f44c147a6575783e094646e97fdb15a43c88"
+          CHECKSUM: "fc4e8f2b229f752a6370c215145464af21e2ba9c1001bc4ac6e0ea24a04c74ca"
         run: |
           cd docs
           HASH="$(make checksum | tail -n1)"

--- a/docs/source/cwl/docker-requirement.rst
+++ b/docs/source/cwl/docker-requirement.rst
@@ -22,7 +22,7 @@ The CWL standard supports a ``DockerRequirement`` feature to execute one or more
         type: stdout
     stdout: output.txt
 
-By default, StreamFlow autmoatically maps a step with the ``DockerRequirement`` option onto a :ref:`Docker <DockerConnector>` deployment with the specified image. This mapping is pretty much equivalent to the following ``streamflow.yml`` file:
+By default, StreamFlow automatically maps a step with the ``DockerRequirement`` option onto a :ref:`Docker <DockerConnector>` deployment with the specified image. This mapping is pretty much equivalent to the following ``streamflow.yml`` file:
 
 .. code-block:: yaml
 
@@ -44,7 +44,7 @@ By default, StreamFlow autmoatically maps a step with the ``DockerRequirement`` 
         config:
           image: node:slim
 
-StreamFlow also supports the possibility to map a CWL ``DockerRequirement`` onto different types of connectors through the :ref:`CWLDockerTranslator <CWLDockerTranslator>` extension point. In particular, the ``docker`` section of a workflow configuration can bind each step or subworkflow to a specific translator type, making it possible to convert a pure CWL workflow with ``DockerRequirement`` features into a hybrid workflow.
+StreamFlow also supports the possibility to map a CWL ``DockerRequirement`` onto different types of connectors through the :ref:`CWLDockerTranslator <CWLDockerTranslator>` extension point. In particular, the ``docker`` section of a workflow configuration can bind each step or subworkflow to a specific translator type, making it possible to convert a pure CWL workflow with ``DockerRequirement`` features into a hybrid workflow. The available translator types are: ``docker``, ``kubernetes``, ``none`` and ``singularity``.
 
 As an example, the following ``streamflow.yml`` file runs the above ``CommandLineTool`` using a :ref:`SingularityConnector <SingularityConnector>` instead of a :ref:`DockerConnector <DockerConnector>` to spawn the container:
 

--- a/docs/source/cwl/docker/no-container.rst
+++ b/docs/source/cwl/docker/no-container.rst
@@ -1,8 +1,7 @@
-=========================
-DockerCWLDockerTranslator
-=========================
+==============================
+NoContainerCWLDockerTranslator
+==============================
 
 The NoContainer :ref:`CWLDockerTranslator <CWLDockerTranslator>` ignores the given configuration for every CWL :ref:`DockerRequirement <CWL Docker Requirement>` specification in the selected subworkflow. The :ref:`LocalConnector <LocalConnector>` is used by default, unless there are bindings of the step to other deployment.
 
-.. jsonschema:: ../../../../streamflow/cwl/requirement/docker/schemas/no-container.json
-    :lift_description: true
+**WARNING:** Use this option with caution. The step execution may not work.  The user must manually ensure that the execution environment is properly configured with all the required software dependencies.

--- a/docs/source/cwl/docker/no-container.rst
+++ b/docs/source/cwl/docker/no-container.rst
@@ -1,0 +1,8 @@
+=========================
+DockerCWLDockerTranslator
+=========================
+
+The NoContainer :ref:`CWLDockerTranslator <CWLDockerTranslator>` ignores the given configuration for every CWL :ref:`DockerRequirement <CWL Docker Requirement>` specification in the selected subworkflow. The :ref:`LocalConnector <LocalConnector>` is used by default, unless there are bindings of the step to other deployment.
+
+.. jsonschema:: ../../../../streamflow/cwl/requirement/docker/schemas/no-container.json
+    :lift_description: true

--- a/docs/source/cwl/docker/no-container.rst
+++ b/docs/source/cwl/docker/no-container.rst
@@ -2,6 +2,6 @@
 NoContainerCWLDockerTranslator
 ==============================
 
-The NoContainer :ref:`CWLDockerTranslator <CWLDockerTranslator>` ignores the given configuration for every CWL :ref:`DockerRequirement <CWL Docker Requirement>` specification in the selected subworkflow. The :ref:`LocalConnector <LocalConnector>` is used by default, unless there are bindings of the step to other deployment.
+The NoContainer :ref:`CWLDockerTranslator <CWLDockerTranslator>` ignores the given configuration for every CWL :ref:`DockerRequirement <CWL Docker Requirement>` specification in the selected subworkflow. The :ref:`LocalConnector <LocalConnector>` is used by default, unless the step is explicitly bound to a different deployment.
 
 **WARNING:** Use this option with caution. The step execution may not work.  The user must manually ensure that the execution environment is properly configured with all the required software dependencies.

--- a/docs/source/ext/cwl-docker-translator.rst
+++ b/docs/source/ext/cwl-docker-translator.rst
@@ -2,7 +2,8 @@
 CWLDockerTranslator
 ===================
 
-StreamFlow relies on a ``CWLDockerTranslator`` object to convert a CWL `DockerRequirement <https://www.commonwl.org/v1.2/CommandLineTool.html#DockerRequirement>`_ specification into a step binding on a given :ref:`Connector <Connector>` instance. By default, the :ref:`DockerCWLDockerTranslator <DockerCWLDockerTranslator>` is used to spawn a :ref:`DockerConnector <DockerConnector>`. However, StreamFlow also supports translators for :ref:`Kubernetes <SingularityCWLDockerTranslator>` and :ref:`Singularity <KubernetesCWLDockerTranslator>`, and more can be implemented by the community using the :ref:`plugins <Plugins>` mechanism (see :ref:`here <CWL Docker Requirement>`).
+StreamFlow relies on a ``CWLDockerTranslator`` object to convert a CWL `DockerRequirement <https://www.commonwl.org/v1.2/CommandLineTool.html#DockerRequirement>`_ specification into a step binding on a given :ref:`Connector <Connector>` instance. By default, the :ref:`DockerCWLDockerTranslator <DockerCWLDockerTranslator>` is used to spawn a :ref:`DockerConnector <DockerConnector>`.
+However, StreamFlow also supports translators for :ref:`Kubernetes <KubernetesCWLDockerTranslator>`, :ref:`Singularity <SingularityCWLDockerTranslator>` and :ref:`NoContainer <NoContainerCWLDockerTranslator>`. This latter allows to execute the step without a container, even if the ``DockerRequirement`` feature is defined. More ``CWLDockerTranslators`` can be implemented by the community using the :ref:`plugins <Plugins>` mechanism (see :ref:`here <CWL Docker Requirement>`).
 
 The ``CWLDockerTranslator`` interface is defined in the ``streamflow.cwl.requirement.docker.translator`` module and exposes a single public method ``get_target``:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -97,6 +97,6 @@ For LaTeX users, the following BibTeX entry can be used:
    :hidden:
 
    cwl/docker/docker.rst
-   cwl/docker/no-container.rst
    cwl/docker/kubernetes.rst
+   cwl/docker/no-container.rst
    cwl/docker/singularity.rst

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -97,5 +97,6 @@ For LaTeX users, the following BibTeX entry can be used:
    :hidden:
 
    cwl/docker/docker.rst
+   cwl/docker/no-container.rst
    cwl/docker/kubernetes.rst
    cwl/docker/singularity.rst

--- a/streamflow/cwl/requirement/docker/__init__.py
+++ b/streamflow/cwl/requirement/docker/__init__.py
@@ -1,10 +1,12 @@
 from streamflow.cwl.requirement.docker.docker import DockerCWLDockerTranslator
 from streamflow.cwl.requirement.docker.kubernetes import KubernetesCWLDockerTranslator
+from streamflow.cwl.requirement.docker.nocontainer import NoContainerCWLDockerTranslator
 from streamflow.cwl.requirement.docker.singularity import SingularityCWLDockerTranslator
 
 cwl_docker_translator_classes = {
     "default": DockerCWLDockerTranslator,
     "docker": DockerCWLDockerTranslator,
     "kubernetes": KubernetesCWLDockerTranslator,
+    "none": NoContainerCWLDockerTranslator,
     "singularity": SingularityCWLDockerTranslator,
 }

--- a/streamflow/cwl/requirement/docker/nocontainer.py
+++ b/streamflow/cwl/requirement/docker/nocontainer.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from importlib_resources import files
+
+from streamflow.core.deployment import Target
+from streamflow.cwl.requirement.docker.translator import CWLDockerTranslator
+
+
+class NoContainerCWLDockerTranslator(CWLDockerTranslator):
+    def __init__(
+        self,
+        config_dir: str,
+        wrapper: bool,
+    ):
+        super().__init__(config_dir=config_dir, wrapper=wrapper)
+
+    @classmethod
+    def get_schema(cls) -> str:
+        return (
+            files(__package__)
+            .joinpath("schemas")
+            .joinpath("no-container.json")
+            .read_text("utf-8")
+        )
+
+    def get_target(
+        self,
+        image: str,
+        output_directory: str | None,
+        network_access: bool,
+        target: Target,
+    ) -> Target:
+        return target

--- a/streamflow/cwl/requirement/docker/schemas/no-container.json
+++ b/streamflow/cwl/requirement/docker/schemas/no-container.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://streamflow.di.unito.it/schemas/cwl/requirement/docker/no-container.json",
+  "type": "object",
+  "properties": {
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
This commit adds the possibility to execute a CWL step without using the containers even when it provides the `DockerRequirement` feature. In such case, the user must ensure that all the necessary applications are available on the bound execution locations.