### PR TITLE
Fixed prefix of input union types

### DIFF
--- a/streamflow/cwl/command.py
+++ b/streamflow/cwl/command.py
@@ -911,7 +911,9 @@ class CWLCommandToken:
                         value = [self.prefix] + list(value)
                     else:
                         value = [self.prefix, value]
-                elif not isinstance(value, MutableSequence):
+                elif isinstance(value, MutableSequence):
+                    value = [self.prefix, *value]
+                else:
                     value = [self.prefix + _get_value_repr(value)]
             # If value is a boolean with no prefix, skip it
             if isinstance(value, bool):

--- a/streamflow/cwl/command.py
+++ b/streamflow/cwl/command.py
@@ -911,9 +911,7 @@ class CWLCommandToken:
                         value = [self.prefix] + list(value)
                     else:
                         value = [self.prefix, value]
-                elif isinstance(value, MutableSequence):
-                    value = [self.prefix].extend(value)
-                else:
+                elif not isinstance(value, MutableSequence):
                     value = [self.prefix + _get_value_repr(value)]
             # If value is a boolean with no prefix, skip it
             if isinstance(value, bool):

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -957,7 +957,7 @@ def _get_command_token_from_input(
                 if token is not None:
                     command_tokens.append(token)
             if command_tokens:
-                token = CWLUnionCommandToken(
+                return CWLUnionCommandToken(
                     name=input_name,
                     value=command_tokens,
                     is_shell_command=True,


### PR DESCRIPTION
This commit fixes two problems:
- The `extend` built-in method of the `List` was used, but a return value was attended. However, the `extend` method operates in-place. 
- When a prefix is present in an input that has union types, the prefix was duplicated several times, e.g. `--input --input DATA`. The CWL `inputBinding` definition used to be evaluated both in the internal `CWLCommandToken` objects of the `CWLUnionCommandToken`, and in an external `CWLCommandToken` wrapping the `CWLUnionCommandToken`.  Now, the external `CWLCommandToken` is not created and it is used the `CWLUnionCommandToken` directly.