### PR TITLE
Fix MacOS X CI on GitHub Actions

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -52,11 +52,11 @@ jobs:
             on: "ubuntu-22.04"
             python: "3.12"
             version: "v1.2"
-          #- on: "macos-13"
-          #  python: "3.12"
-          #  commit: "76bdf9b55e2378432e0e6380ccedebb4a94ce483"
-          #  exclude: "docker_entrypoint,modify_file_content"
-          #  version: "v1.2"
+          - on: "macos-13"
+            python: "3.12"
+            commit: "76bdf9b55e2378432e0e6380ccedebb4a94ce483"
+            exclude: "docker_entrypoint,modify_file_content"
+            version: "v1.2"
     runs-on: ${{ matrix.on }}
     steps:
       - uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
         with:
           node-version: "20"
       - name: "Install Docker (MacOS X)"
-        uses: douglascamata/setup-docker-macos-action@v1-alpha.13
+        uses: douglascamata/setup-docker-macos-action@v1-alpha.14
         if: ${{ startsWith(matrix.on, 'macos-') }}
       - uses: docker/setup-qemu-action@v3
       - name: "Install Apptainer"
@@ -213,9 +213,9 @@ jobs:
       matrix:
         on: [ "ubuntu-22.04"]
         python: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
-        #include:
-        #  - on: "macos-13"
-        #    python: "3.12"
+        include:
+          - on: "macos-13"
+            python: "3.12"
     runs-on: ${{ matrix.on }}
     env:
       TOXENV: ${{ format('py{0}-unit', matrix.python) }}
@@ -232,7 +232,7 @@ jobs:
         with:
           node-version: "20"
       - name: "Install Docker (MacOs X)"
-        uses: douglascamata/setup-docker-macos-action@v1-alpha.13
+        uses: douglascamata/setup-docker-macos-action@v1-alpha.14
         if: ${{ startsWith(matrix.on, 'macos-') }}
       - uses: docker/setup-qemu-action@v3
       - name: "Install Apptainer"


### PR DESCRIPTION
Thsi commit restores the MacOS X continous integration by updating the `setup-docker-macos-action` step to version `v1-alpha.14`. This version fixes a bug with the newest GitHub MacOS X runner image (see douglascamata/setup-docker-macos-action#40), which led to temporarily disabling the CI on MacOS X (see #459).