### PR TITLE
Improved job propagation after scheduling

### DIFF
--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -1522,11 +1522,14 @@ class ScheduleStep(BaseStep):
                             await self.workflow.context.scheduler.schedule(
                                 job, self.binding_config, self.hardware_requirement
                             )
-                            locations = self.workflow.context.scheduler.get_locations(
-                                job.name
-                            )
                             await self._propagate_job(
-                                connectors[locations[0].deployment], locations, job
+                                connector=self.workflow.context.scheduler.get_connector(
+                                    job.name
+                                ),
+                                locations=self.workflow.context.scheduler.get_locations(
+                                    job.name
+                                ),
+                                job=job,
                             )
             else:
                 # Create Job
@@ -1544,9 +1547,10 @@ class ScheduleStep(BaseStep):
                     self.binding_config,
                     self.hardware_requirement,
                 )
-                locations = self.workflow.context.scheduler.get_locations(job.name)
                 await self._propagate_job(
-                    connectors[locations[0].deployment], locations, job
+                    connector=self.workflow.context.scheduler.get_connector(job.name),
+                    locations=self.workflow.context.scheduler.get_locations(job.name),
+                    job=job,
                 )
                 status = Status.COMPLETED
             await self.terminate(self._get_status(status))


### PR DESCRIPTION
Before this commit, the way in which the selected `Connector` object was retrieved for a given scheduled `Job` was prone to errors if the `ExecutionLocation` assigned to the `Job` was belonging to a wrapped `Connector`. Now, the right `Connector` object is retrieved directly from the `Scheduler` implementation.