### PR TITLE
Refactor `DataManager` class and fix local copy

### DIFF
--- a/streamflow/data/remotepath.py
+++ b/streamflow/data/remotepath.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import base64
-import errno
 import glob
 import hashlib
 import os
 import posixpath
 import shutil
-from collections.abc import MutableSequence, MutableMapping
+from collections.abc import MutableMapping, MutableSequence
 from email.message import Message
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -530,24 +529,6 @@ async def size(
         _check_status(command, location, result, status)
         result = result.strip().strip("'\"")
         return int(result) if result.isdigit() else 0
-
-
-async def symlink(
-    connector: Connector, location: ExecutionLocation | None, src: str, path: str
-) -> None:
-    if isinstance(connector, LocalConnector):
-        src = os.path.abspath(src)
-        if os.path.isdir(path):
-            path = os.path.join(path, os.path.basename(src))
-        try:
-            os.symlink(
-                os.path.abspath(src), path, target_is_directory=os.path.isdir(src)
-            )
-        except OSError as e:
-            if not e.errno == errno.EEXIST:
-                raise
-    else:
-        await connector.run(location=location, command=["ln", "-snf", src, path])
 
 
 async def write(

--- a/streamflow/deployment/connector/local.py
+++ b/streamflow/deployment/connector/local.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import logging
 import os
 import shutil
@@ -27,7 +28,11 @@ def _local_copy(src: str, dst: str, read_only: bool):
     if read_only:
         if os.path.isdir(dst):
             dst = os.path.join(dst, os.path.basename(src))
-        os.symlink(src, dst, target_is_directory=os.path.isdir(src))
+        try:
+            os.symlink(src, dst, target_is_directory=os.path.isdir(src))
+        except OSError as e:
+            if not e.errno == errno.EEXIST:
+                raise
     else:
         if os.path.isdir(src):
             os.makedirs(dst, exist_ok=True)


### PR DESCRIPTION
This commit refactors the `DataManager` to simplify the logic. In detail, it propagates the symbolic link logic directly to the `Connector` hierarchy instead of handling it explicitly in the `DataManager` level. In addition, it fixes same connector data movements to apply symbolic links when the file is read only.