### PR TITLE
Re-introduced log level option in `DockerComposeConnector`

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -147,7 +147,7 @@ jobs:
           python -m pip install -r docs/requirements.txt
       - name: "Build documentation and check for consistency"
         env:
-          CHECKSUM: "8a3b1110a041d65b09a15c076ef8023f8d81a3aa2ee6faa632480f2f43ea30a1"
+          CHECKSUM: "b1583a89a95cc4516e4fb8cce606fb5796d35e476e03235dbeabf7cd51f8be7d"
         run: |
           cd docs
           HASH="$(make checksum | tail -n1)"

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,7 +19,10 @@ help:
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-checksum: html
+clean:
+	@rm -fr build/
+
+checksum: clean html
 	@echo "Documentation checksum: "
 	@find build/html/ 						\
 			-not -name 'searchindex.js'		\

--- a/streamflow/deployment/connector/schemas/docker-compose.json
+++ b/streamflow/deployment/connector/schemas/docker-compose.json
@@ -20,6 +20,17 @@
       "type": "boolean",
       "description": "Show more output"
     },
+    "logLevel": {
+      "type": "string",
+      "enum": [
+        "DEBUG",
+        "INFO",
+        "WARNING",
+        "ERROR",
+        "CRITICAL"
+      ],
+      "description": "Set log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)"
+    },
     "noAnsi": {
       "type": "boolean",
       "description": "Do not print ANSI control characters"


### PR DESCRIPTION
This commit re-introduces the log level configuration in the `DockerComposeConnector`. 
Moreover, it adds in the documentation makefile the `clean` rule.