### PR TITLE
Fixed record field name in `CWLObjectTokenProcessor`

### DIFF
--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -640,7 +640,7 @@ def _create_token_processor(
             # Record type: -> ObjectTokenProcessor
             elif port_type["type"] == "record":
                 record_name_prefix = utils.get_name(
-                    posixpath.sep, posixpath.sep, port_type.get("name", port_name)
+                    posixpath.sep, posixpath.sep, port_type.get("name", cwl_name_prefix)
                 )
                 return CWLObjectTokenProcessor(
                     name=port_name,


### PR DESCRIPTION
This commit fixes the processor names in the `processors` attribute of the `CWLObjectTokenProcessor` objects.
The `processors` attribute is a dictionary such as the key is the processor name and the value is the `Processor` instance. 
Before this commit, the keys were not the correct processor names.