### PR TITLE
Fix `ValueFromTransformer` without input deps

### DIFF
--- a/streamflow/cwl/combinator.py
+++ b/streamflow/cwl/combinator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, AsyncIterable, MutableMapping, MutableSequence
+from typing import Any, AsyncIterable, MutableMapping, MutableSequence, cast
 
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.persistence import DatabaseLoadingContext
@@ -44,7 +44,10 @@ class ListMergeCombinator(DotProductCombinator):
     ) -> ListMergeCombinator:
         return cls(
             name=row["name"],
-            workflow=await loading_context.load_workflow(context, row["workflow"]),
+            workflow=cast(
+                CWLWorkflow,
+                await loading_context.load_workflow(context, row["workflow"]),
+            ),
             input_names=row["input_names"],
             output_name=row["output_name"],
             flatten=row["flatten"],

--- a/streamflow/cwl/command.py
+++ b/streamflow/cwl/command.py
@@ -117,10 +117,10 @@ def _build_command_output_processor(name: str, step: Step, value: Any):
     if isinstance(value, MutableSequence):
         return CWLMapCommandOutputProcessor(
             name=name,
-            workflow=step.workflow,
+            workflow=cast(CWLWorkflow, step.workflow),
             processor=CWLUnionCommandOutputProcessor(
                 name=name,
-                workflow=step.workflow,
+                workflow=cast(CWLWorkflow, step.workflow),
                 processors=[
                     _build_command_output_processor(name=name, step=step, value=v)
                     for v in value
@@ -130,12 +130,14 @@ def _build_command_output_processor(name: str, step: Step, value: Any):
     elif isinstance(value, MutableMapping):
         if (token_type := utils.get_token_class(value)) in ["File", "Directory"]:
             return CWLCommandOutputProcessor(
-                name=name, workflow=step.workflow, token_type=token_type  # nosec
+                name=name,
+                workflow=cast(CWLWorkflow, step.workflow),
+                token_type=token_type,  # nosec
             )
         else:
             return CWLObjectCommandOutputProcessor(
                 name=name,
-                workflow=step.workflow,
+                workflow=cast(CWLWorkflow, step.workflow),
                 processors={
                     k: _build_command_output_processor(name=name, step=step, value=v)
                     for k, v in value.items()
@@ -143,7 +145,7 @@ def _build_command_output_processor(name: str, step: Step, value: Any):
             )
     else:
         return CWLCommandOutputProcessor(  # nosec
-            name=name, workflow=step.workflow, token_type="Any"
+            name=name, workflow=cast(CWLWorkflow, step.workflow), token_type="Any"
         )
 
 

--- a/streamflow/cwl/processor.py
+++ b/streamflow/cwl/processor.py
@@ -147,7 +147,10 @@ class CWLTokenProcessor(TokenProcessor):
     ) -> CWLTokenProcessor:
         return cls(
             name=row["name"],
-            workflow=await loading_context.load_workflow(context, row["workflow"]),
+            workflow=cast(
+                CWLWorkflow,
+                await loading_context.load_workflow(context, row["workflow"]),
+            ),
             token_type=row["token_type"],
             check_type=row["check_type"],
             enum_symbols=row["enum_symbols"],
@@ -385,7 +388,10 @@ class CWLCommandOutputProcessor(CommandOutputProcessor):
     ) -> CommandOutputProcessor:
         return cls(
             name=row["name"],
-            workflow=await loading_context.load_workflow(context, row["workflow"]),
+            workflow=cast(
+                CWLWorkflow,
+                await loading_context.load_workflow(context, row["workflow"]),
+            ),
             target=(
                 (await loading_context.load_target(context, row["workflow"]))
                 if row["target"]
@@ -726,7 +732,10 @@ class CWLMapTokenProcessor(TokenProcessor):
     ) -> CWLMapTokenProcessor:
         return cls(
             name=row["name"],
-            workflow=await loading_context.load_workflow(context, row["workflow"]),
+            workflow=cast(
+                CWLWorkflow,
+                await loading_context.load_workflow(context, row["workflow"]),
+            ),
             processor=await TokenProcessor.load(
                 context, row["processor"], loading_context
             ),
@@ -788,7 +797,10 @@ class CWLMapCommandOutputProcessor(CommandOutputProcessor):
     ) -> CommandOutputProcessor:
         return cls(
             name=row["name"],
-            workflow=await loading_context.load_workflow(context, row["workflow"]),
+            workflow=cast(
+                CWLWorkflow,
+                await loading_context.load_workflow(context, row["workflow"]),
+            ),
             processor=await CommandOutputProcessor.load(
                 context, row["processor"], loading_context
             ),
@@ -865,7 +877,10 @@ class CWLObjectTokenProcessor(TokenProcessor):
     ) -> CWLObjectTokenProcessor:
         return cls(
             name=row["name"],
-            workflow=await loading_context.load_workflow(context, row["workflow"]),
+            workflow=cast(
+                CWLWorkflow,
+                await loading_context.load_workflow(context, row["workflow"]),
+            ),
             processors={
                 k: v
                 for k, v in zip(
@@ -966,7 +981,10 @@ class CWLObjectCommandOutputProcessor(CommandOutputProcessor):
         params = json.loads(row["params"])
         return cls(
             name=row["name"],
-            workflow=await loading_context.load_workflow(context, row["workflow"]),
+            workflow=cast(
+                CWLWorkflow,
+                await loading_context.load_workflow(context, row["workflow"]),
+            ),
             target=(
                 (await loading_context.load_target(context, row["workflow"]))
                 if row["target"]
@@ -1152,7 +1170,10 @@ class CWLUnionTokenProcessor(TokenProcessor):
     ) -> CWLUnionTokenProcessor:
         return cls(
             name=row["name"],
-            workflow=await loading_context.load_workflow(context, row["workflow"]),
+            workflow=cast(
+                CWLWorkflow,
+                await loading_context.load_workflow(context, row["workflow"]),
+            ),
             processors=cast(
                 MutableSequence[TokenProcessor],
                 await asyncio.gather(
@@ -1269,7 +1290,10 @@ class CWLUnionCommandOutputProcessor(CommandOutputProcessor):
     ) -> CommandOutputProcessor:
         return cls(
             name=row["name"],
-            workflow=await loading_context.load_workflow(context, row["workflow"]),
+            workflow=cast(
+                CWLWorkflow,
+                await loading_context.load_workflow(context, row["workflow"]),
+            ),
             processors=cast(
                 MutableSequence[CommandOutputProcessor],
                 await asyncio.gather(

--- a/streamflow/cwl/step.py
+++ b/streamflow/cwl/step.py
@@ -252,7 +252,10 @@ class CWLConditionalStep(CWLBaseConditionalStep):
         params = json.loads(row["params"])
         step = cls(
             name=row["name"],
-            workflow=await loading_context.load_workflow(context, row["workflow"]),
+            workflow=cast(
+                CWLWorkflow,
+                await loading_context.load_workflow(context, row["workflow"]),
+            ),
             expression=params["expression"],
             expression_lib=params["expression_lib"],
             full_js=params["full_js"],
@@ -333,7 +336,10 @@ class CWLEmptyScatterConditionalStep(CWLBaseConditionalStep):
         params = json.loads(row["params"])
         return cls(
             name=row["name"],
-            workflow=await loading_context.load_workflow(context, row["workflow"]),
+            workflow=cast(
+                CWLWorkflow,
+                await loading_context.load_workflow(context, row["workflow"]),
+            ),
             scatter_method=params["scatter_method"],
         )
 
@@ -443,7 +449,10 @@ class CWLTransferStep(TransferStep):
         params = json.loads(row["params"])
         step = cls(
             name=row["name"],
-            workflow=await loading_context.load_workflow(context, row["workflow"]),
+            workflow=cast(
+                CWLWorkflow,
+                await loading_context.load_workflow(context, row["workflow"]),
+            ),
             job_port=cast(
                 JobPort, await loading_context.load_port(context, params["job_port"])
             ),

--- a/streamflow/cwl/transformer.py
+++ b/streamflow/cwl/transformer.py
@@ -122,7 +122,10 @@ class CWLTokenTransformer(ManyToOneTransformer):
         params = json.loads(row["params"])
         return cls(
             name=row["name"],
-            workflow=await loading_context.load_workflow(context, row["workflow"]),
+            workflow=cast(
+                CWLWorkflow,
+                await loading_context.load_workflow(context, row["workflow"]),
+            ),
             port_name=params["port_name"],
             processor=await TokenProcessor.load(
                 context, params["processor"], loading_context
@@ -166,7 +169,10 @@ class DefaultTransformer(ManyToOneTransformer):
         params = json.loads(row["params"])
         return cls(
             name=row["name"],
-            workflow=await loading_context.load_workflow(context, row["workflow"]),
+            workflow=cast(
+                CWLWorkflow,
+                await loading_context.load_workflow(context, row["workflow"]),
+            ),
             default_port=await loading_context.load_port(
                 context, params["default_port"]
             ),
@@ -341,7 +347,10 @@ class ValueFromTransformer(ManyToOneTransformer):
         )
         return cls(
             name=row["name"],
-            workflow=await loading_context.load_workflow(context, row["workflow"]),
+            workflow=cast(
+                CWLWorkflow,
+                await loading_context.load_workflow(context, row["workflow"]),
+            ),
             port_name=params["port_name"],
             processor=await TokenProcessor.load(
                 context, params["processor"], loading_context

--- a/tests/test_build_wf.py
+++ b/tests/test_build_wf.py
@@ -9,6 +9,7 @@ from streamflow.core.deployment import LocalTarget, FilterConfig
 from streamflow.core.workflow import Workflow, Port, Step
 from streamflow.cwl.command import CWLCommand, CWLCommandTokenProcessor
 from streamflow.cwl.translator import _create_command_output_processor_base
+from streamflow.cwl.workflow import CWLWorkflow
 from streamflow.persistence.loading_context import WorkflowBuilder
 from streamflow.workflow.combinator import LoopCombinator
 from streamflow.workflow.port import ConnectorPort, JobPort
@@ -203,7 +204,7 @@ async def test_execute_step(context: StreamFlowContext):
         out_port,
         _create_command_output_processor_base(
             port_name=out_port.name,
-            workflow=workflow,
+            workflow=cast(CWLWorkflow, workflow),
             port_target=None,
             port_type="string",
             cwl_element={},
@@ -345,7 +346,7 @@ async def test_workflow(context: StreamFlowContext):
         out_port,
         _create_command_output_processor_base(
             port_name=out_port.name,
-            workflow=workflow,
+            workflow=cast(CWLWorkflow, workflow),
             port_target=None,
             port_type="string",
             cwl_element={},

--- a/tests/test_cwl_build_wf.py
+++ b/tests/test_cwl_build_wf.py
@@ -1,5 +1,5 @@
 import posixpath
-from typing import Type
+from typing import Type, cast
 
 import pytest
 
@@ -29,6 +29,7 @@ from streamflow.cwl.transformer import (
     OnlyNonNullTransformer,
     ValueFromTransformer,
 )
+from streamflow.cwl.workflow import CWLWorkflow
 from streamflow.workflow.port import JobPort
 from streamflow.workflow.step import CombinatorStep
 from tests.conftest import are_equals
@@ -106,7 +107,7 @@ async def test_list_merge_combinator(context: StreamFlowContext):
             "name": utils.random_name() + "-combinator",
             "combinator": ListMergeCombinator(
                 name=utils.random_name(),
-                workflow=workflow,
+                workflow=cast(CWLWorkflow, workflow),
                 input_names=[port.name],
                 output_name=port.name,
                 flatten=False,
@@ -151,7 +152,7 @@ async def test_loop_value_from_transformer(context: StreamFlowContext):
             "name": utils.random_name() + "-loop-value-from-transformer",
             "processor": CWLTokenProcessor(
                 name=port.name,
-                workflow=workflow,
+                workflow=cast(CWLWorkflow, workflow),
             ),
             "port_name": port.name,
             "full_js": True,
@@ -206,7 +207,7 @@ async def test_value_from_transformer(context: StreamFlowContext):
             "name": utils.random_name() + "-value-from-transformer",
             "processor": CWLTokenProcessor(
                 name=port.name,
-                workflow=workflow,
+                workflow=cast(CWLWorkflow, workflow),
             ),
             "port_name": port.name,
             "full_js": True,
@@ -302,7 +303,7 @@ async def test_cwl_token_transformer(context: StreamFlowContext):
             "port_name": "test",
             "processor": CWLTokenProcessor(
                 name=step_name,
-                workflow=workflow,
+                workflow=cast(CWLWorkflow, workflow),
             ),
         },
         context,

--- a/tests/test_cwl_persistence.py
+++ b/tests/test_cwl_persistence.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import posixpath
-from typing import Any, MutableSequence
+from typing import Any, MutableSequence, cast
 
 import pytest
 from rdflib import Graph
@@ -388,7 +388,7 @@ async def test_list_merge_combinator(context: StreamFlowContext):
         name=name + "-combinator",
         combinator=ListMergeCombinator(
             name=utils.random_name(),
-            workflow=workflow,
+            workflow=cast(CWLWorkflow, workflow),
             input_names=[port.name],
             output_name=name,
             flatten=False,

--- a/tests/test_cwl_provenance.py
+++ b/tests/test_cwl_provenance.py
@@ -207,7 +207,7 @@ async def test_cwl_token_transformer(context: StreamFlowContext):
             "port_name": port_name,
             "processor": CWLTokenProcessor(
                 name=step_name,
-                workflow=workflow,
+                workflow=cast(CWLWorkflow, workflow),
             ),
         },
         token_list=token_list,
@@ -577,7 +577,7 @@ async def test_list_merge_combinator(context: StreamFlowContext):
         name=step_name + "-combinator",
         combinator=ListMergeCombinator(
             name=utils.random_name(),
-            workflow=workflow,
+            workflow=cast(CWLWorkflow, workflow),
             input_names=[port_name],
             output_name=port_name,
             flatten=False,
@@ -617,7 +617,7 @@ async def test_loop_value_from_transformer(context: StreamFlowContext):
         name=name + "-loop-value-from-transformer",
         processor=CWLTokenProcessor(
             name=in_port.name,
-            workflow=workflow,
+            workflow=cast(CWLWorkflow, workflow),
         ),
         port_name=port_name,
         full_js=True,

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -144,7 +144,7 @@ async def test_invalidate_location(context, src_connector, src_location):
     root_data_loc = context.data_manager.get_data_locations(
         "/", src_connector.deployment_name
     )[0]
-    context.data_manager.invalidate_location(root_data_loc, root_data_loc.path)
+    context.data_manager.invalidate_location(root_data_loc.location, root_data_loc.path)
 
     # Check data manager has invalidated the location
     path = "/"


### PR DESCRIPTION
Before this commit, a `ValueFromTransformer` without dependencies was not waiting for any input token, generating potential errors due to wrong token tags inside `scatter` and `loop` constructs. Now, a `ValueFromTransformer` without dependencies waits for all the other input ports to be available before being processed.