### PR TITLE
Implementing stacked locations scheduling

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -147,7 +147,7 @@ jobs:
           python -m pip install -r docs/requirements.txt
       - name: "Build documentation and check for consistency"
         env:
-          CHECKSUM: "448639866a45681d025c33d9c75db98e6894e81277c586b3b3f2f7bbcddaeb5d"
+          CHECKSUM: "b583c19cfc1ec9047564c69f83181732a74257566320ea084c406aa309160869"
         run: |
           cd docs
           HASH="$(make checksum | tail -n1)"

--- a/docs/source/ext/connector.rst
+++ b/docs/source/ext/connector.rst
@@ -53,14 +53,14 @@ The ``streamflow.core.deployment`` module defines the ``Connector`` interface, w
 
     async def get_stream_reader(
         self,
-        command: MutableSequence[int],
+        command: MutableSequence[str],
         location: ExecutionLocation,
     ) -> StreamWrapperContextManager:
         ...
 
     async def get_stream_writer(
         self,
-        command: MutableSequence[int],
+        command: MutableSequence[str],
         location: ExecutionLocation,
     ) -> StreamWrapperContextManager:
         ...

--- a/docs/source/ext/scheduling.rst
+++ b/docs/source/ext/scheduling.rst
@@ -87,9 +87,16 @@ The ``get_location`` method receives much information about the current executio
 
 The ``Job`` parameter contains the ``Job`` object to be allocated, and the ``hardware_requirement`` parameter is a ``HardwareRequirement`` object specifying the ``Job``'s resource requirements. The ``available_locations`` parameter contains the list of locations available for placement in the target deployment. They are obtained by calling the ``get_available_locations`` method of the related :ref:`Connector <Connector>` object.
 
+An ``AvailableLocation`` object should specify the ``stacked`` flag to state if the location relies on hardware resources from the underlying wrapped locations (e.g., a Docker container) or not (e.g., a Slurm submission to a remote node). When ``stacked`` is true, a ``Scheduler`` implementation should take into account the lower levels of the stack to validate if the execution environment provides enough resources for running a ``Job``. Conversely, when ``stacked`` is false (the default value), the ``Scheduler`` should only consider hardware information provided by the current ``AvailableLocation`` object.
+
+Note that a ``Scheduler`` implementation should run these checks before calling the ``get_location`` method of a scheduling ``Policy``, properly filtering the ``available_locations`` parameter before propagating it. Therefore, the ``available_locations`` parameter should only contain the locations that satisfy the hardware requirements of the processed ``Job`` object.
+
 The ``jobs`` and ``locations`` parameters describe the current status of the workflow execution. The ``jobs`` parameter is a dictionary of ``JobAllocation`` objects, containing information about all the previously allocated ``Job`` objects, indexed by their unique name. Each ``JobAllocation`` structure contains the ``Job`` name, its target, the list of locations associated with the ``Job`` execution, the current ``Status`` of the ``Job``, and the hardware resources allocated for its execution on each selected location.
 
 The ``locations`` parameter is the set of locations allocated to at least one ``Job`` in the past, indexed by their deployment and unique name. Each ``LocationAllocation`` object contains the location name, the name of its deployment, and the list of ``Job`` objects allocated to it, identified by their unique name.
+
+Note that when multiple locations are stacked through the ``wraps`` directive and specify the ``stacked`` flag, a ``LocationAllocation`` object contains also the jobs allocated to the locations that wrap the associated ``AvailableLocation`` object, either directly or indirectly. Conversely, ``JobAllocation`` objects only register direct allocations.
+
 
 Implementations
 ---------------

--- a/streamflow/core/scheduling.py
+++ b/streamflow/core/scheduling.py
@@ -142,6 +142,7 @@ class AvailableLocation:
         "hardware",
         "location",
         "slots",
+        "stacked",
         "wraps",
     )
 
@@ -151,7 +152,8 @@ class AvailableLocation:
         deployment: str,
         hostname: str,
         service: str | None = None,
-        slots: int = 1,
+        slots: int | None = None,
+        stacked: bool = False,
         hardware: Hardware | None = None,
         wraps: AvailableLocation | None = None,
     ):
@@ -163,7 +165,8 @@ class AvailableLocation:
             service=service,
             wraps=wraps.location if wraps else None,
         )
-        self.slots: int = slots
+        self.slots: int | None = slots
+        self.stacked: bool = stacked
         self.wraps: AvailableLocation | None = wraps
 
     @property

--- a/streamflow/deployment/connector/queue_manager.py
+++ b/streamflow/deployment/connector/queue_manager.py
@@ -480,6 +480,7 @@ class QueueManagerConnector(ConnectorWrapper, ABC):
                 service=service,
                 hostname=location.hostname,
                 slots=self.maxConcurrentJobs,
+                stacked=False,
                 wraps=location,
             )
         }


### PR DESCRIPTION
When a `ConnectorWrapper` wraps an inner `Connector` object, the locations returned by the `get_available_locations` method could either be allocated directly on the lower hardware stack (e.g., Docker containers) or be offloaded to remote machines (e.g., the jobs of a Slurm allocation).

This commit introduces the `stacked` flag in the `AvailableLocation` object to specify if a location represents the former (`true`) or the latter (`false`, the default value) case.

In addition, this commit instructs the `Scheduler` to take into account the whole hardware stack when validating resource requirements, slightly modifying how the `LocationAllocation` objects are populated.