### PR TITLE
Fix input directory path

### DIFF
--- a/streamflow/cwl/utils.py
+++ b/streamflow/cwl/utils.py
@@ -608,7 +608,11 @@ def get_path_from_token(token_value: MutableMapping[str, Any]) -> str | None:
     location = token_value.get("location", token_value.get("path"))
     if location and "://" in location:
         scheme = urllib.parse.urlsplit(location).scheme
-        return urllib.parse.unquote(location[7:]) if scheme == "file" else None
+        return (
+            urllib.parse.unquote(location[7:]).rstrip(posixpath.sep)
+            if scheme == "file"
+            else None
+        )
     return location
 
 

--- a/streamflow/cwl/utils.py
+++ b/streamflow/cwl/utils.py
@@ -6,6 +6,7 @@ import logging
 import posixpath
 import urllib.parse
 from enum import Enum
+from pathlib import PurePosixPath
 from types import ModuleType
 from typing import (
     Any,
@@ -609,7 +610,7 @@ def get_path_from_token(token_value: MutableMapping[str, Any]) -> str | None:
     if location and "://" in location:
         scheme = urllib.parse.urlsplit(location).scheme
         return (
-            urllib.parse.unquote(location[7:]).rstrip(posixpath.sep)
+            PurePosixPath(urllib.parse.unquote(location[7:])).as_posix()
             if scheme == "file"
             else None
         )

--- a/streamflow/cwl/utils.py
+++ b/streamflow/cwl/utils.py
@@ -6,7 +6,7 @@ import logging
 import posixpath
 import urllib.parse
 from enum import Enum
-from pathlib import PurePosixPath
+from pathlib import PurePath
 from types import ModuleType
 from typing import (
     Any,
@@ -610,7 +610,7 @@ def get_path_from_token(token_value: MutableMapping[str, Any]) -> str | None:
     if location and "://" in location:
         scheme = urllib.parse.urlsplit(location).scheme
         return (
-            PurePosixPath(urllib.parse.unquote(location[7:])).as_posix()
+            str(PurePath(urllib.parse.unquote(location[7:])))
             if scheme == "file"
             else None
         )

--- a/streamflow/deployment/connector/local.py
+++ b/streamflow/deployment/connector/local.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import sys
 import tempfile
-from pathlib import Path
+from pathlib import PurePath
 from typing import MutableMapping, MutableSequence
 
 import psutil
@@ -19,7 +19,7 @@ from streamflow.core.scheduling import AvailableLocation, Hardware
 from streamflow.deployment.connector.base import BaseConnector
 
 
-def _get_disk_usage(path: Path):
+def _get_disk_usage(path: PurePath):
     while not os.path.exists(path):
         path = path.parent
     return float(shutil.disk_usage(path).free / 2**20)
@@ -99,17 +99,17 @@ class LocalConnector(BaseConnector):
                     cores=self.cores,
                     memory=self.memory,
                     input_directory=(
-                        _get_disk_usage(Path(input_directory))
+                        _get_disk_usage(PurePath(input_directory))
                         if input_directory
                         else float("inf")
                     ),
                     output_directory=(
-                        _get_disk_usage(Path(output_directory))
+                        _get_disk_usage(PurePath(output_directory))
                         if output_directory
                         else float("inf")
                     ),
                     tmp_directory=(
-                        _get_disk_usage(Path(tmp_directory))
+                        _get_disk_usage(PurePath(tmp_directory))
                         if tmp_directory
                         else float("inf")
                     ),


### PR DESCRIPTION
This commit fixes the directory path. Before this commit, `dirname` and `basename` attributes were not correctly populated when a path was terminating with a separator `/`. This commit also substitutes the `Path` class with `PurePath` to reduce overhead.