### PR TITLE
Moved `Graph` reference from `CWLTokenProcessor` class to `CWLWorkflow`

### DIFF
--- a/streamflow/cwl/processor.py
+++ b/streamflow/cwl/processor.py
@@ -116,7 +116,6 @@ class CWLTokenProcessor(TokenProcessor):
         enum_symbols: MutableSequence[str] | None = None,
         expression_lib: MutableSequence[str] | None = None,
         file_format: str | None = None,
-        format_graph: bool = False,
         full_js: bool = False,
         load_contents: bool | None = None,
         load_listing: LoadListing | None = None,
@@ -131,7 +130,6 @@ class CWLTokenProcessor(TokenProcessor):
         self.enum_symbols: MutableSequence[str] | None = enum_symbols
         self.expression_lib: MutableSequence[str] | None = expression_lib
         self.file_format: str | None = file_format
-        self.format_graph: bool = format_graph
         self.full_js: bool = full_js
         self.load_contents: bool | None = load_contents
         self.load_listing: LoadListing | None = load_listing
@@ -155,7 +153,6 @@ class CWLTokenProcessor(TokenProcessor):
             enum_symbols=row["enum_symbols"],
             expression_lib=row["expression_lib"],
             file_format=row["file_format"],
-            format_graph=row["format_graph"],
             full_js=row["full_js"],
             load_contents=row["load_contents"],
             load_listing=(
@@ -192,11 +189,7 @@ class CWLTokenProcessor(TokenProcessor):
                 cwl_utils.file_formats.check_format(
                     token_value,
                     input_formats,
-                    (
-                        cast(CWLWorkflow, self.workflow).format_graph
-                        if self.format_graph
-                        else None
-                    ),
+                    cast(CWLWorkflow, self.workflow).format_graph,
                 )
             except ValidationException as e:
                 raise WorkflowExecutionException(e.message) from e
@@ -303,7 +296,6 @@ class CWLTokenProcessor(TokenProcessor):
                 "enum_symbols": self.enum_symbols,
                 "expression_lib": self.expression_lib,
                 "file_format": self.file_format,
-                "format_graph": self.format_graph,
                 "full_js": self.full_js,
                 "load_contents": self.load_contents,
                 "load_listing": self.load_listing.value if self.load_listing else None,

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -183,7 +183,7 @@ def _create_command(
 
 def _create_command_output_processor_base(
     port_name: str,
-    workflow: Workflow,
+    workflow: CWLWorkflow,
     port_target: Target | None,
     port_type: Any,
     cwl_element: MutableMapping[str, Any],
@@ -247,7 +247,7 @@ def _create_command_output_processor_base(
 
 def _create_command_output_processor(
     port_name: str,
-    workflow: Workflow,
+    workflow: CWLWorkflow,
     port_target: Target | None,
     port_type: Any,
     cwl_element: MutableMapping[str, Any],
@@ -437,7 +437,7 @@ def _create_context() -> MutableMapping[str, Any]:
 
 def _create_list_merger(
     name: str,
-    workflow: Workflow,
+    workflow: CWLWorkflow,
     ports: MutableMapping[str, Port],
     output_port: Port | None = None,
     link_merge: str | None = None,
@@ -580,12 +580,11 @@ def _create_residual_combinator(
 
 def _create_token_processor(
     port_name: str,
-    workflow: Workflow,
+    workflow: CWLWorkflow,
     port_type: Any,
     cwl_element: MutableMapping[str, Any],
     cwl_name_prefix: str,
     schema_def_types: MutableMapping[str, Any],
-    format_graph: bool,
     context: MutableMapping[str, Any],
     optional: bool = False,
     default_required_sf: bool = True,
@@ -607,7 +606,6 @@ def _create_token_processor(
                         cwl_element=cwl_element,
                         cwl_name_prefix=cwl_name_prefix,
                         schema_def_types=schema_def_types,
-                        format_graph=format_graph,
                         context=context,
                         check_type=check_type,
                         force_deep_listing=force_deep_listing,
@@ -664,7 +662,6 @@ def _create_token_processor(
                                 ),
                             ),
                             schema_def_types=schema_def_types,
-                            format_graph=format_graph,
                             context=context,
                             check_type=check_type,
                             force_deep_listing=force_deep_listing,
@@ -696,7 +693,6 @@ def _create_token_processor(
                 cwl_element=cwl_element,
                 cwl_name_prefix=cwl_name_prefix,
                 schema_def_types=schema_def_types,
-                format_graph=format_graph,
                 context=context,
                 optional=optional,
                 check_type=check_type,
@@ -716,7 +712,6 @@ def _create_token_processor(
                         cwl_element=cwl_element,
                         cwl_name_prefix=cwl_name_prefix,
                         schema_def_types=schema_def_types,
-                        format_graph=format_graph,
                         context=context,
                         optional=optional,
                         check_type=check_type,
@@ -735,7 +730,6 @@ def _create_token_processor(
             cwl_element=cwl_element,
             cwl_name_prefix=cwl_name_prefix,
             schema_def_types=schema_def_types,
-            format_graph=format_graph,
             context=context,
             optional=optional,
             check_type=check_type,
@@ -756,7 +750,6 @@ def _create_token_processor(
                 check_type=check_type,
                 expression_lib=expression_lib,
                 file_format=cwl_element.get("format"),
-                format_graph=format_graph,
                 full_js=full_js,
                 load_contents=cwl_element.get(
                     "loadContents",
@@ -805,11 +798,10 @@ def _create_token_processor(
 def _create_token_transformer(
     name: str,
     port_name: str,
-    workflow: Workflow,
+    workflow: CWLWorkflow,
     cwl_element: MutableMapping[str, Any],
     cwl_name_prefix: str,
     schema_def_types: MutableMapping[str, Any],
-    format_graph: bool,
     context: MutableMapping[str, Any],
     check_type: bool = True,
     only_propagate_secondary_files: bool = True,
@@ -825,7 +817,6 @@ def _create_token_transformer(
             cwl_element=cwl_element,
             cwl_name_prefix=cwl_name_prefix,
             schema_def_types=schema_def_types,
-            format_graph=format_graph,
             context=context,
             check_type=check_type,
             only_propagate_secondary_files=only_propagate_secondary_files,
@@ -1493,7 +1484,7 @@ class CWLTranslator:
 
     def _recursive_translate(
         self,
-        workflow: Workflow,
+        workflow: CWLWorkflow,
         cwl_element: cwltool.process.Process,
         context: MutableMapping[str, Any],
         name_prefix: str,
@@ -1639,9 +1630,6 @@ class CWLTranslator:
                 global_name=global_name,
                 port_name=port_name,
             )
-            # Add the `Graph` in the workflow
-            if workflow.format_graph is None:
-                workflow.format_graph = self.loading_context.loader.graph
             # Add a token transformer step to process inputs
             token_transformer = _create_token_transformer(
                 name=global_name + "-token-transformer",
@@ -1650,7 +1638,6 @@ class CWLTranslator:
                 cwl_element=element_input,
                 cwl_name_prefix=posixpath.join(cwl_name_prefix, port_name),
                 schema_def_types=schema_def_types,
-                format_graph=True,
                 context=context,
                 only_propagate_secondary_files=(name_prefix != "/"),
             )
@@ -1798,9 +1785,6 @@ class CWLTranslator:
                 global_name=global_name,
                 port_name=port_name,
             )
-            # Add the `Graph` in the workflow
-            if workflow.format_graph is None:
-                workflow.format_graph = self.loading_context.loader.graph
             # Create token transformer step
             token_transformers[global_name] = _create_token_transformer(
                 name=global_name + "-token-transformer",
@@ -1809,7 +1793,6 @@ class CWLTranslator:
                 cwl_element=element_input,
                 cwl_name_prefix=posixpath.join(cwl_name_prefix, port_name),
                 schema_def_types=schema_def_types,
-                format_graph=True,
                 context=context,
                 only_propagate_secondary_files=(name_prefix != "/"),
             )
@@ -1933,7 +1916,7 @@ class CWLTranslator:
 
     def _translate_workflow_step(
         self,
-        workflow: Workflow,
+        workflow: CWLWorkflow,
         cwl_element: cwltool.workflow.WorkflowStep,
         context: MutableMapping[str, Any],
         name_prefix: str,
@@ -2436,7 +2419,7 @@ class CWLTranslator:
 
     def _translate_workflow_step_input(
         self,
-        workflow: Workflow,
+        workflow: CWLWorkflow,
         context: MutableMapping[str, Any],
         element_id: str,
         element_input: MutableMapping[str, Any],
@@ -2508,7 +2491,6 @@ class CWLTranslator:
                     cwl_element=element_input,
                     cwl_name_prefix=posixpath.join(cwl_step_name, port_name),
                     schema_def_types=schema_def_types,
-                    format_graph=self.loading_context.loader.graph,
                     context=context,
                     check_type=False,
                 ),
@@ -2632,6 +2614,7 @@ class CWLTranslator:
             config=self.workflow_config.config,
             name=self.name,
             cwl_version=self.loading_context.metadata["cwlVersion"],
+            format_graph=self.loading_context.loader.graph,
         )
         # Create context
         context = _create_context()
@@ -2696,9 +2679,6 @@ class CWLTranslator:
                         full_js=full_js,
                         expression_lib=expression_lib,
                     )
-                    # Add the `Graph` in the workflow
-                    if workflow.format_graph is None:
-                        workflow.format_graph = self.loading_context.loader.graph
                     # Build transformer step
                     transformer_step = workflow.create_step(
                         cls=CWLTokenTransformer,
@@ -2711,7 +2691,6 @@ class CWLTranslator:
                             cwl_element=cwl_elements[output_name],
                             cwl_name_prefix=posixpath.join(cwl_root_prefix, port_name),
                             schema_def_types=_get_schema_def_types(requirements),
-                            format_graph=True,
                             context=context,
                             check_type=False,
                             default_required_sf=False,

--- a/streamflow/cwl/workflow.py
+++ b/streamflow/cwl/workflow.py
@@ -21,10 +21,11 @@ class CWLWorkflow(Workflow):
         cwl_version: str,
         config: MutableMapping[str, Any],
         name: str = None,
+        format_graph: Graph | None = None,
     ):
         super().__init__(context, config, name)
         self.cwl_version: str = cwl_version
-        self.format_graph: Graph | None = None
+        self.format_graph: Graph | None = format_graph
         self.type: str | None = "cwl"
 
     async def _save_additional_params(
@@ -50,15 +51,14 @@ class CWLWorkflow(Workflow):
         loading_context: DatabaseLoadingContext,
     ) -> CWLWorkflow:
         params = json.loads(row["params"])
-        workflow = cls(
+        return cls(
             context=context,
             config=params["config"],
             cwl_version=params["cwl_version"],
             name=row["name"],
+            format_graph=(
+                Graph().parse(data=params["format_graph"])
+                if params["format_graph"] is not None
+                else None
+            ),
         )
-        workflow.format_graph = (
-            Graph().parse(data=params["format_graph"])
-            if params["format_graph"] is not None
-            else None
-        )
-        return workflow

--- a/tests/test_cwl_persistence.py
+++ b/tests/test_cwl_persistence.py
@@ -10,7 +10,7 @@ from ruamel.yaml.scalarstring import DoubleQuotedScalarString, LiteralScalarStri
 from streamflow.core import utils
 from streamflow.core.command import CommandTokenProcessor, UnionCommandTokenProcessor
 from streamflow.core.context import StreamFlowContext
-from streamflow.core.workflow import Step, Workflow
+from streamflow.core.workflow import Step
 from streamflow.cwl.combinator import ListMergeCombinator
 from streamflow.cwl.command import (
     CWLCommand,
@@ -52,7 +52,7 @@ from streamflow.cwl.workflow import CWLWorkflow
 from streamflow.workflow.port import JobPort
 from streamflow.workflow.step import CombinatorStep, ExecuteStep
 from tests.conftest import save_load_and_test
-from tests.utils.workflow import CWL_VERSION
+from tests.utils.workflow import CWL_VERSION, create_workflow
 
 
 def _create_cwl_command(
@@ -94,7 +94,7 @@ def _create_cwl_command_token_processor(
     )
 
 
-def _create_cwl_token_processor(name: str, workflow: Workflow) -> CWLTokenProcessor:
+def _create_cwl_token_processor(name: str, workflow: CWLWorkflow) -> CWLTokenProcessor:
     return CWLTokenProcessor(
         name=name,
         workflow=workflow,
@@ -102,7 +102,7 @@ def _create_cwl_token_processor(name: str, workflow: Workflow) -> CWLTokenProces
         enum_symbols=["path1", "path2"],
         expression_lib=["expr_lib1", "expr_lib2"],
         secondary_files=[SecondaryFile("file1", True)],
-        format_graph=Graph(),
+        format_graph=workflow.format_graph is not None,
         load_listing=LoadListing.no_listing,
     )
 
@@ -129,10 +129,10 @@ async def test_cwl_command(context: StreamFlowContext):
     workflow = CWLWorkflow(
         context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
     )
-    port = workflow.create_port()
+    job_port = workflow.create_port(JobPort)
     await workflow.save(context)
     step = workflow.create_step(
-        cls=ExecuteStep, name=utils.random_name(), job_port=port
+        cls=ExecuteStep, name=utils.random_name(), job_port=job_port
     )
     step.command = _create_cwl_command(step, [])
     await save_load_and_test(step, context)
@@ -144,10 +144,10 @@ async def test_cwl_expression_command(context: StreamFlowContext):
     workflow = CWLWorkflow(
         context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
     )
-    port = workflow.create_port()
+    job_port = workflow.create_port(JobPort)
     await workflow.save(context)
     step = workflow.create_step(
-        cls=ExecuteStep, name=utils.random_name(), job_port=port
+        cls=ExecuteStep, name=utils.random_name(), job_port=job_port
     )
     step.command = CWLExpressionCommand(
         step=step,
@@ -167,10 +167,10 @@ async def test_cwl_command_token_processor(context: StreamFlowContext):
     workflow = CWLWorkflow(
         context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
     )
-    port = workflow.create_port()
+    job_port = workflow.create_port(JobPort)
     await workflow.save(context)
     step = workflow.create_step(
-        cls=ExecuteStep, name=utils.random_name(), job_port=port
+        cls=ExecuteStep, name=utils.random_name(), job_port=job_port
     )
 
     step.command = _create_cwl_command(
@@ -193,10 +193,10 @@ async def test_cwl_command_token_processors_nested(context: StreamFlowContext):
     workflow = CWLWorkflow(
         context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
     )
-    port = workflow.create_port()
+    job_port = workflow.create_port(JobPort)
     await workflow.save(context)
     step = workflow.create_step(
-        cls=ExecuteStep, name=utils.random_name(), job_port=port
+        cls=ExecuteStep, name=utils.random_name(), job_port=job_port
     )
 
     step.command = _create_cwl_command(
@@ -219,10 +219,10 @@ async def test_cwl_object_command_token_processor(context: StreamFlowContext):
     workflow = CWLWorkflow(
         context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
     )
-    port = workflow.create_port()
+    job_port = workflow.create_port(JobPort)
     await workflow.save(context)
     step = workflow.create_step(
-        cls=ExecuteStep, name=utils.random_name(), job_port=port
+        cls=ExecuteStep, name=utils.random_name(), job_port=job_port
     )
     step.command = _create_cwl_command(
         step,
@@ -245,10 +245,10 @@ async def test_cwl_object_command_token_processors_nested(context: StreamFlowCon
     workflow = CWLWorkflow(
         context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
     )
-    port = workflow.create_port()
+    job_port = workflow.create_port(JobPort)
     await workflow.save(context)
     step = workflow.create_step(
-        cls=ExecuteStep, name=utils.random_name(), job_port=port
+        cls=ExecuteStep, name=utils.random_name(), job_port=job_port
     )
 
     processors = [
@@ -289,10 +289,10 @@ async def test_cwl_union_command_token_processor(context: StreamFlowContext):
     workflow = CWLWorkflow(
         context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
     )
-    port = workflow.create_port()
+    job_port = workflow.create_port(JobPort)
     await workflow.save(context)
     step = workflow.create_step(
-        cls=ExecuteStep, name=utils.random_name(), job_port=port
+        cls=ExecuteStep, name=utils.random_name(), job_port=job_port
     )
     step.command = _create_cwl_command(
         step,
@@ -316,10 +316,10 @@ async def test_cwl_union_command_token_processor_nested(context: StreamFlowConte
     workflow = CWLWorkflow(
         context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
     )
-    port = workflow.create_port()
+    job_port = workflow.create_port(JobPort)
     await workflow.save(context)
     step = workflow.create_step(
-        cls=ExecuteStep, name=utils.random_name(), job_port=port
+        cls=ExecuteStep, name=utils.random_name(), job_port=job_port
     )
     step.command = _create_cwl_command(
         step,
@@ -354,10 +354,10 @@ async def test_cwl_map_command_token_processor(context: StreamFlowContext):
     workflow = CWLWorkflow(
         context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
     )
-    port = workflow.create_port()
+    job_port = workflow.create_port(JobPort)
     await workflow.save(context)
     step = workflow.create_step(
-        cls=ExecuteStep, name=utils.random_name(), job_port=port
+        cls=ExecuteStep, name=utils.random_name(), job_port=job_port
     )
     step.command = _create_cwl_command(
         step,
@@ -378,12 +378,7 @@ async def test_cwl_map_command_token_processor(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_list_merge_combinator(context: StreamFlowContext):
     """Test saving and loading CombinatorStep with ListMergeCombinator from database"""
-    workflow = CWLWorkflow(
-        context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
-    )
-    port = workflow.create_port()
-    await workflow.save(context)
-
+    workflow, (port, *_) = await create_workflow(context=context, num_port=1)
     name = utils.random_name()
     step = workflow.create_step(
         cls=CombinatorStep,
@@ -402,15 +397,11 @@ async def test_list_merge_combinator(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_default_transformer(context: StreamFlowContext):
     """Test saving and loading DefaultTransformer from database"""
-    workflow = CWLWorkflow(
-        context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
-    )
-    port = workflow.create_port()
-    await workflow.save(context)
-
-    name = utils.random_name()
+    workflow, (port, *_) = await create_workflow(context=context, num_port=1)
     transformer = workflow.create_step(
-        cls=DefaultTransformer, name=name + "-transformer", default_port=port
+        cls=DefaultTransformer,
+        name=utils.random_name() + "-transformer",
+        default_port=port,
     )
     await save_load_and_test(transformer, context)
 
@@ -418,15 +409,11 @@ async def test_default_transformer(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_default_retag_transformer(context: StreamFlowContext):
     """Test saving and loading DefaultRetagTransformer from database"""
-    workflow = CWLWorkflow(
-        context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
-    )
-    port = workflow.create_port()
-    await workflow.save(context)
-
-    name = utils.random_name()
+    workflow, (port, *_) = await create_workflow(context=context, num_port=1)
     transformer = workflow.create_step(
-        cls=DefaultRetagTransformer, name=name + "-transformer", default_port=port
+        cls=DefaultRetagTransformer,
+        name=utils.random_name() + "-transformer",
+        default_port=port,
     )
     await save_load_and_test(transformer, context)
 
@@ -438,6 +425,8 @@ async def test_cwl_token_transformer(context: StreamFlowContext):
         context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
     )
     port = workflow.create_port()
+    if workflow.format_graph is None:
+        workflow.format_graph = Graph()
     await workflow.save(context)
 
     name = utils.random_name()
@@ -458,6 +447,8 @@ async def test_value_from_transformer(context: StreamFlowContext):
     )
     port = workflow.create_port()
     job_port = workflow.create_port(JobPort)
+    if workflow.format_graph is None:
+        workflow.format_graph = Graph()
     await workflow.save(context)
 
     name = utils.random_name()
@@ -482,6 +473,8 @@ async def test_loop_value_from_transformer(context: StreamFlowContext):
     )
     port = workflow.create_port()
     job_port = workflow.create_port(JobPort)
+    if workflow.format_graph is None:
+        workflow.format_graph = Graph()
     await workflow.save(context)
 
     name = utils.random_name()
@@ -505,6 +498,8 @@ async def test_cwl_map_token_transformer(context: StreamFlowContext):
         context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
     )
     port = workflow.create_port()
+    if workflow.format_graph is None:
+        workflow.format_graph = Graph()
     await workflow.save(context)
 
     name = utils.random_name()
@@ -528,6 +523,8 @@ async def test_cwl_object_token_transformer(context: StreamFlowContext):
         context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
     )
     port = workflow.create_port()
+    if workflow.format_graph is None:
+        workflow.format_graph = Graph()
     await workflow.save(context)
 
     name = utils.random_name()
@@ -553,6 +550,8 @@ async def test_cwl_union_token_transformer(context: StreamFlowContext):
         context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
     )
     port = workflow.create_port()
+    if workflow.format_graph is None:
+        workflow.format_graph = Graph()
     await workflow.save(context)
 
     name = utils.random_name()
@@ -572,13 +571,7 @@ async def test_cwl_union_token_transformer(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_all_non_null_transformer(context: StreamFlowContext):
     """Test saving and loading AllNonNullTransformer from database"""
-    workflow = CWLWorkflow(
-        context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
-    )
-    in_port = workflow.create_port()
-    out_port = workflow.create_port()
-    await workflow.save(context)
-
+    workflow, (in_port, out_port) = await create_workflow(context=context)
     name = utils.random_name()
     transformer = workflow.create_step(
         cls=AllNonNullTransformer, name=name + "-transformer"
@@ -591,13 +584,7 @@ async def test_all_non_null_transformer(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_first_non_null_transformer(context: StreamFlowContext):
     """Test saving and loading FirstNonNullTransformer from database"""
-    workflow = CWLWorkflow(
-        context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
-    )
-    in_port = workflow.create_port()
-    out_port = workflow.create_port()
-    await workflow.save(context)
-
+    workflow, (in_port, out_port) = await create_workflow(context=context)
     name = utils.random_name()
     transformer = workflow.create_step(
         cls=FirstNonNullTransformer, name=name + "-transformer"
@@ -610,13 +597,7 @@ async def test_first_non_null_transformer(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_forward_transformer(context: StreamFlowContext):
     """Test saving and loading ForwardTransformer from database"""
-    workflow = CWLWorkflow(
-        context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
-    )
-    in_port = workflow.create_port()
-    out_port = workflow.create_port()
-    await workflow.save(context)
-
+    workflow, (in_port, out_port) = await create_workflow(context=context)
     name = utils.random_name()
     transformer = workflow.create_step(
         cls=ForwardTransformer, name=name + "-transformer"
@@ -629,13 +610,7 @@ async def test_forward_transformer(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_list_to_element_transformer(context: StreamFlowContext):
     """Test saving and loading ListToElementTransformer from database"""
-    workflow = CWLWorkflow(
-        context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
-    )
-    in_port = workflow.create_port()
-    out_port = workflow.create_port()
-    await workflow.save(context)
-
+    workflow, (in_port, out_port) = await create_workflow(context=context)
     name = utils.random_name()
     transformer = workflow.create_step(
         cls=ListToElementTransformer, name=name + "-transformer"
@@ -648,13 +623,7 @@ async def test_list_to_element_transformer(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_only_non_null_transformer(context: StreamFlowContext):
     """Test saving and loading OnlyNonNullTransformer from database"""
-    workflow = CWLWorkflow(
-        context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
-    )
-    in_port = workflow.create_port()
-    out_port = workflow.create_port()
-    await workflow.save(context)
-
+    workflow, (in_port, out_port) = await create_workflow(context=context)
     name = utils.random_name()
     transformer = workflow.create_step(
         cls=OnlyNonNullTransformer, name=name + "-transformer"
@@ -667,13 +636,7 @@ async def test_only_non_null_transformer(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_cwl_empty_scatter_conditional_step(context: StreamFlowContext):
     """Test saving and loading CWLEmptyScatterConditionalStep from database"""
-    workflow = CWLWorkflow(
-        context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
-    )
-    in_port = workflow.create_port()
-    out_port = workflow.create_port()
-    await workflow.save(context)
-
+    workflow, (in_port, out_port) = await create_workflow(context=context)
     name = utils.random_name()
     empty_scatter_conditional_step = workflow.create_step(
         cls=CWLEmptyScatterConditionalStep,
@@ -688,12 +651,7 @@ async def test_cwl_empty_scatter_conditional_step(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_cwl_conditional_step(context: StreamFlowContext):
     """Test saving and loading CWLConditionalStep from database"""
-    workflow = CWLWorkflow(
-        context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
-    )
-    skip_port = workflow.create_port()
-    await workflow.save(context)
-
+    workflow, (skip_port, *_) = await create_workflow(context=context, num_port=1)
     step = workflow.create_step(
         cls=CWLConditionalStep,
         name=utils.random_name() + "-when",
@@ -708,12 +666,7 @@ async def test_cwl_conditional_step(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_cwl_loop_conditional_step(context: StreamFlowContext):
     """Test saving and loading CWLLoopConditionalStep from database"""
-    workflow = CWLWorkflow(
-        context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
-    )
-    skip_port = workflow.create_port()
-    await workflow.save(context)
-
+    workflow, (skip_port, *_) = await create_workflow(context=context, num_port=1)
     step = workflow.create_step(
         cls=CWLLoopConditionalStep,
         name=utils.random_name() + "-when",
@@ -731,13 +684,12 @@ async def test_cwl_transfer_step(context: StreamFlowContext):
     workflow = CWLWorkflow(
         context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
     )
-    port = workflow.create_port()
+    job_port = workflow.create_port(JobPort)
     await workflow.save(context)
-
     step = workflow.create_step(
         cls=CWLTransferStep,
-        name=posixpath.join(utils.random_name(), "__transfer__", port.name),
-        job_port=port,
+        name=posixpath.join(utils.random_name(), "__transfer__", "test"),
+        job_port=job_port,
         writable=True,
     )
     await save_load_and_test(step, context)
@@ -749,13 +701,12 @@ async def test_cwl_input_injector_step(context: StreamFlowContext):
     workflow = CWLWorkflow(
         context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
     )
-    port = workflow.create_port()
+    job_port = workflow.create_port(JobPort)
     await workflow.save(context)
-
     step = workflow.create_step(
         cls=CWLInputInjectorStep,
         name=posixpath.join(utils.random_name(), "-injector"),
-        job_port=port,
+        job_port=job_port,
     )
     await save_load_and_test(step, context)
 
@@ -764,11 +715,7 @@ async def test_cwl_input_injector_step(context: StreamFlowContext):
 @pytest.mark.parametrize("step_cls", [CWLLoopOutputAllStep, CWLLoopOutputLastStep])
 async def test_cwl_loop_output(context: StreamFlowContext, step_cls: type[Step]):
     """Test saving and loading CWLLoopOutput from database"""
-    workflow = CWLWorkflow(
-        context=context, name=utils.random_name(), config={}, cwl_version=CWL_VERSION
-    )
-    await workflow.save(context)
-
+    workflow, _ = await create_workflow(context=context, num_port=0)
     step = workflow.create_step(
         cls=step_cls,
         name=posixpath.join(utils.random_name(), "-loop-output"),

--- a/tests/test_cwl_persistence.py
+++ b/tests/test_cwl_persistence.py
@@ -102,7 +102,6 @@ def _create_cwl_token_processor(name: str, workflow: CWLWorkflow) -> CWLTokenPro
         enum_symbols=["path1", "path2"],
         expression_lib=["expr_lib1", "expr_lib2"],
         secondary_files=[SecondaryFile("file1", True)],
-        format_graph=workflow.format_graph is not None,
         load_listing=LoadListing.no_listing,
     )
 


### PR DESCRIPTION
This commit reduces the memory space required by a workflow instance, particularly in the database and also in RAM when the workflow is loaded from the database.

Before this commit, when a `Workflow` was instantiated, each `CWLTokenProcessor` instance shared the same `Graph` instance. However, each `CWLTokenProcessor` instance saved in the database their own `Graph` replica independently. This behaviour was highly costly and generated duplicated data. Moreover, when a new `Workflow` was loaded from the database, each `CWLTokenProcessor` instance created its own `Graph` instance because there was no logic that made them share the same instance.

Now, the `CWLWorkflow` has an attribute to store the `Graph` instance, and each `CWLTokenProcessor` refers to it when needed.