### PR TITLE
Fix `SingularityConnector` environment variables

### DIFF
--- a/streamflow/deployment/connector/container.py
+++ b/streamflow/deployment/connector/container.py
@@ -1127,7 +1127,11 @@ class SingularityConnector(ContainerConnector):
     def _get_run_command(
         self, command: str, location: ExecutionLocation, interactive: bool = False
     ):
-        return f"singularity exec instance://{location.name} sh -c '{command}'"
+        return (
+            f"singularity exec "
+            f"{get_option('cleanenv', self.cleanenv)}"
+            f"instance://{location.name} sh -c '{command}'"
+        )
 
     async def deploy(self, external: bool) -> None:
         if not external:


### PR DESCRIPTION
This commit fixes the environment variables in the singularity container. Before this commit, the `cleanenv` option was used just when the singularity container was started. However, it is necessary to use this option also every time the `exec` command is used.