### PR TITLE
Temporarily disable MacOS X GitHub Actions

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -64,7 +64,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           cache: pip
-          cache-dependency-path: |
+          cache-dependency-path: | 
             requirements.txt
             test-requirements.txt
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -52,11 +52,11 @@ jobs:
             on: "ubuntu-22.04"
             python: "3.12"
             version: "v1.2"
-          - on: "macos-13"
-            python: "3.12"
-            commit: "76bdf9b55e2378432e0e6380ccedebb4a94ce483"
-            exclude: "docker_entrypoint,modify_file_content"
-            version: "v1.2"
+          #- on: "macos-13"
+          #  python: "3.12"
+          #  commit: "76bdf9b55e2378432e0e6380ccedebb4a94ce483"
+          #  exclude: "docker_entrypoint,modify_file_content"
+          #  version: "v1.2"
     runs-on: ${{ matrix.on }}
     steps:
       - uses: actions/checkout@v4
@@ -213,9 +213,9 @@ jobs:
       matrix:
         on: [ "ubuntu-22.04"]
         python: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
-        include:
-          - on: "macos-13"
-            python: "3.12"
+        #include:
+        #  - on: "macos-13"
+        #    python: "3.12"
     runs-on: ${{ matrix.on }}
     env:
       TOXENV: ${{ format('py{0}-unit', matrix.python) }}


### PR DESCRIPTION
Due to a bug in the setup-docker-macos-action (see douglascamata/setup-docker-macos-action#37), the MacOS X GitHub Actions are not working properly. This commit temporarily disables them. They will be restored as soon as the bug is solved.