### PR TITLE
Fixed StreamFlow name

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -91,7 +91,7 @@ jobs:
           kubectl apply -f https://docs.projectcalico.org/v3.25/manifests/calico.yaml
           kubectl -n kube-system set env daemonset/calico-node FELIX_IGNORELOOSERPF=true
         if: ${{ matrix.docker == 'kubernetes' }}
-      - name: "Install Streamflow"
+      - name: "Install StreamFlow"
         run: |
           python -m pip install . --user
       - name: "Test CWL ${{ matrix.version }} conformance"
@@ -147,7 +147,7 @@ jobs:
           python -m pip install -r docs/requirements.txt
       - name: "Build documentation and check for consistency"
         env:
-          CHECKSUM: "b1583a89a95cc4516e4fb8cce606fb5796d35e476e03235dbeabf7cd51f8be7d"
+          CHECKSUM: "1ec60f9c4b89bfa0892207c6f909f44c147a6575783e094646e97fdb15a43c88"
         run: |
           cd docs
           HASH="$(make checksum | tail -n1)"
@@ -172,7 +172,7 @@ jobs:
           rm -rf /opt/ghc
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Streamflow
+      - name: Install StreamFlow
         run: |
          pip install . 
          pip install --upgrade --force-reinstall attrs lockfile
@@ -201,7 +201,7 @@ jobs:
             requirements.txt
             test-requirements.txt
             tox.ini
-      - name: "Install Python Dependencies and Streamflow"
+      - name: "Install Python Dependencies and StreamFlow"
         run: |
           python -m pip install tox --user
           python -m pip install . --user
@@ -252,7 +252,7 @@ jobs:
           kubectl apply -f https://docs.projectcalico.org/v3.25/manifests/calico.yaml
           kubectl -n kube-system set env daemonset/calico-node FELIX_IGNORELOOSERPF=true
         if: ${{ startsWith(matrix.on, 'ubuntu-') }}
-      - name: "Install Python Dependencies and Streamflow"
+      - name: "Install Python Dependencies and StreamFlow"
         run: |
           python -m pip install tox --user
           python -m pip install . --user

--- a/docs/source/connector/flux.rst
+++ b/docs/source/connector/flux.rst
@@ -50,7 +50,7 @@ Being passed directly to the ``flux batch`` command line, the YAML options have 
 
 .. warning::
 
-    Note that the ``file`` property in the upper configuration level, i.e., outside a ``service`` definition, is still supported in Streamflow ``v0.2``, but it is deprecated and will be removed in StreamFlow ``v0.3``.
+    Note that the ``file`` property in the upper configuration level, i.e., outside a ``service`` definition, is still supported in StreamFlow ``v0.2``, but it is deprecated and will be removed in StreamFlow ``v0.3``.
 
 For a quick demo or tutorial, see our `example workflow <https://github.com/alpha-unito/streamflow/tree/master/examples/flux>`_.
 

--- a/docs/source/connector/pbs.rst
+++ b/docs/source/connector/pbs.rst
@@ -53,7 +53,7 @@ Being passed directly to the ``qsub`` command line, the YAML options have higher
 
 .. warning::
 
-    Note that the ``file`` property in the upper configuration level, i.e., outside a ``service`` definition, is still supported in Streamflow ``v0.2``, but it is deprecated and will be removed in StreamFlow ``v0.3``.
+    Note that the ``file`` property in the upper configuration level, i.e., outside a ``service`` definition, is still supported in StreamFlow ``v0.2``, but it is deprecated and will be removed in StreamFlow ``v0.3``.
 
 The unit of binding is the entire HPC facility. In contrast, the scheduling unit is a single job placement in the PBS queue. Users can limit the maximum number of concurrently placed jobs by setting the ``maxConcurrentJobs`` parameter.
 

--- a/docs/source/connector/slurm.rst
+++ b/docs/source/connector/slurm.rst
@@ -52,7 +52,7 @@ Being passed directly to the ``sbatch`` command line, the YAML options have high
 
 .. warning::
 
-    Note that the ``file`` property in the upper configuration level, i.e., outside a ``service`` definition, is still supported in Streamflow ``v0.2``, but it is deprecated and will be removed in StreamFlow ``v0.3``.
+    Note that the ``file`` property in the upper configuration level, i.e., outside a ``service`` definition, is still supported in StreamFlow ``v0.2``, but it is deprecated and will be removed in StreamFlow ``v0.3``.
 
 The unit of binding is the entire HPC facility. In contrast, the scheduling unit is a single job placement in the Slurm queue. Users can limit the maximum number of concurrently placed jobs by setting the ``maxConcurrentJobs`` parameter.
 

--- a/examples/flux/README.md
+++ b/examples/flux/README.md
@@ -1,4 +1,4 @@
-# Flux in Streamflow
+# Flux in StreamFlow
 
 From the root of the repository, build the container:
 


### PR DESCRIPTION
This commit fixes the StreamFlow name in the documentation and in the CI test names