### PR TITLE
Fixed optional parameter

### DIFF
--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -1415,7 +1415,7 @@ class CWLTranslator:
         workflow,
     ):
         inner_input_ports, outer_input_ports = set(), set()
-        # Get CommandLineTool/ExpressionTool input names
+        # Get inner CWL object input names
         for element_input in cwl_element.embedded_tool.tool["inputs"]:
             inner_cwl_name_prefix = utils.get_inner_cwl_prefix(
                 cwl_name_prefix, name_prefix, cwl_element

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -1405,6 +1405,47 @@ class CWLTranslator:
         else:
             return default_port
 
+    def _handle_optional_input_variables(
+        self,
+        cwl_element,
+        cwl_name_prefix,
+        default_ports,
+        name_prefix,
+        step_name,
+        workflow,
+    ):
+        inner_input_ports, outer_input_ports = set(), set()
+        # Get CommandLineTool/ExpressionTool input names
+        for element_input in cwl_element.embedded_tool.tool["inputs"]:
+            inner_cwl_name_prefix = utils.get_inner_cwl_prefix(
+                cwl_name_prefix, name_prefix, cwl_element
+            )
+            global_name = utils.get_name(
+                step_name, inner_cwl_name_prefix, element_input["id"]
+            )
+            port_name = posixpath.relpath(global_name, step_name)
+            inner_input_ports.add(port_name)
+        # Get WorkflowStep input names
+        for element_input in cwl_element.tool["inputs"]:
+            step_name = utils.get_name(name_prefix, cwl_name_prefix, cwl_element.id)
+            cwl_step_name = utils.get_name(
+                name_prefix, cwl_name_prefix, cwl_element.id, preserve_cwl_prefix=True
+            )
+            global_name = utils.get_name(step_name, cwl_step_name, element_input["id"])
+            port_name = posixpath.relpath(global_name, step_name)
+            outer_input_ports.add(port_name)
+        # Create a `DefaultTransformer` for each optional input
+        for port_name in inner_input_ports - outer_input_ports:
+            global_name = os.path.join(step_name, port_name)
+            default_ports[global_name] = self._handle_default_port(
+                global_name=global_name,
+                port_name=port_name,
+                transformer_suffix="-step-default-transformer",
+                port=None,
+                workflow=workflow,
+                value=None,
+            )
+
     def _inject_input(
         self,
         workflow: Workflow,
@@ -1918,25 +1959,6 @@ class CWLTranslator:
                 cwl_name_prefix=cwl_name_prefix,
             )
 
-    def _ab(self, inner_input_ports, outer_input_ports, step_name, cwl_element, name_prefix, cwl_name_prefix):
-        for element_input in cwl_element.embedded_tool.tool["inputs"]:
-            inner_cwl_name_prefix = utils.get_inner_cwl_prefix(
-                cwl_name_prefix, name_prefix, cwl_element
-            )
-            global_name = utils.get_name(
-                step_name, inner_cwl_name_prefix, element_input["id"]
-            )
-            port_name = posixpath.relpath(global_name, step_name)
-            inner_input_ports.append(port_name)
-        for element_input in cwl_element.tool["inputs"]:
-            step_name = utils.get_name(name_prefix, cwl_name_prefix, cwl_element.id)
-            cwl_step_name = utils.get_name(
-                name_prefix, cwl_name_prefix, cwl_element.id, preserve_cwl_prefix=True
-            )
-            global_name = utils.get_name(step_name, cwl_step_name, element_input["id"])
-            port_name = posixpath.relpath(global_name, step_name)
-            outer_input_ports.append(port_name)
-
     def _translate_workflow_step(
         self,
         workflow: CWLWorkflow,
@@ -1977,22 +1999,14 @@ class CWLTranslator:
         default_ports = {}
         value_from_transformers = {}
         input_dependencies = {}
-
-        inner_input_ports, outer_input_ports = [], []
-        self._ab(inner_input_ports, outer_input_ports,step_name, cwl_element, name_prefix, cwl_name_prefix)
-        logger.info(f"Step {step_name} diff in.out {set(inner_input_ports) - set(outer_input_ports)}")
-        # todo: check port types? Are they optional?
-        #  Or is it enough the different between inner and outer to infer that the port is a optional parameter?
-        for port_name in set(inner_input_ports) - set(outer_input_ports):
-            global_name = os.path.join(step_name, port_name)
-            default_ports[global_name] = self._handle_default_port(
-                global_name=global_name,
-                port_name=port_name,
-                transformer_suffix="-step-default-transformer",
-                port=None,
-                workflow=workflow,
-                value=None,
-            )
+        self._handle_optional_input_variables(
+            cwl_element,
+            cwl_name_prefix,
+            default_ports,
+            name_prefix,
+            step_name,
+            workflow,
+        )
         for element_input in cwl_element.tool["inputs"]:
             self._translate_workflow_step_input(
                 workflow=workflow,
@@ -2453,7 +2467,6 @@ class CWLTranslator:
             name_prefix=step_name,
             cwl_name_prefix=inner_cwl_name_prefix,
         )
-
         # Update output ports with the external ones
         self.output_ports = {**self.output_ports, **external_output_ports}
 

--- a/tests/test_cwl_loop.py
+++ b/tests/test_cwl_loop.py
@@ -92,18 +92,6 @@ def test_loop_fail_non_boolean_loop_when() -> None:
     assert main(params) == 1
 
 
-def test_loop_opt_variable(capsys) -> None:
-    """Test a loop case with two variables but one is optional."""
-    params = [
-        get_data("tests/loop/opt-var-loop.cwl"),
-        get_data("tests/loop/single-var-loop-job.yml"),
-    ]
-    main(params)
-    expected = {"o1": 10}
-    captured = capsys.readouterr()
-    assert json.loads(captured.out) == expected
-
-
 def test_loop_single_variable(capsys) -> None:
     """Test a simple loop case with a single variable."""
     params = [

--- a/tests/test_cwl_loop.py
+++ b/tests/test_cwl_loop.py
@@ -92,6 +92,18 @@ def test_loop_fail_non_boolean_loop_when() -> None:
     assert main(params) == 1
 
 
+def test_loop_opt_variable(capsys) -> None:
+    """Test a loop case with two variables but one is optional."""
+    params = [
+        get_data("tests/loop/opt-var-loop.cwl"),
+        get_data("tests/loop/single-var-loop-job.yml"),
+    ]
+    main(params)
+    expected = {"o1": 10}
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == expected
+
+
 def test_loop_single_variable(capsys) -> None:
     """Test a simple loop case with a single variable."""
     params = [


### PR DESCRIPTION
This commit fixes the optional parameter feature. Before this commit, empty `Token` objects were injected into ports without input steps. However, an execution deadlock occurred when `scatter` or `loop` features of CWL were included in a workflow.

After this commit, optional parameters are handled as null `default` values. Specifically, for each input parameter that is not explicitly linked to the output of a previous step, a `DefaultTransformer` with the `None` default value is injected into the workflow representation. Whether a parameter is used or not can be detected while translating a workflow from CWL to StreamFlow dataflow semantics. Indeed, if a the parameter is present in an inner CWL object (`CommandLineTool`, `ExpressionTool`, or nested `Workflow`) but not in the wrapping `WorkflowStep` object, and the parameter type is optional, the fix can be applied.