### PR TITLE
Simplify data movement logic

### DIFF
--- a/streamflow/deployment/connector/base.py
+++ b/streamflow/deployment/connector/base.py
@@ -63,6 +63,90 @@ async def extract_tar_stream(
             )
 
 
+async def copy_local_to_remote(
+    connector: Connector,
+    location: ExecutionLocation,
+    src: str,
+    dst: str,
+    writer_command: MutableSequence[str],
+) -> None:
+    async with await connector.get_stream_writer(
+        command=writer_command, location=location
+    ) as writer:
+        try:
+            async with aiotarstream.open(
+                stream=writer,
+                format=tarfile.GNU_FORMAT,
+                mode="w",
+                dereference=True,
+                copybufsize=connector.transferBufferSize,
+            ) as tar:
+                await tar.add(src, arcname=dst)
+        except tarfile.TarError as e:
+            raise WorkflowExecutionException(
+                f"Error copying {src} to {dst} on location {location}: {e}"
+            ) from e
+
+
+async def copy_remote_to_local(
+    connector: Connector,
+    location: ExecutionLocation,
+    src: str,
+    dst: str,
+    reader_command: MutableSequence[str],
+) -> None:
+    async with await connector.get_stream_reader(
+        command=reader_command, location=location
+    ) as reader:
+        try:
+            async with aiotarstream.open(
+                stream=reader,
+                mode="r",
+                copybufsize=connector.transferBufferSize,
+            ) as tar:
+                await extract_tar_stream(tar, src, dst, connector.transferBufferSize)
+        except tarfile.TarError as e:
+            raise WorkflowExecutionException(
+                f"Error copying {src} from location {location} to {dst}: {e}"
+            ) from e
+
+
+async def copy_remote_to_remote(
+    connector: Connector,
+    locations: MutableSequence[ExecutionLocation],
+    source_connector: Connector,
+    source_location: ExecutionLocation,
+    reader_command: MutableSequence[str],
+    writer_command: MutableSequence[str],
+) -> None:
+    # Open source StreamReader
+    async with await source_connector.get_stream_reader(
+        command=reader_command,
+        location=source_location,
+    ) as reader:
+        # Open a target StreamWriter for each location
+        write_contexts = await asyncio.gather(
+            *(
+                asyncio.create_task(
+                    connector.get_stream_writer(writer_command, location)
+                )
+                for location in locations
+            )
+        )
+        async with contextlib.AsyncExitStack() as exit_stack:
+            writers = await asyncio.gather(
+                *(
+                    asyncio.create_task(exit_stack.enter_async_context(context))
+                    for context in write_contexts
+                )
+            )
+            # Multiplex the reader output to all the writers
+            while content := await reader.read(source_connector.transferBufferSize):
+                await asyncio.gather(
+                    *(asyncio.create_task(writer.write(content)) for writer in writers)
+                )
+
+
 class BaseConnector(Connector, FutureAware, ABC):
     def __init__(self, deployment_name: str, config_dir: str, transferBufferSize: int):
         super().__init__(
@@ -93,40 +177,24 @@ class BaseConnector(Connector, FutureAware, ABC):
     async def _copy_local_to_remote_single(
         self, src: str, dst: str, location: ExecutionLocation, read_only: bool = False
     ) -> None:
-        async with await self.get_stream_writer(
-            command=["tar", "xf", "-", "-C", "/"], location=location
-        ) as writer:
-            try:
-                async with aiotarstream.open(
-                    stream=writer,
-                    format=tarfile.GNU_FORMAT,
-                    mode="w",
-                    dereference=True,
-                    copybufsize=self.transferBufferSize,
-                ) as tar:
-                    await tar.add(src, arcname=dst)
-            except tarfile.TarError as e:
-                raise WorkflowExecutionException(
-                    f"Error copying {src} to {dst} on location {location}: {e}"
-                ) from e
+        await copy_local_to_remote(
+            connector=self,
+            location=location,
+            src=src,
+            dst=dst,
+            writer_command=["tar", "xf", "-", "-C", "/"],
+        )
 
     async def _copy_remote_to_local(
         self, src: str, dst: str, location: ExecutionLocation, read_only: bool = False
     ) -> None:
-        async with await self.get_stream_reader(
-            command=["tar", "chf", "-", "-C", *posixpath.split(src)], location=location
-        ) as reader:
-            try:
-                async with aiotarstream.open(
-                    stream=reader,
-                    mode="r",
-                    copybufsize=self.transferBufferSize,
-                ) as tar:
-                    await extract_tar_stream(tar, src, dst, self.transferBufferSize)
-            except tarfile.TarError as e:
-                raise WorkflowExecutionException(
-                    f"Error copying {src} from location {location} to {dst}: {e}"
-                ) from e
+        await copy_remote_to_local(
+            connector=self,
+            location=location,
+            src=src,
+            dst=dst,
+            reader_command=["tar", "chf", "-", "-C", *posixpath.split(src)],
+        )
 
     async def _copy_remote_to_remote(
         self,
@@ -134,7 +202,7 @@ class BaseConnector(Connector, FutureAware, ABC):
         dst: str,
         locations: MutableSequence[ExecutionLocation],
         source_location: ExecutionLocation,
-        source_connector: str | None = None,
+        source_connector: Connector | None = None,
         read_only: bool = False,
     ) -> None:
         source_connector = source_connector or self
@@ -146,46 +214,22 @@ class BaseConnector(Connector, FutureAware, ABC):
                 await self.run(source_location, command)
                 locations.remove(source_location)
         if locations:
-            # Get write command
-            write_command = await utils.get_remote_to_remote_write_command(
-                src_connector=source_connector,
-                src_location=source_location,
-                src=src,
-                dst_connector=self,
-                dst_locations=locations,
-                dst=dst,
+            # Perform remote to remote copy
+            await copy_remote_to_remote(
+                connector=self,
+                locations=locations,
+                source_connector=source_connector,
+                source_location=source_location,
+                reader_command=["tar", "chf", "-", "-C", *posixpath.split(src)],
+                writer_command=await utils.get_remote_to_remote_write_command(
+                    src_connector=source_connector,
+                    src_location=source_location,
+                    src=src,
+                    dst_connector=self,
+                    dst_locations=locations,
+                    dst=dst,
+                ),
             )
-            # Open source StreamReader
-            async with await source_connector.get_stream_reader(
-                command=["tar", "chf", "-", "-C", *posixpath.split(src)],
-                location=source_location,
-            ) as reader:
-                # Open a target StreamWriter for each location
-                write_contexts = await asyncio.gather(
-                    *(
-                        asyncio.create_task(
-                            self.get_stream_writer(write_command, location)
-                        )
-                        for location in locations
-                    )
-                )
-                async with contextlib.AsyncExitStack() as exit_stack:
-                    writers = await asyncio.gather(
-                        *(
-                            asyncio.create_task(exit_stack.enter_async_context(context))
-                            for context in write_contexts
-                        )
-                    )
-                    # Multiplex the reader output to all the writers
-                    while content := await reader.read(
-                        source_connector.transferBufferSize
-                    ):
-                        await asyncio.gather(
-                            *(
-                                asyncio.create_task(writer.write(content))
-                                for writer in writers
-                            )
-                        )
 
     async def copy_local_to_remote(
         self,


### PR DESCRIPTION
This commit simplifies the `ConnectorWrapper` hierarchy by removing `BaseConnector` from its inheritance set. Indeed, the aim of basic `ConnectorWrapper` implementations is simply to delegate almost everything to the internal `Connector` class.

In addition, this commit moves the data movement logic outside the `BaseConnector` internal methods, improving portability and making it possible for `ConnectorWrapper` instance to directly call the data movement code, without having to extend `BaseConnector`. As a side effect, the data movement code of `SSHConnector` and `KubernetesConnector` have been refactored to be much less redundant.