### PR TITLE
Added explicit `return` in `_copy_remote_to_remote`

### DIFF
--- a/streamflow/deployment/connector/container.py
+++ b/streamflow/deployment/connector/container.py
@@ -394,7 +394,7 @@ class ContainerConnector(ConnectorWrapper, ABC):
                     )
                 )
             # Perform a standard remote-to-remote copy for unbound locations
-            await BaseConnector._copy_remote_to_remote(
+            return await BaseConnector._copy_remote_to_remote(
                 self,
                 src=src,
                 dst=dst,
@@ -405,7 +405,7 @@ class ContainerConnector(ConnectorWrapper, ABC):
             )
         # Otherwise, perform a standard remote-to-remote copy
         else:
-            await BaseConnector._copy_remote_to_remote(
+            return await BaseConnector._copy_remote_to_remote(
                 self,
                 src=src,
                 dst=dst,


### PR DESCRIPTION
This commit adds explicit `return` statements in all the branches of the `if-else` construct in the `_copy_remote_to_remote` method of the `ContainerConnector` class. Before this commit, only one branch of the `if-else` construct had the `return` statement. This fix is necessary to be complaint to the `py/mixed-returns` rule of the `CodeQL` tool.