### PR TITLE
Improve performance of local copies

### DIFF
--- a/streamflow/core/utils.py
+++ b/streamflow/core/utils.py
@@ -8,6 +8,7 @@ import itertools
 import os
 import posixpath
 import shlex
+import shutil
 import uuid
 from typing import (
     Any,
@@ -268,6 +269,14 @@ def get_tag(tokens: Iterable[Token]) -> str:
         if len(tag) > len(output_tag):
             output_tag = tag
     return output_tag
+
+
+def local_copy(src: str, dst: str):
+    if os.path.isdir(src):
+        os.makedirs(dst, exist_ok=True)
+        shutil.copytree(src, dst, dirs_exist_ok=True)
+    else:
+        shutil.copy(src, dst)
 
 
 def random_name() -> str:

--- a/streamflow/data/manager.py
+++ b/streamflow/data/manager.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from importlib_resources import files
 
 from streamflow.core.data import DataLocation, DataManager, DataType
+from streamflow.core.utils import local_copy
 from streamflow.data import remotepath
 from streamflow.deployment.connector.local import LocalConnector
 from streamflow.deployment.utils import get_path_processor
@@ -27,12 +28,15 @@ async def _copy(
     writable: False,
 ) -> None:
     if isinstance(src_connector, LocalConnector):
-        await dst_connector.copy_local_to_remote(
-            src=src,
-            dst=dst,
-            locations=dst_locations,
-            read_only=not writable,
-        )
+        if isinstance(dst_connector, LocalConnector):
+            local_copy(src, dst)
+        else:
+            await dst_connector.copy_local_to_remote(
+                src=src,
+                dst=dst,
+                locations=dst_locations,
+                read_only=not writable,
+            )
     elif isinstance(dst_connector, LocalConnector):
         await src_connector.copy_remote_to_local(
             src=src,

--- a/streamflow/deployment/connector/local.py
+++ b/streamflow/deployment/connector/local.py
@@ -16,6 +16,7 @@ from streamflow.core.deployment import (
     LOCAL_LOCATION,
 )
 from streamflow.core.scheduling import AvailableLocation, Hardware
+from streamflow.core.utils import local_copy
 from streamflow.deployment.connector.base import BaseConnector
 
 
@@ -49,6 +50,20 @@ class LocalConnector(BaseConnector):
         else:
             return "sh"
 
+    async def _copy_local_to_remote(
+        self,
+        src: str,
+        dst: str,
+        locations: MutableSequence[ExecutionLocation],
+        read_only: bool = False,
+    ) -> None:
+        local_copy(src, dst)
+
+    async def _copy_remote_to_local(
+        self, src: str, dst: str, location: ExecutionLocation, read_only: bool = False
+    ) -> None:
+        local_copy(src, dst)
+
     async def _copy_remote_to_remote(
         self,
         src: str,
@@ -60,11 +75,7 @@ class LocalConnector(BaseConnector):
     ) -> None:
         source_connector = source_connector or self
         if source_connector == self:
-            if os.path.isdir(src):
-                os.makedirs(dst, exist_ok=True)
-                shutil.copytree(src, dst, dirs_exist_ok=True)
-            else:
-                shutil.copy(src, dst)
+            local_copy(src, dst)
         else:
             await super()._copy_remote_to_remote(
                 src=src,


### PR DESCRIPTION
This commit avoids running external, shell-based commands when a token must be copied between local locations. Instead, it falls back to fully Python-based file system management, which is orders of magnitude faster.