### PR TITLE
Improved ssh retry mechanism

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -157,7 +157,7 @@ jobs:
           python -m pip install -r docs/requirements.txt
       - name: "Build documentation and check for consistency"
         env:
-          CHECKSUM: "6642d8d7533c7cf3ec9de7bdbf1871e3a313dd73fa6551fe3bb10e4e94e7ff08"
+          CHECKSUM: "b59239241d3529a179df6158271dd00ba7a86e807a37a11ac8e078ad9c377f94"
         run: |
           cd docs
           HASH="$(make checksum | tail -n1)"

--- a/streamflow/deployment/connector/container.py
+++ b/streamflow/deployment/connector/container.py
@@ -1422,7 +1422,7 @@ class DockerComposeConnector(DockerBaseConnector):
             (json_end := output.rfind("}")) != -1
         ):
             if json_start != 0 and logger.isEnabledFor(logging.DEBUG):
-                logger.debug(f"Docker Compose log: {output[:json_start]}")
+                logger.debug(f"Docker Compose log: {output[:json_start].strip()}")
             locations = json.loads(output[json_start : json_end + 1])
         else:
             raise WorkflowExecutionException(

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -210,6 +210,7 @@ class SSHContextManager:
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         async with self._condition:
             if self._selected_context:
+                await self._selected_context.close()
                 if self._proc:
                     await self._proc.__aexit__(exc_type, exc_val, exc_tb)
                 self._condition.notify_all()

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -92,6 +92,16 @@ class SSHContext:
 
     async def close(self):
         if self._ssh_connection is not None:
+            max_times = 0
+            while len(self._ssh_connection._channels) > 0:
+                await asyncio.sleep(5)
+                max_times += 1
+                if max_times > 5:
+                    logger.warning(
+                        f"The SSH connection {self.get_hostname()} has had open channels for too long. "
+                        f"Forcing connection closure"
+                    )
+                    break
             self._ssh_connection.close()
             await self._ssh_connection.wait_closed()
             self._ssh_connection = None

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -26,12 +26,6 @@ from streamflow.deployment.stream import StreamReaderWrapper, StreamWriterWrappe
 from streamflow.deployment.template import CommandTemplateMap
 from streamflow.log_handler import logger
 
-from streamflow.log_handler import defaultStreamHandler
-
-asyncssh.logging.logger.setLevel(logging.DEBUG)
-asyncssh.logging.logger.set_debug_level(2)
-asyncssh.logging.logger.logger.addHandler(defaultStreamHandler)
-
 
 def _parse_hostname(hostname):
     if ":" in hostname:
@@ -126,11 +120,6 @@ class SSHContext:
         if self._ssh_connection is not None:
             self._ssh_connection.close()
             await self._ssh_connection.wait_closed()
-            while not self._ssh_connection.is_closed():
-                logger.info(
-                    f"self._ssh_connection.is_closed(): {self._ssh_connection.is_closed()}"
-                )
-                raise WorkflowExecutionException("Connection not yet closed")
             self._ssh_connection = None
         self._connect_event.set()  # it is necessary to free any blocked tasks and avoid deadlocks
         self._connect_event.clear()
@@ -684,8 +673,6 @@ class SSHConnector(BaseConnector):
             environment=environment,
         ) as proc:
             result = await proc.wait(timeout=timeout)
-        if result.returncode is None:
-            raise Exception("Return code cannot be None")
         return (result.stdout.strip(), result.returncode) if capture_output else None
 
     async def undeploy(self, external: bool) -> None:

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -26,6 +26,12 @@ from streamflow.deployment.stream import StreamReaderWrapper, StreamWriterWrappe
 from streamflow.deployment.template import CommandTemplateMap
 from streamflow.log_handler import logger
 
+from streamflow.log_handler import defaultStreamHandler
+
+asyncssh.logging.logger.setLevel(logging.DEBUG)
+asyncssh.logging.logger.set_debug_level(2)
+asyncssh.logging.logger.logger.addHandler(defaultStreamHandler)
+
 
 def _parse_hostname(hostname):
     if ":" in hostname:
@@ -120,6 +126,11 @@ class SSHContext:
         if self._ssh_connection is not None:
             self._ssh_connection.close()
             await self._ssh_connection.wait_closed()
+            while not self._ssh_connection.is_closed():
+                logger.info(
+                    f"self._ssh_connection.is_closed(): {self._ssh_connection.is_closed()}"
+                )
+                await asyncio.sleep(1)
             self._ssh_connection = None
         self._connect_event.set()  # it is necessary to free any blocked tasks and avoid deadlocks
         self._connect_event.clear()
@@ -673,6 +684,8 @@ class SSHConnector(BaseConnector):
             environment=environment,
         ) as proc:
             result = await proc.wait(timeout=timeout)
+        if result.returncode is None:
+            raise Exception("Return code cannot be None")
         return (result.stdout.strip(), result.returncode) if capture_output else None
 
     async def undeploy(self, external: bool) -> None:

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -672,8 +672,8 @@ class SSHConnector(BaseConnector):
             stderr=asyncio.subprocess.STDOUT,
             environment=environment,
         ) as proc:
-            result = await proc.wait(timeout=timeout)
-        return (result.stdout.strip(), proc.returncode) if capture_output else None
+            result = await proc.wait(check=True, timeout=timeout)
+        return (result.stdout.strip(), result.returncode) if capture_output else None
 
     async def undeploy(self, external: bool) -> None:
         for ssh_context in self.ssh_context_factories.values():

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -130,7 +130,7 @@ class SSHContext:
                 logger.info(
                     f"self._ssh_connection.is_closed(): {self._ssh_connection.is_closed()}"
                 )
-                await asyncio.sleep(1)
+                raise WorkflowExecutionException("Connection not yet closed")
             self._ssh_connection = None
         self._connect_event.set()  # it is necessary to free any blocked tasks and avoid deadlocks
         self._connect_event.clear()

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -204,14 +204,14 @@ class SSHContextManager:
                             context.ssh_attempts += 1
                             await context.close()
                             self._selected_context = None
-                            self._proc.__aexit(None, None, None)
                             logger.warning(f"Connection attempt {context.ssh_attempts}")
                     await asyncio.sleep(self._retry_delay)
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         async with self._condition:
             if self._selected_context:
-                await self._selected_context.close()
+                # await self._selected_context.close()
+                # self._selected_context = None
                 if self._proc:
                     await self._proc.__aexit__(exc_type, exc_val, exc_tb)
                 self._condition.notify_all()

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -201,9 +201,10 @@ class SSHContextManager:
                                     f"Error opening SSH session to {context.get_hostname()} "
                                     f"to execute command `{self.command}`: [{coe.code}] {coe.reason}"
                                 )
-                            self._selected_context = None
                             context.ssh_attempts += 1
                             await context.close()
+                            self._selected_context = None
+                            self._proc.__aexit(None, None, None)
                             logger.warning(f"Connection attempt {context.ssh_attempts}")
                     await asyncio.sleep(self._retry_delay)
 

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -440,7 +440,7 @@ class SSHConnector(BaseConnector):
                 location=location,
                 command="nproc && "
                 "free | grep Mem | awk '{print $2}' && "
-                "df -aT | tail -n +2 | awk 'NF == 1 {device = $1; getline; $0 = device $0} {print $7, $2, $3}'",
+                "df -aT | tail -n +2 | awk 'NF == 1 {device = $1; getline; $0 = device $0} {print $7, $2, $5}'",
                 stderr=asyncio.subprocess.STDOUT,
             ) as proc:
                 result = await proc.wait()

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -9,7 +9,6 @@ from importlib.resources import files
 from typing import Any
 
 import asyncssh
-from asyncssh import ChannelOpenError, ConnectionLost
 
 from streamflow.core import utils
 from streamflow.core.data import StreamWrapper, StreamWrapperContextManager
@@ -110,7 +109,7 @@ class SSHContext:
                 self._connecting = True
                 try:
                     self._ssh_connection = await self._get_connection(self._config)
-                except (ConnectionError, ConnectionLost, asyncssh.Error) as e:
+                except (ConnectionError, asyncssh.Error) as e:
                     if logger.isEnabledFor(logging.WARNING):
                         logger.warning(
                             f"Connection to {self._config.hostname} failed: {e}."
@@ -196,19 +195,14 @@ class SSHContextManager:
                             await self._proc.__aenter__()
                             self._selected_context.ssh_attempts = 0
                             return self._proc
-                        except (
-                            ChannelOpenError,
-                            ConnectionError,
-                            ConnectionLost,
-                            asyncssh.Error,
-                        ) as exc:
+                        except (ConnectionError, asyncssh.Error) as exc:
                             if logger.isEnabledFor(logging.WARNING):
                                 logger.warning(
-                                    f"Error opening SSH session to {context.get_hostname()} "
-                                    f"to execute command `{self.command}`: {type(exc)}[{exc.code}] {exc.reason}"
+                                    f"Error {type(exc).__name__} opening SSH session to {context.get_hostname()} "
+                                    f"to execute command `{self.command}`: [{exc.code}] {exc.reason}"
                                 )
                                 logger.warning(
-                                    f"Connection to {context.get_hostname()} attempts: {context.ssh_attempts}"
+                                    f"Connection to {context.get_hostname()} attempts: {context.ssh_attempts} "
                                     f"self._proc: {self._proc}, self._selected_context: {self._selected_context}"
                                 )
                             self._selected_context = None

--- a/streamflow/deployment/stream.py
+++ b/streamflow/deployment/stream.py
@@ -39,7 +39,6 @@ class StreamReaderWrapper(StreamWrapper):
 
 class StreamWriterWrapper(StreamWrapper):
     async def close(self):
-        # self.stream.write_eof()
         self.stream.close()
         await self.stream.wait_closed()
 

--- a/streamflow/deployment/stream.py
+++ b/streamflow/deployment/stream.py
@@ -39,7 +39,7 @@ class StreamReaderWrapper(StreamWrapper):
 
 class StreamWriterWrapper(StreamWrapper):
     async def close(self):
-        self.stream.write_eof()
+        # self.stream.write_eof()
         self.stream.close()
         await self.stream.wait_closed()
 

--- a/streamflow/deployment/stream.py
+++ b/streamflow/deployment/stream.py
@@ -39,6 +39,7 @@ class StreamReaderWrapper(StreamWrapper):
 
 class StreamWriterWrapper(StreamWrapper):
     async def close(self):
+        self.stream.write_eof()
         self.stream.close()
         await self.stream.wait_closed()
 

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -94,7 +94,7 @@ class BaseStep(Step, ABC):
         if logger.isEnabledFor(logging.DEBUG):
             if check_termination(inputs.values()):
                 logger.debug(
-                    f"Step {self.name} received termination token with Status {_reduce_statuses([t.value for t in inputs.values()]).name.lower()}"
+                    f"Step {self.name} received termination token with Status {_reduce_statuses([t.value for t in inputs.values()]).name}"
                 )
             else:
                 logger.debug(

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -145,8 +145,10 @@ async def test_ssh_connector_multiple_request_fail(context: StreamFlowContext) -
         *(connector.get_available_locations() for _ in range(3)),
         return_exceptions=True,
     ):
-        assert isinstance(result, (ConnectionError, asyncssh.Error)) or (
-            isinstance(result, WorkflowExecutionException)
-            and result.args[0]
-            == "Hosts .* have no more available contexts: terminating."
+        assert (
+            re.match(
+                r"Hosts \[.*] have no more available contexts: terminating.",
+                result.args[0],
+            )
+            is not None
         )

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -147,5 +147,6 @@ async def test_ssh_connector_multiple_request_fail(context: StreamFlowContext) -
     ):
         assert isinstance(result, (ConnectionError, asyncssh.Error)) or (
             isinstance(result, WorkflowExecutionException)
-            and result.args[0] == "No more contexts available: terminating."
+            and result.args[0]
+            == "Hosts .* have no more available contexts: terminating."
         )

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 from collections.abc import Callable, MutableSequence
 from typing import Any
 
-import asyncssh
 import pytest
 import pytest_asyncio
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -147,5 +147,5 @@ async def test_ssh_connector_multiple_request_fail(context: StreamFlowContext) -
     ):
         assert isinstance(result, (ConnectionError, asyncssh.Error)) or (
             isinstance(result, WorkflowExecutionException)
-            and result.args[0] == "Impossible to connect to .*"
+            and result.args[0] == "No more contexts available: terminating."
         )

--- a/tests/utils/deployment.py
+++ b/tests/utils/deployment.py
@@ -280,6 +280,8 @@ async def get_ssh_deployment_config(_context: StreamFlowContext):
                     "hostname": "127.0.0.1:2222",
                     "sshKey": f.name,
                     "username": "linuxserver.io",
+                    "retries": 0,
+                    "retryDelay": 1,
                 }
             ],
             "maxConcurrentSessions": 10,

--- a/tests/utils/deployment.py
+++ b/tests/utils/deployment.py
@@ -280,8 +280,8 @@ async def get_ssh_deployment_config(_context: StreamFlowContext):
                     "hostname": "127.0.0.1:2222",
                     "sshKey": f.name,
                     "username": "linuxserver.io",
-                    "retries": 0,
-                    "retryDelay": 1,
+                    "retries": 2,
+                    "retryDelay": 5,
                 }
             ],
             "maxConcurrentSessions": 10,


### PR DESCRIPTION
This commit improves the retry mechanism's resilience. Before this commit, the mechanism involved only opening the connection. Now, it covers both connection opening and connection communication exceptions. In addition, now the `SSHConnector` correctly retrieves the free disk size to determine the available storage space, instead of using the full disk size. Finally, two logging messages were fixed. A Docker `DEBUG` logging message has a new line at the end. The step exit status was in lowercase, but in StreamFlow, it is shown in uppercase. 