### PR TITLE
Handle lists in CWL `glob` field

### DIFF
--- a/cwl-conformance-test.sh
+++ b/cwl-conformance-test.sh
@@ -86,7 +86,6 @@ if [ "${RETURN_CODE}" -eq "0" ] ; then
 fi
 
 # Cleanup
-deactivate
 rm -rf "${COMMIT}.tar.gz" "${SCRIPT_DIRECTORY}/${REPO}-${COMMIT}" "${SCRIPT_DIRECTORY}/cwl-conformance-venv"
 
 # Exit


### PR DESCRIPTION
According to the CWL standard specification, the `glob` field of an `outputBinding` section can be an array of strings. In that case, a compliant WMS should find files or directories that match any pattern in the array. This case was not handled by StreamFlow, and this commit implements support for it.