### PR TITLE
Fixed output step when it is an empty list

### DIFF
--- a/streamflow/cwl/processor.py
+++ b/streamflow/cwl/processor.py
@@ -844,7 +844,9 @@ class CWLMapCommandOutputProcessor(CommandOutputProcessor):
         else:
             token = await self.processor.process(job, command_output, connector)
         if not isinstance(token, ListToken):
-            token = ListToken(value=[token], tag=token.tag)
+            token = ListToken(
+                value=[token] if token.value is not None else [], tag=token.tag
+            )
         return token.update(token.value)
 
     async def _save_additional_params(self, context: StreamFlowContext):

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -272,7 +272,7 @@ def _create_command_output_processor(
                         cwl_name_prefix=cwl_name_prefix,
                         schema_def_types=schema_def_types,
                         context=context,
-                        optional=optional,
+                        optional=True,
                     ),
                 )
             # Enum type: -> create command output processor


### PR DESCRIPTION
This commit returns an empty list when no data are generated from a CWL step that expects an `array` output type. In addition, this commit forces all output processors to be `optional` when an `array` output type is specified, as the CWL standard allows falling back to an empty list even for non-optional output parameters.