### PR TITLE
Fixed `workdir` of wrapped deployment

### DIFF
--- a/streamflow/deployment/manager.py
+++ b/streamflow/deployment/manager.py
@@ -163,6 +163,7 @@ class DefaultDeploymentManager(DeploymentManager):
                 external=deployment_config.external,
                 lazy=deployment_config.lazy,
                 scheduling_policy=deployment_config.scheduling_policy,
+                workdir=deployment_config.workdir,
                 wraps=deployment_config.wraps,
             )
         # If it is not a ConnectorWrapper, do nothing

--- a/streamflow/deployment/utils.py
+++ b/streamflow/deployment/utils.py
@@ -61,7 +61,14 @@ def get_binding_config(
                 external=target_deployment.get("external", False),
                 lazy=target_deployment.get("lazy", True),
                 scheduling_policy=target_deployment["scheduling_policy"],
-                workdir=target_deployment.get("workdir"),
+                workdir=target_deployment.get("workdir")
+                or (
+                    workflow_config.deployments[target_deployment["wraps"]].get(
+                        "workdir"
+                    )
+                    if "wraps" in target_deployment
+                    else None
+                ),
                 wraps=get_wraps_config(target_deployment.get("wraps")),
             )
             targets.append(


### PR DESCRIPTION
This commit fixes the inheritance mechanism for the `workdir` property of wrapped deployments. In the case where the wrapped deployment has not defined a `workdir`, but its wrapper deployment does, the first inherits from the second.

Moreover, the `_inner_deploy` method of the `DefaultDeploymentManager` class now injects the `workdir` into the `DeploymentConfig` of the inner connector. The previous behaviour did not lead to errors, but it was corrected to avoid future ones.