### PR TITLE
Fix remote write 

### DIFF
--- a/streamflow/data/remotepath.py
+++ b/streamflow/data/remotepath.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import errno
 import glob
 import hashlib
@@ -466,7 +467,13 @@ async def write(
         with open(path, "w") as f:
             f.write(content)
     else:
-        command = ["printf", '"{content}"'.format(content=content.replace('"', '\\"'))]
+        command = [
+            "echo",
+            base64.b64encode(content.encode("utf-8")).decode("utf-8"),
+            "|",
+            "base64",
+            "-d",
+        ]
         result, status = await connector.run(
             location=location, command=command, stdout=path, capture_output=True
         )


### PR DESCRIPTION
This commit fixes the creation of a file in a remote location. Before this commit, some special characters (e.g., the dollar sign `$`) were not escaped correctly. To avoid this problem, the file content is now encoded locally in base64 and decoded in the remote location, redirecting the `stdout` to the target file.