### PR TITLE
Make `ContainerConnector` extend `ConnectorWrapper`

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -147,7 +147,7 @@ jobs:
           python -m pip install -r docs/requirements.txt
       - name: "Build documentation and check for consistency"
         env:
-          CHECKSUM: "b583c19cfc1ec9047564c69f83181732a74257566320ea084c406aa309160869"
+          CHECKSUM: "9a70e1d8042b301096323818b30dad9e66ac528ba1f11210a702c0ad48bfd07a"
         run: |
           cd docs
           HASH="$(make checksum | tail -n1)"

--- a/docs/source/connector/container.rst
+++ b/docs/source/connector/container.rst
@@ -1,0 +1,5 @@
+==================
+ContainerConnector
+==================
+
+The ``ContainerConnector`` is an abstract connector that serves as a base class to implement software container connectors (e.g., :ref:`Docker <DockerConnector>`, :ref:`Docker Compose <DockerComposeConnector>`, and :ref:`Singularity <SingularityConnector>`). It extends the abstract :ref:`ConnectorWrapper <ConnectorWrapper>` interface, allowing users to spawn software containers on top of local or remote execution environments using the :ref:`stacked locations <Stacked locations>` mechanism. Plus, it prevents :ref:`BatchConnector <BatchConnector>` instances to be wrapped as inner connectors.

--- a/docs/source/connector/docker-compose.rst
+++ b/docs/source/connector/docker-compose.rst
@@ -2,7 +2,7 @@
 DockerComposeConnector
 =======================
 
-The `DockerCompose <https://docs.docker.com/compose/>`_ connector can spawn complex, multi-container environments described in a Docker Compose file locally on the StreamFlow node. The entire set of ``services`` in the Docker Compose file contitutes the unit of deployment, while a single service is the unit of binding. Finally, the single instance of a potentially replicated service is the unit of scheduling.
+The `DockerCompose <https://docs.docker.com/compose/>`_ connector can spawn complex, multi-container environments described in a Docker Compose file locally on the StreamFlow node. The entire set of ``services`` in the Docker Compose file contitutes the unit of deployment, while a single service is the unit of binding. Finally, the single instance of a potentially replicated service is the unit of scheduling. It extends the :ref:`ContainerConnector <ContainerConnector>`, which inherits from the :ref:`ConnectorWrapper <ConnectorWrapper>` interface, allowing users to spawn Docker containers on top of local or remote execution environments using the :ref:`stacked locations <Stacked locations>` mechanism.
 
 .. jsonschema:: ../../../streamflow/deployment/connector/schemas/docker-compose.json
     :lift_description: true

--- a/docs/source/connector/docker.rst
+++ b/docs/source/connector/docker.rst
@@ -2,7 +2,7 @@
 DockerConnector
 ===============
 
-The `Docker <https://www.docker.com/>`_ connector can spawn one or more instances of a Docker container locally on the StreamFlow node. The units of deployment and binding for this connector correspond to the set of homogeneous container instances, while the unit of scheduling is the single instance.
+The `Docker <https://www.docker.com/>`_ connector can spawn one or more instances of a Docker container locally on the StreamFlow node. The units of deployment and binding for this connector correspond to the set of homogeneous container instances, while the unit of scheduling is the single instance. It extends the :ref:`ContainerConnector <ContainerConnector>`, which inherits from the :ref:`ConnectorWrapper <ConnectorWrapper>` interface, allowing users to spawn Docker containers on top of local or remote execution environments using the :ref:`stacked locations <Stacked locations>` mechanism.
 
 .. jsonschema:: ../../../streamflow/deployment/connector/schemas/docker.json
     :lift_description: true

--- a/docs/source/connector/queue-manager.rst
+++ b/docs/source/connector/queue-manager.rst
@@ -2,7 +2,7 @@
 QueueManagerConnector
 =====================
 
-The ``QueueManagerConnector`` is an abstract connector that serves as a base class to implement High Performance Computing connectors, based on queue managers (e.g., :ref:`Slurm <SlurmConnector>`, :ref:`PBS <PBSConnector>`, and :ref:`Flux <FluxConnector>`). It extends the :ref:`ConnectorWrapper <ConnectorWrapper>` interface, allowing users to offload jobs to local or remote queue managers. The HPC facility is supposed to be constantly active, reducing the deployment phase to deploy the inner connector (e.g., to create an :ref:`SSHConnection <SSHConnection>` pointing to an HPC login node).
+The ``QueueManagerConnector`` is an abstract connector that serves as a base class to implement High Performance Computing connectors, based on queue managers (e.g., :ref:`Slurm <SlurmConnector>`, :ref:`PBS <PBSConnector>`, and :ref:`Flux <FluxConnector>`). It extends the :ref:`ConnectorWrapper <ConnectorWrapper>` interface, allowing users to offload jobs to local or remote queue managers. Plus, it extends the :ref:`BatchConnector <BatchConnector>` interface. The underlying HPC facility is supposed to be constantly active, reducing the deployment phase to deploy the inner connector (e.g., to create an :ref:`SSHConnection <SSHConnection>` pointing to an HPC login node).
 
 .. warning::
 

--- a/docs/source/connector/singularity.rst
+++ b/docs/source/connector/singularity.rst
@@ -2,7 +2,7 @@
 SingularityConnector
 =====================
 
-The `Singularity <https://sylabs.io/singularity>`_ connector can spawn one or more instances of a Singularity container locally on the StreamFlow node. The units of deployment and binding for this connector correspond to the set of homogeneous container instances, while the unit of scheduling is the single instance.
+The `Singularity <https://sylabs.io/singularity>`_ connector can spawn one or more instances of a Singularity container locally on the StreamFlow node. The units of deployment and binding for this connector correspond to the set of homogeneous container instances, while the unit of scheduling is the single instance. It extends the :ref:`ContainerConnector <ContainerConnector>`, which inherits from the :ref:`ConnectorWrapper <ConnectorWrapper>` interface, allowing users to spawn Singularity containers on top of local or remote execution environments using the :ref:`stacked locations <Stacked locations>` mechanism.
 
 .. jsonschema:: ../../../streamflow/deployment/connector/schemas/singularity.json
     :lift_description: true

--- a/docs/source/ext/connector.rst
+++ b/docs/source/ext/connector.rst
@@ -119,6 +119,11 @@ ConnectorWrapper
 
 StreamFlow supports :ref:`stacked locations <Stacked locations>` using the ``wraps`` directive. However, not all ``Connector`` instances support inner connectors, but only those that extend the ``ConenctorWrapper`` interface. By default, a ``ConnectorWrapper`` instance receives an internal ``Connector`` object as a constructor parameter and delegates all the method calls to the wrapped ``Connector``. Plus, it already extends the ``FutureAware`` class, correctly handling :ref:`FutureConnector <FutureConnector>` instances. Users who want to create a custom ``Connector`` instance with support for the ``wraps`` directive must extend the ``ConnectorWrapper`` class and not the ``BaseConnector`` as in other cases.
 
+BatchConnector
+==============
+
+Some ``Connector`` instances implement remote executions through batch systems (e.g., Slurm, PBS, or AWS Batch). These connectors should extend the ``BatchConnector`` base class to notify users that they cannot manage deployment, execution, and undeployment operations of an internal ``ConnectorWrapper`` instance as separate phases of its life-cycle (see :ref:`QueueManagerConnector <QueueManagerConnector>`). On the other hand, ``ConnectorWrapper`` implementers can explicitly disallow their class to wrap inner ``BatchConnector`` classes by failing fast during object construction (see :ref:`ContainerConnector <ContainerConnector>`).
+
 Streaming
 =========
 

--- a/docs/source/ext/scheduling.rst
+++ b/docs/source/ext/scheduling.rst
@@ -97,7 +97,6 @@ The ``locations`` parameter is the set of locations allocated to at least one ``
 
 Note that when multiple locations are stacked through the ``wraps`` directive and specify the ``stacked`` flag, a ``LocationAllocation`` object contains also the jobs allocated to the locations that wrap the associated ``AvailableLocation`` object, either directly or indirectly. Conversely, ``JobAllocation`` objects only register direct allocations.
 
-
 Implementations
 ---------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -80,6 +80,7 @@ For LaTeX users, the following BibTeX entry can be used:
    :caption: Connectors
    :hidden:
 
+   connector/container.rst
    connector/docker.rst
    connector/docker-compose.rst
    connector/flux.rst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",
     "Topic :: System :: Distributed Computing"
 ]

--- a/streamflow/core/utils.py
+++ b/streamflow/core/utils.py
@@ -271,12 +271,17 @@ def get_tag(tokens: Iterable[Token]) -> str:
     return output_tag
 
 
-def local_copy(src: str, dst: str):
-    if os.path.isdir(src):
-        os.makedirs(dst, exist_ok=True)
-        shutil.copytree(src, dst, dirs_exist_ok=True)
+def local_copy(src: str, dst: str, read_only: bool):
+    if read_only:
+        if os.path.isdir(dst):
+            dst = os.path.join(dst, os.path.basename(src))
+        os.symlink(src, dst, target_is_directory=os.path.isdir(src))
     else:
-        shutil.copy(src, dst)
+        if os.path.isdir(src):
+            os.makedirs(dst, exist_ok=True)
+            shutil.copytree(src, dst, dirs_exist_ok=True)
+        else:
+            shutil.copy(src, dst)
 
 
 def random_name() -> str:

--- a/streamflow/cwl/requirement/docker/docker.py
+++ b/streamflow/cwl/requirement/docker/docker.py
@@ -7,7 +7,7 @@ from typing import MutableSequence
 from importlib_resources import files
 
 from streamflow.core import utils
-from streamflow.core.deployment import DeploymentConfig, Target
+from streamflow.core.deployment import DeploymentConfig, Target, WrapsConfig
 from streamflow.cwl.requirement.docker.translator import CWLDockerTranslator
 
 
@@ -67,7 +67,6 @@ class DockerCWLDockerTranslator(CWLDockerTranslator):
         labelFile: MutableSequence[str] | None = None,
         link: MutableSequence[str] | None = None,
         linkLocalIP: MutableSequence[str] | None = None,
-        locationsCacheSize: int | None = None,
         locationsCacheTTL: int | None = None,
         logDriver: str = "none",
         logOpts: MutableSequence[str] | None = None,
@@ -88,7 +87,6 @@ class DockerCWLDockerTranslator(CWLDockerTranslator):
         publish: MutableSequence[str] | None = None,
         publishAll: bool = False,
         readOnly: bool = False,
-        replicas: int = 1,
         restart: str | None = None,
         rm: bool = True,
         runtime: str | None = None,
@@ -162,7 +160,6 @@ class DockerCWLDockerTranslator(CWLDockerTranslator):
         self.labelFile: MutableSequence[str] | None = labelFile
         self.link: MutableSequence[str] | None = link
         self.linkLocalIP: MutableSequence[str] | None = linkLocalIP
-        self.locationsCacheSize: int | None = locationsCacheSize
         self.locationsCacheTTL: int | None = locationsCacheTTL
         self.logDriver: str = logDriver
         self.logOpts: MutableSequence[str] | None = logOpts
@@ -183,7 +180,6 @@ class DockerCWLDockerTranslator(CWLDockerTranslator):
         self.publish: MutableSequence[str] | None = publish
         self.publishAll: bool = publishAll
         self.readOnly: bool = readOnly
-        self.replicas: int = replicas
         self.restart: str | None = restart
         self.rm: bool = rm
         self.runtime: str | None = runtime
@@ -289,7 +285,6 @@ class DockerCWLDockerTranslator(CWLDockerTranslator):
                     "labelFile": self.labelFile,
                     "link": self.link,
                     "linkLocalIP": self.linkLocalIP,
-                    "locationsCacheSize": self.locationsCacheSize,
                     "locationsCacheTTL": self.locationsCacheTTL,
                     "logDriver": self.logDriver,
                     "logOpts": self.logOpts,
@@ -310,7 +305,6 @@ class DockerCWLDockerTranslator(CWLDockerTranslator):
                     "publish": self.publish,
                     "publishAll": self.publishAll,
                     "readOnly": self.readOnly,
-                    "replicas": self.replicas,
                     "restart": self.restart,
                     "rm": self.rm,
                     "runtime": self.runtime,
@@ -332,7 +326,13 @@ class DockerCWLDockerTranslator(CWLDockerTranslator):
                     "volumesFrom": self.volumesFrom,
                 },
                 workdir="/tmp/streamflow",  # nosec
-                wraps=target if self.wrapper else None,
+                wraps=(
+                    WrapsConfig(
+                        deployment=target.deployment.name, service=target.service
+                    )
+                    if self.wrapper
+                    else None
+                ),
             ),
             service=image,
         )

--- a/streamflow/cwl/requirement/docker/schemas/docker.json
+++ b/streamflow/cwl/requirement/docker/schemas/docker.json
@@ -401,16 +401,6 @@
       "type": "boolean",
       "description": "Mount the container's root filesystem as read only"
     },
-    "replicas": {
-      "type": "integer",
-      "description": "Number of instances to be co-allocated",
-      "default": 1
-    },
-    "locationsCacheSize": {
-      "type": "integer",
-      "description": "Available locations cache size",
-      "default": 10
-    },
     "locationsCacheTTL": {
       "type": "integer",
       "description": "Available locations cache TTL (in seconds). When such cache expires, the connector performs a new request to check locations availability",

--- a/streamflow/cwl/requirement/docker/schemas/singularity.json
+++ b/streamflow/cwl/requirement/docker/schemas/singularity.json
@@ -236,16 +236,6 @@
       "type": "integer",
       "description": "Limit number of container PIDs, use -1 for unlimited"
     },
-    "replicas": {
-      "type": "integer",
-      "description": "Number of instances to be co-allocated",
-      "default": 1
-    },
-    "locationsCacheSize": {
-      "type": "integer",
-      "description": "Available locations cache size",
-      "default": 10
-    },
     "locationsCacheTTL": {
       "type": "integer",
       "description": "Available locations cache TTL (in seconds). When such cache expires, the connector performs a new request to check locations availability",

--- a/streamflow/cwl/requirement/docker/singularity.py
+++ b/streamflow/cwl/requirement/docker/singularity.py
@@ -7,7 +7,7 @@ from typing import MutableSequence
 from importlib_resources import files
 
 from streamflow.core import utils
-from streamflow.core.deployment import DeploymentConfig, Target
+from streamflow.core.deployment import DeploymentConfig, Target, WrapsConfig
 from streamflow.cwl.requirement.docker.translator import CWLDockerTranslator
 
 
@@ -45,7 +45,6 @@ class SingularityCWLDockerTranslator(CWLDockerTranslator):
         hostname: str | None = None,
         ipc: bool = False,
         keepPrivs: bool = False,
-        locationsCacheSize: int = None,
         locationsCacheTTL: int = None,
         memory: str | None = None,
         memoryReservation: str | None = None,
@@ -68,7 +67,6 @@ class SingularityCWLDockerTranslator(CWLDockerTranslator):
         pemPath: str | None = None,
         pidFile: str | None = None,
         pidsLimit: int | None = None,
-        replicas: int = 1,
         rocm: bool = False,
         scratch: MutableSequence[str] | None = None,
         security: MutableSequence[str] | None = None,
@@ -106,7 +104,6 @@ class SingularityCWLDockerTranslator(CWLDockerTranslator):
         self.home: str | None = home
         self.hostname: str | None = hostname
         self.ipc: bool = ipc
-        self.locationsCacheSize: int | None = locationsCacheSize
         self.locationsCacheTTL: int | None = locationsCacheTTL
         self.keepPrivs: bool = keepPrivs
         self.memory: str | None = memory
@@ -130,7 +127,6 @@ class SingularityCWLDockerTranslator(CWLDockerTranslator):
         self.pemPath: str | None = pemPath
         self.pidFile: str | None = pidFile
         self.pidsLimit: int | None = pidsLimit
-        self.replicas: int = replicas
         self.rocm: bool = rocm
         self.scratch: MutableSequence[str] | None = scratch
         self.security: MutableSequence[str] | None = security
@@ -202,7 +198,6 @@ class SingularityCWLDockerTranslator(CWLDockerTranslator):
                     "hostname": self.hostname,
                     "ipc": self.ipc,
                     "keepPrivs": self.keepPrivs,
-                    "locationsCacheSize": self.locationsCacheSize,
                     "locationsCacheTTL": self.locationsCacheTTL,
                     "memory": self.memory,
                     "memoryReservation": self.memoryReservation,
@@ -225,7 +220,6 @@ class SingularityCWLDockerTranslator(CWLDockerTranslator):
                     "pemPath": self.pemPath,
                     "pidFile": self.pidFile,
                     "pidsLimit": self.pidsLimit,
-                    "replicas": self.replicas,
                     "rocm": self.rocm,
                     "scratch": self.scratch,
                     "security": self.security,
@@ -236,7 +230,13 @@ class SingularityCWLDockerTranslator(CWLDockerTranslator):
                     "writableTmpfs": self.writableTmpfs,
                 },
                 workdir="/tmp/streamflow",  # nosec
-                wraps=target if self.wrapper else None,
+                wraps=(
+                    WrapsConfig(
+                        deployment=target.deployment.name, service=target.service
+                    )
+                    if self.wrapper
+                    else None
+                ),
             ),
             service=image,
         )

--- a/streamflow/cwl/step.py
+++ b/streamflow/cwl/step.py
@@ -20,9 +20,9 @@ from streamflow.cwl import utils
 from streamflow.cwl.token import CWLFileToken
 from streamflow.cwl.utils import (
     LoadListing,
-    get_token_class,
-    get_path_from_token,
     get_file_token,
+    get_path_from_token,
+    get_token_class,
     register_data,
 )
 from streamflow.data import remotepath

--- a/streamflow/data/manager.py
+++ b/streamflow/data/manager.py
@@ -29,7 +29,7 @@ async def _copy(
 ) -> None:
     if isinstance(src_connector, LocalConnector):
         if isinstance(dst_connector, LocalConnector):
-            local_copy(src, dst)
+            local_copy(src, dst, not writable)
         else:
             await dst_connector.copy_local_to_remote(
                 src=src,

--- a/streamflow/data/remotepath.py
+++ b/streamflow/data/remotepath.py
@@ -321,8 +321,7 @@ async def mkdirs(
         for path in paths:
             os.makedirs(path, exist_ok=True)
     else:
-        command = ["mkdir", "-p"]
-        command.extend(paths)
+        command = ["mkdir", "-p"] + list(paths)
         await asyncio.gather(
             *(
                 asyncio.create_task(connector.run(location=location, command=command))

--- a/streamflow/deployment/connector/kubernetes.py
+++ b/streamflow/deployment/connector/kubernetes.py
@@ -358,20 +358,6 @@ class KubernetesBaseConnector(BaseConnector, ABC):
                 effective_locations.append(location)
         return effective_locations
 
-    def _get_run_command(
-        self, command: str, location: ExecutionLocation, interactive: bool = False
-    ):
-        pod, container = location.name.split(":")
-        return (
-            f"kubectl "
-            f"{get_option('namespace', self.namespace)}"
-            f"{get_option('kubeconfig', self.kubeconfig)}"
-            f"exec {pod} "
-            f"{get_option('i', interactive)}"
-            f"{get_option('container', container)}"
-            f"-- {command}"
-        )
-
     @abstractmethod
     async def _get_running_pods(self) -> V1PodList: ...
 

--- a/streamflow/deployment/connector/local.py
+++ b/streamflow/deployment/connector/local.py
@@ -36,11 +36,11 @@ class LocalConnector(BaseConnector):
 
     def _get_run_command(
         self, command: str, location: ExecutionLocation, interactive: bool = False
-    ):
+    ) -> MutableSequence[str]:
         if sys.platform == "win32":
-            return f"{self._get_shell()} /C '{command}'"
+            return [self._get_shell(), "/C", f"'{command}'"]
         else:
-            return f"{self._get_shell()} -c '{command}'"
+            return [self._get_shell(), "-c", f"'{command}'"]
 
     def _get_shell(self) -> str:
         if sys.platform == "win32":
@@ -57,12 +57,12 @@ class LocalConnector(BaseConnector):
         locations: MutableSequence[ExecutionLocation],
         read_only: bool = False,
     ) -> None:
-        local_copy(src, dst)
+        local_copy(src, dst, read_only)
 
     async def _copy_remote_to_local(
         self, src: str, dst: str, location: ExecutionLocation, read_only: bool = False
     ) -> None:
-        local_copy(src, dst)
+        local_copy(src, dst, read_only)
 
     async def _copy_remote_to_remote(
         self,
@@ -75,7 +75,7 @@ class LocalConnector(BaseConnector):
     ) -> None:
         source_connector = source_connector or self
         if source_connector == self:
-            local_copy(src, dst)
+            local_copy(src, dst, read_only)
         else:
             await super()._copy_remote_to_remote(
                 src=src,

--- a/streamflow/deployment/connector/queue_manager.py
+++ b/streamflow/deployment/connector/queue_manager.py
@@ -22,10 +22,10 @@ from streamflow.core.exception import (
 )
 from streamflow.core.scheduling import AvailableLocation
 from streamflow.core.utils import get_option
+from streamflow.deployment.connector.base import BatchConnector
 from streamflow.deployment.connector.ssh import SSHConnector
 from streamflow.deployment.template import CommandTemplateMap
-from streamflow.deployment.utils import get_inner_location
-from streamflow.deployment.wrapper import ConnectorWrapper
+from streamflow.deployment.wrapper import ConnectorWrapper, get_inner_location
 from streamflow.log_handler import logger
 
 
@@ -318,7 +318,7 @@ class FluxService(QueueManagerService):
         self.urgency: int | None = urgency
 
 
-class QueueManagerConnector(ConnectorWrapper, ABC):
+class QueueManagerConnector(BatchConnector, ConnectorWrapper, ABC):
     def __init__(
         self,
         deployment_name: str,

--- a/streamflow/deployment/connector/schemas/docker.json
+++ b/streamflow/deployment/connector/schemas/docker.json
@@ -66,13 +66,9 @@
       },
       "description": "Command to run when deploying the container"
     },
-    "containerIds": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "uniqueItems": true,
-      "description": "When referencing an external environment, ids of existing containers must be explicitly listed"
+    "containerId": {
+      "type": "string",
+      "description": "When referencing an external environment, the id of the existing container must be specified"
     },
     "cpuPeriod": {
       "type": "integer",
@@ -412,24 +408,9 @@
       "type": "boolean",
       "description": "Mount the container's root filesystem as read only"
     },
-    "replicas": {
-      "type": "integer",
-      "description": "Number of instances to be co-allocated",
-      "default": 1
-    },
-    "locationsCacheSize": {
-      "type": "integer",
-      "description": "Available locations cache size",
-      "default": 10
-    },
     "locationsCacheTTL": {
       "type": "integer",
       "description": "Available locations cache TTL (in seconds). When such cache expires, the connector performs a new request to check locations availability",
-      "default": 10
-    },
-    "resourcesCacheSize": {
-      "type": "integer",
-      "description": "(**Deprecated.** Use locationsCacheSize.) Available resources cache size",
       "default": 10
     },
     "resourcesCacheTTL": {

--- a/streamflow/deployment/connector/schemas/singularity.json
+++ b/streamflow/deployment/connector/schemas/singularity.json
@@ -130,13 +130,9 @@
       "type": "string",
       "description": "Set container hostname"
     },
-    "instanceNames": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "uniqueItems": true,
-      "description": "When referencing an external environment, names of existing instances must be explicitly listed"
+    "instanceName": {
+      "type": "string",
+      "description": "When referencing an external environment, the name of the existing instance must be specified"
     },
     "ipc": {
       "type": "boolean",
@@ -246,24 +242,9 @@
       "type": "integer",
       "description": "Limit number of container PIDs, use -1 for unlimited"
     },
-    "replicas": {
-      "type": "integer",
-      "description": "Number of instances to be co-allocated",
-      "default": 1
-    },
-    "locationsCacheSize": {
-      "type": "integer",
-      "description": "Available locations cache size",
-      "default": 10
-    },
     "locationsCacheTTL": {
       "type": "integer",
       "description": "Available locations cache TTL (in seconds). When such cache expires, the connector performs a new request to check locations availability",
-      "default": 10
-    },
-    "resourcesCacheSize": {
-      "type": "integer",
-      "description": "(**Deprecated.** Use locationsCacheSize.) Available resources cache size",
       "default": 10
     },
     "resourcesCacheTTL": {

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -575,11 +575,6 @@ class SSHConnector(BaseConnector):
             }
         return existing_directories
 
-    def _get_run_command(
-        self, command: str, location: ExecutionLocation, interactive: bool = False
-    ):
-        return f"ssh {location.name} {command}"
-
     def _get_ssh_client_process(
         self,
         location: str,

--- a/streamflow/deployment/utils.py
+++ b/streamflow/deployment/utils.py
@@ -5,18 +5,16 @@ import os
 import posixpath
 from pathlib import PurePosixPath
 from types import ModuleType
-from typing import Any, MutableMapping, MutableSequence, TYPE_CHECKING
+from typing import Any, MutableMapping, TYPE_CHECKING
 
 from streamflow.core.config import BindingConfig
 from streamflow.core.deployment import (
     DeploymentConfig,
-    ExecutionLocation,
     FilterConfig,
     LocalTarget,
     Target,
     WrapsConfig,
 )
-from streamflow.core.exception import WorkflowExecutionException
 from streamflow.deployment.connector import LocalConnector
 from streamflow.log_handler import logger
 
@@ -88,20 +86,6 @@ def get_binding_config(
         )
     else:
         return BindingConfig(targets=[LocalTarget()])
-
-
-def get_inner_location(location: ExecutionLocation) -> ExecutionLocation:
-    if location.wraps is None:
-        raise WorkflowExecutionException(
-            f"Location {location.name} does not wrap any inner location"
-        )
-    return location.wraps
-
-
-def get_inner_locations(
-    locations: MutableSequence[ExecutionLocation],
-) -> MutableSequence[ExecutionLocation]:
-    return list({get_inner_location(loc) for loc in locations})
 
 
 def get_path_processor(connector: Connector) -> ModuleType:

--- a/streamflow/persistence/loading_context.py
+++ b/streamflow/persistence/loading_context.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from typing import MutableMapping
 
 from streamflow.core.context import StreamFlowContext
-from streamflow.core.deployment import DeploymentConfig, Target, FilterConfig
+from streamflow.core.deployment import DeploymentConfig, FilterConfig, Target
 from streamflow.core.persistence import DatabaseLoadingContext
-from streamflow.core.workflow import Port, Step, Token, Workflow, Status
+from streamflow.core.workflow import Port, Status, Step, Token, Workflow
 
 
 class DefaultDatabaseLoadingContext(DatabaseLoadingContext):


### PR DESCRIPTION
This commit transforms `ContainerConnector` class and all its derivate classes in `ContainerWrapper` classes, allowing software containers to be deployed on top of local or remote execution locations wthrough the StreamFlow stacked locations mechanism.

This commit also introduces a new `BatchConnector` class that can be used to prevent `ContainerConnector` instances from wrapping queue-based connectors (e.g., Slurm or PBS), as they cannot manage container deployment, execution, and undeployment operations as different phases of the location life-cycle. This class allow `ContainerConnector` instances to fail fast during construction phase if an unsupported `Connector` is wrapped.