### PR TITLE
Simplify `DataManager` logic for local transfers

### DIFF
--- a/streamflow/core/utils.py
+++ b/streamflow/core/utils.py
@@ -8,7 +8,6 @@ import itertools
 import os
 import posixpath
 import shlex
-import shutil
 import uuid
 from typing import (
     Any,
@@ -266,19 +265,6 @@ def get_tag(tokens: Iterable[Token]) -> str:
         if len(tag) > len(output_tag):
             output_tag = tag
     return output_tag
-
-
-def local_copy(src: str, dst: str, read_only: bool):
-    if read_only:
-        if os.path.isdir(dst):
-            dst = os.path.join(dst, os.path.basename(src))
-        os.symlink(src, dst, target_is_directory=os.path.isdir(src))
-    else:
-        if os.path.isdir(src):
-            os.makedirs(dst, exist_ok=True)
-            shutil.copytree(src, dst, dirs_exist_ok=True)
-        else:
-            shutil.copy(src, dst)
 
 
 def random_name() -> str:

--- a/streamflow/data/manager.py
+++ b/streamflow/data/manager.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 from importlib_resources import files
 
 from streamflow.core.data import DataLocation, DataManager, DataType
-from streamflow.core.utils import local_copy
 from streamflow.data import remotepath
 from streamflow.deployment.connector.local import LocalConnector
 from streamflow.deployment.utils import get_path_processor
@@ -28,15 +27,12 @@ async def _copy(
     writable: False,
 ) -> None:
     if isinstance(src_connector, LocalConnector):
-        if isinstance(dst_connector, LocalConnector):
-            local_copy(src, dst, not writable)
-        else:
-            await dst_connector.copy_local_to_remote(
-                src=src,
-                dst=dst,
-                locations=dst_locations,
-                read_only=not writable,
-            )
+        await dst_connector.copy_local_to_remote(
+            src=src,
+            dst=dst,
+            locations=dst_locations,
+            read_only=not writable,
+        )
     elif isinstance(dst_connector, LocalConnector):
         await src_connector.copy_remote_to_local(
             src=src,


### PR DESCRIPTION
Before this commit, the `DataManager` class treated local-to-local transfers as a special case. However, the same behaviour can be obtained by simply delegating a local-to-remote transfer to a `LocalConnector` instance. This commit implements this easier path.