### PR TITLE
Fix requirement eval in CWL `WorkflowStep`

### DIFF
--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -1975,10 +1975,6 @@ class CWLTranslator:
             name_prefix, cwl_name_prefix, cwl_element.id, preserve_cwl_prefix=True
         )
         # Extract requirements
-        for hint in cwl_element.embedded_tool.hints:
-            context["hints"][hint["class"]] = hint
-        for requirement in cwl_element.embedded_tool.requirements:
-            context["requirements"][requirement["class"]] = requirement
         requirements = {**context["hints"], **context["requirements"]}
         # Extract JavaScript requirements
         expression_lib, full_js = _process_javascript_requirement(requirements)


### PR DESCRIPTION
Before this commit, StreamFlow was using the fields of the `InlineJavascriptRequirement` specified inside the embedded tool when evaluating the expressions of a `WorkflowStep` object. This is a wrong behaviour, as the `WorkflowStep` should obey to the requirements specified in the parent `Workflow` object. This commit fixes this behaviour.