### PR TITLE
Fix concurrency in `DefaultScheduler`

### DIFF
--- a/streamflow/deployment/wrapper.py
+++ b/streamflow/deployment/wrapper.py
@@ -8,6 +8,7 @@ from streamflow.core.data import StreamWrapperContextManager
 from streamflow.core.deployment import Connector, ExecutionLocation
 from streamflow.core.exception import WorkflowExecutionException
 from streamflow.core.scheduling import AvailableLocation
+from streamflow.deployment.future import FutureAware
 
 
 def get_inner_location(location: ExecutionLocation) -> ExecutionLocation:
@@ -24,7 +25,7 @@ def get_inner_locations(
     return list({get_inner_location(loc) for loc in locations})
 
 
-class ConnectorWrapper(Connector, ABC):
+class ConnectorWrapper(Connector, FutureAware, ABC):
     def __init__(
         self,
         deployment_name: str,


### PR DESCRIPTION
Now that hardware resources are checked for thw whole stack of `Connector` objects, just locking on a single `Condition` related to the outermost `Connector` is not enough to prevent race conditions. This commit ensures that a `Lock` object for each `Connector` in the stack is acquired prior to reserve or release resources during scheduling. Locks are always acquired and released in order, preventing deadlocks.

In addition, this commit makes the `ConnectorWrapper` compatible with the `FutureConnector` feature by extending the `FutureAware` class.