### PR TITLE
Added `get_stream_writer` method to `Connector`

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -147,7 +147,7 @@ jobs:
           python -m pip install -r docs/requirements.txt
       - name: "Build documentation and check for consistency"
         env:
-          CHECKSUM: "fc4e8f2b229f752a6370c215145464af21e2ba9c1001bc4ac6e0ea24a04c74ca"
+          CHECKSUM: "448639866a45681d025c33d9c75db98e6894e81277c586b3b3f2f7bbcddaeb5d"
         run: |
           cd docs
           HASH="$(make checksum | tail -n1)"

--- a/docs/source/ext/connector.rst
+++ b/docs/source/ext/connector.rst
@@ -52,7 +52,16 @@ The ``streamflow.core.deployment`` module defines the ``Connector`` interface, w
         ...
 
     async def get_stream_reader(
-        self, location: ExecutionLocation, src: str
+        self,
+        command: MutableSequence[int],
+        location: ExecutionLocation,
+    ) -> StreamWrapperContextManager:
+        ...
+
+    async def get_stream_writer(
+        self,
+        command: MutableSequence[int],
+        location: ExecutionLocation,
     ) -> StreamWrapperContextManager:
         ...
 
@@ -82,7 +91,7 @@ The ``undeploy`` method destroys the remote execution environment, potentially c
 
 The ``get_available_locations`` method is used in the scheduling phase to obtain the locations available for job execution, identified by their unique name (see :ref:`here <Scheduling>`). The method receives some optional input parameters to filter valid locations. The ``service`` parameter specifies a specific set of locations in a deployment, and its precise meaning differs for each deployment type (see :ref:`here <Binding steps and deployments>`). The other three parameters (``input_directory``, ``output_directory``, and ``tmp_directory``) allow the ``Connector`` to return correct disk usage values for each of the three folders in case of remote instances with multiple volumes attached.
 
-The ``get_stream_reader`` method returns a ``StreamWrapperContextManager`` instance, which allows the ``src`` data on the ``location`` to be read using a stream (see :ref:`here <Streaming>`). The stream must be read respecting the size of the available buffer, which is defined by the ``transferBufferSize`` attribute of the ``Connector`` instance. This method improve performance of data copies between pairs of remote locations.
+The ``get_stream_reader`` and ``get_stream_writer`` methods return a ``StreamWrapperContextManager`` instance, obtained by executing the ``command`` on the ``location``, to read or write data using a stream (see :ref:`here <Streaming>`). The streams must be read and written respecting the size of the available buffer, which is defined by the ``transferBufferSize`` attribute of the ``Connector`` instance. These methods improve performance of data copies between pairs of remote locations.
 
 The ``copy`` methods perform a data transfer from a ``src`` path to a ``dst`` path in one or more destination ``locations`` in the execution environment controlled by the ``Connector``. The ``read_only`` parameter notifies the ``Connector`` if the destination files will be modified in place or not. This parameter prevents unattended side effects (e.g., symlink optimizations on the remote locations). The ``copy_remote_to_remote`` method accepts two additional parameters: a ``source_location`` and an optional ``source_connector``. The latter identifies the ``Connector`` instance that controls the ``source_location`` and defaults to ``self`` when not specified.
 
@@ -115,7 +124,7 @@ Streaming
 
 StreamFlow uses ``tar`` streams as the primary way to transfer data between locations. The main reason is that the ``tar`` command is so standard nowadays that it can be found OOTB in almost all execution environments, and its API does not vary significantly across implementations.
 
-To ensure compatibility between different ``Connector`` instances when performing data transfers, StreamFlow implements two interfaces: a ``StreamWrapper`` API to read and write data streams and a ``get_stream_reader`` method to obtain a ``StreamWrapper`` object from a ``Connector`` instance.
+To ensure compatibility between different ``Connector`` instances when performing data transfers, StreamFlow implements two interfaces: a ``StreamWrapper`` API to read and write data streams and two methods called ``get_stream_reader`` and ``get_stream_writer`` to obtain ``StreamWrapper`` objects from a ``Connector`` instance.
 
 The ``StreamWrapper`` interface is straightforward. It is reported below:
 

--- a/streamflow/core/deployment.py
+++ b/streamflow/core/deployment.py
@@ -131,7 +131,12 @@ class Connector(SchemaEntity):
 
     @abstractmethod
     async def get_stream_reader(
-        self, location: ExecutionLocation, src: str
+        self, command: MutableSequence[str], location: ExecutionLocation
+    ) -> StreamWrapperContextManager: ...
+
+    @abstractmethod
+    async def get_stream_writer(
+        self, command: MutableSequence[str], location: ExecutionLocation
     ) -> StreamWrapperContextManager: ...
 
 

--- a/streamflow/deployment/wrapper.py
+++ b/streamflow/deployment/wrapper.py
@@ -20,7 +20,11 @@ class ConnectorWrapper(Connector, FutureAware, ABC):
         service: str | None,
         transferBufferSize: int,
     ):
-        super().__init__(deployment_name, config_dir, transferBufferSize)
+        super().__init__(
+            deployment_name=deployment_name,
+            config_dir=config_dir,
+            transferBufferSize=transferBufferSize,
+        )
         self.connector: Connector = connector
         self.service: str | None = service
 
@@ -88,9 +92,18 @@ class ConnectorWrapper(Connector, FutureAware, ABC):
         )
 
     async def get_stream_reader(
-        self, location: ExecutionLocation, src: str
+        self, command: MutableSequence[str], location: ExecutionLocation
     ) -> StreamWrapperContextManager:
-        return await self.connector.get_stream_reader(get_inner_location(location), src)
+        return await self.connector.get_stream_reader(
+            command, get_inner_location(location)
+        )
+
+    async def get_stream_writer(
+        self, command: MutableSequence[str], location: ExecutionLocation
+    ) -> StreamWrapperContextManager:
+        return await self.connector.get_stream_writer(
+            command, get_inner_location(location)
+        )
 
     async def run(
         self,

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -39,8 +39,8 @@ def _get_connector_method_params(method_name: str) -> MutableSequence[Any]:
         return ["test_src", "test_dst", [loc], loc]
     elif method_name == "get_available_locations":
         return []
-    elif method_name == "get_stream_reader":
-        return [loc, "test_src"]
+    elif method_name in ("get_stream_reader", "get_stream_writer"):
+        return [["test_command"], loc]
     elif method_name == "run":
         return [loc, ["ls"]]
     else:

--- a/tests/utils/connector.py
+++ b/tests/utils/connector.py
@@ -85,9 +85,14 @@ class FailureConnector(Connector):
         raise FailureConnectorException("FailureConnector undeploy")
 
     async def get_stream_reader(
-        self, location: ExecutionLocation, src: str
+        self, command: MutableSequence[str], location: ExecutionLocation
     ) -> StreamWrapperContextManager:
         raise FailureConnectorException("FailureConnector get_stream_reader")
+
+    async def get_stream_writer(
+        self, command: MutableSequence[str], location: ExecutionLocation
+    ) -> StreamWrapperContextManager:
+        raise FailureConnectorException("FailureConnector get_stream_writer")
 
 
 class ParameterizableHardwareConnector(LocalConnector):


### PR DESCRIPTION
This commit adds a new `get_stream_writer` method to the `Connector` interface and uses it to heavily simplify the data copy code in all existing `Connector` implementations. Now all copy methods rely on `get_stream_reader` and `get_stream_writer` methods to perform their operations, removing the need to specialize the `BaseConnector` class in most cases.