### PR TITLE
Add `local` field to `ExecutionLocation`

### DIFF
--- a/streamflow/core/scheduling.py
+++ b/streamflow/core/scheduling.py
@@ -274,6 +274,7 @@ class AvailableLocation:
         name: str,
         deployment: str,
         hostname: str,
+        local: bool | None = False,
         service: str | None = None,
         slots: int | None = None,
         stacked: bool = False,
@@ -284,6 +285,7 @@ class AvailableLocation:
         self.location: ExecutionLocation = ExecutionLocation(
             deployment=deployment,
             hostname=hostname,
+            local=local,
             name=name,
             service=service,
             stacked=stacked,
@@ -300,6 +302,10 @@ class AvailableLocation:
     @property
     def hostname(self) -> str:
         return self.location.hostname
+
+    @property
+    def local(self) -> bool:
+        return self.location.local
 
     @property
     def name(self) -> str:

--- a/streamflow/cwl/processor.py
+++ b/streamflow/cwl/processor.py
@@ -12,7 +12,7 @@ from streamflow.core.command import CommandOutput, CommandOutputProcessor
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.deployment import (
     Connector,
-    LOCAL_LOCATION,
+    LocalTarget,
     Target,
 )
 from streamflow.core.exception import (
@@ -210,7 +210,7 @@ class CWLTokenProcessor(TokenProcessor):
             except StopIteration:
                 # If such location does not exist, apply the standard heuristic to select the best one
                 data_location = self.workflow.context.data_manager.get_source_location(
-                    path=filepath, dst_deployment=LOCAL_LOCATION
+                    path=filepath, dst_deployment=LocalTarget.deployment_name
                 )
             if data_location:
                 connector = self.workflow.context.deployment_manager.get_connector(

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -29,7 +29,6 @@ from streamflow.core.context import StreamFlowContext
 from streamflow.core.deployment import (
     DeploymentConfig,
     ExecutionLocation,
-    LOCAL_LOCATION,
     LocalTarget,
     Target,
 )
@@ -1135,9 +1134,7 @@ def _process_docker_requirement(
         CWLDockerTranslator,
         translator_type(
             config_dir=config_dir,
-            wrapper=(
-                config.wrapper if target.deployment.name != LOCAL_LOCATION else None
-            ),
+            wrapper=(config.wrapper if target.deployment.type != "local" else None),
             **config.config,
         ),
     )
@@ -2671,9 +2668,12 @@ class CWLTranslator:
             else posixpath.sep
         )
         # Register data locations for config files
+        deployment_name = LocalTarget.deployment_name
         path = _get_path(self.cwl_definition.tool["id"])
         self.context.data_manager.register_path(
-            location=ExecutionLocation(deployment=LOCAL_LOCATION, name=LOCAL_LOCATION),
+            location=ExecutionLocation(
+                deployment=deployment_name, local=True, name="__LOCAL__"
+            ),
             path=path,
             relpath=os.path.basename(path),
         )
@@ -2681,7 +2681,7 @@ class CWLTranslator:
             path = _get_path(self.cwl_inputs["id"])
             self.context.data_manager.register_path(
                 location=ExecutionLocation(
-                    deployment=LOCAL_LOCATION, name=LOCAL_LOCATION
+                    deployment=deployment_name, local=True, name="__LOCAL__"
                 ),
                 path=path,
                 relpath=os.path.basename(path),

--- a/streamflow/cwl/utils.py
+++ b/streamflow/cwl/utils.py
@@ -5,7 +5,7 @@ import asyncio
 import logging
 import posixpath
 import urllib.parse
-from collections.abc import MutableSequence, MutableMapping
+from collections.abc import MutableMapping, MutableSequence
 from enum import Enum
 from pathlib import PurePath
 from types import ModuleType
@@ -32,7 +32,6 @@ from streamflow.core.utils import random_name
 from streamflow.core.workflow import Job, Token, Workflow
 from streamflow.cwl.expression import DependencyResolver
 from streamflow.data import remotepath
-from streamflow.deployment.connector import LocalConnector
 from streamflow.deployment.utils import get_path_processor
 from streamflow.log_handler import logger
 from streamflow.workflow.utils import get_token_value
@@ -1080,7 +1079,7 @@ async def write_remote_file(
                         path=path,
                         location=(
                             "on local file-system"
-                            if isinstance(connector, LocalConnector)
+                            if location.local
                             else f"on location {location}"
                         ),
                     )

--- a/streamflow/data/remotepath.py
+++ b/streamflow/data/remotepath.py
@@ -75,7 +75,7 @@ async def checksum(
     location: ExecutionLocation | None,
     path: str,
 ) -> str | None:
-    if isinstance(connector, LocalConnector):
+    if location.local:
         if os.path.isfile(path):
             loop = asyncio.get_running_loop()
             return await loop.run_in_executor(
@@ -148,7 +148,7 @@ async def download(
 async def exists(
     connector: Connector, location: ExecutionLocation | None, path: str
 ) -> bool:
-    if isinstance(connector, LocalConnector):
+    if location.local:
         return os.path.exists(path)
     else:
         command = [f'test -e "{path}"']
@@ -180,7 +180,7 @@ async def follow_symlink(
     :param path: the path to be resolved in the case of symbolic link
     :return: the path of the resolved symlink or `None` if the link points to a location that does not exist
     """
-    if isinstance(connector, LocalConnector):
+    if location.local:
         return os.path.realpath(path) if os.path.exists(path) else None
     else:
         # If at least one primary location is present on the site
@@ -287,7 +287,7 @@ async def get_storage_usages(
 async def head(
     connector: Connector, location: ExecutionLocation | None, path: str, num_bytes: int
 ) -> str:
-    if isinstance(connector, LocalConnector):
+    if location.local:
         with open(path, "rb") as f:
             return f.read(num_bytes).decode("utf-8")
     else:
@@ -302,7 +302,7 @@ async def head(
 async def isdir(
     connector: Connector, location: ExecutionLocation | None, path: str
 ) -> bool:
-    if isinstance(connector, LocalConnector):
+    if location.local:
         return os.path.isdir(path)
     else:
         command = [f'test -d "{path}"']
@@ -322,7 +322,7 @@ async def isdir(
 async def isfile(
     connector: Connector, location: ExecutionLocation | None, path: str
 ) -> bool:
-    if isinstance(connector, LocalConnector):
+    if location.local:
         return os.path.isfile(path)
     else:
         command = [f'test -f "{path}"']
@@ -342,7 +342,7 @@ async def isfile(
 async def islink(
     connector: Connector, location: ExecutionLocation | None, path: str
 ) -> bool:
-    if isinstance(connector, LocalConnector):
+    if location.local:
         return os.path.islink(path)
     else:
         command = [f'test -L "{path}"']
@@ -365,7 +365,7 @@ async def listdir(
     path: str,
     file_type: FileType | None = None,
 ) -> MutableSequence[str]:
-    if isinstance(connector, LocalConnector):
+    if location.local:
         return _listdir_local(path, file_type)
     else:
         command = 'find -L "{path}" -mindepth 1 -maxdepth 1 {type}'.format(
@@ -422,7 +422,7 @@ async def mkdirs(
 async def read(
     connector: Connector, location: ExecutionLocation | None, path: str
 ) -> str:
-    if isinstance(connector, LocalConnector):
+    if location.local:
         with open(path, "rb") as f:
             return f.read().decode("utf-8")
     else:
@@ -437,7 +437,7 @@ async def read(
 async def resolve(
     connector: Connector, location: ExecutionLocation | None, pattern: str
 ) -> MutableSequence[str] | None:
-    if isinstance(connector, LocalConnector):
+    if location.local:
         return sorted(glob.glob(pattern))
     else:
         command = [
@@ -466,7 +466,7 @@ async def rm(
     location: ExecutionLocation | None,
     path: str | MutableSequence[str],
 ) -> None:
-    if isinstance(connector, LocalConnector):
+    if location.local:
         if isinstance(path, MutableSequence):
             for p in path:
                 if os.path.exists(p):
@@ -511,7 +511,7 @@ async def size(
     """
     if not path:
         return 0
-    elif isinstance(connector, LocalConnector):
+    elif location.local:
         if not isinstance(path, MutableSequence):
             path = [path]
         return sum(utils.get_size(p) for p in path)
@@ -541,7 +541,7 @@ async def size(
 async def write(
     connector: Connector, location: ExecutionLocation | None, path: str, content: str
 ) -> None:
-    if isinstance(connector, LocalConnector):
+    if location.local:
         with open(path, "w") as f:
             f.write(content)
     else:

--- a/streamflow/deployment/connector/container.py
+++ b/streamflow/deployment/connector/container.py
@@ -16,7 +16,7 @@ import psutil
 
 from streamflow.core import utils
 from streamflow.core.data import StreamWrapperContextManager
-from streamflow.core.deployment import Connector, ExecutionLocation, LOCAL_LOCATION
+from streamflow.core.deployment import Connector, ExecutionLocation
 from streamflow.core.exception import (
     WorkflowDefinitionException,
     WorkflowExecutionException,
@@ -555,7 +555,7 @@ class ContainerConnector(ConnectorWrapper, ABC):
             )
 
     def _wraps_local(self) -> bool:
-        return self._inner_location.name == LOCAL_LOCATION
+        return self._inner_location.local
 
     async def deploy(self, external: bool) -> None:
         # Retrieve the underlying location

--- a/streamflow/deployment/connector/local.py
+++ b/streamflow/deployment/connector/local.py
@@ -17,7 +17,6 @@ from streamflow.core import utils
 from streamflow.core.deployment import (
     Connector,
     ExecutionLocation,
-    LOCAL_LOCATION,
 )
 from streamflow.core.scheduling import AvailableLocation, Hardware, Storage
 from streamflow.deployment.connector.base import (
@@ -110,7 +109,7 @@ class LocalConnector(BaseConnector):
         read_only: bool = False,
     ) -> None:
         source_connector = source_connector or self
-        if isinstance(source_connector, LocalConnector):
+        if source_location.local:
             if logger.isEnabledFor(logging.INFO):
                 logger.info(f"COPYING from {src} to {dst} on local file-system")
             _local_copy(src, dst, read_only)
@@ -134,11 +133,12 @@ class LocalConnector(BaseConnector):
         self, service: str | None = None
     ) -> MutableMapping[str, AvailableLocation]:
         return {
-            LOCAL_LOCATION: AvailableLocation(
-                name=LOCAL_LOCATION,
+            "__LOCAL__": AvailableLocation(
+                name="__LOCAL__",
                 deployment=self.deployment_name,
                 service=service,
                 hostname="localhost",
+                local=True,
                 slots=1,
                 hardware=self._hardware,
             )

--- a/streamflow/deployment/manager.py
+++ b/streamflow/deployment/manager.py
@@ -11,7 +11,6 @@ from streamflow.core.deployment import (
     Connector,
     DeploymentConfig,
     DeploymentManager,
-    LOCAL_LOCATION,
     LocalTarget,
 )
 from streamflow.core.exception import (
@@ -101,7 +100,7 @@ class DefaultDeploymentManager(DeploymentManager):
         if issubclass(connector_type, ConnectorWrapper):
             # Retrieve the inner connector's config
             if deployment_config.wraps is None:
-                deployment_name = LOCAL_LOCATION
+                deployment_name = LocalTarget.deployment_name
                 service = None
                 if deployment_name not in self.config_map:
                     local_target = LocalTarget()

--- a/streamflow/recovery/checkpoint_manager.py
+++ b/streamflow/recovery/checkpoint_manager.py
@@ -10,7 +10,7 @@ from importlib.resources import files
 
 from streamflow.core import utils
 from streamflow.core.data import DataLocation
-from streamflow.core.deployment import ExecutionLocation, LOCAL_LOCATION
+from streamflow.core.deployment import ExecutionLocation, LocalTarget
 from streamflow.core.recovery import CheckpointManager
 from streamflow.core.utils import random_name
 
@@ -36,7 +36,11 @@ class DefaultCheckpointManager(CheckpointManager):
             src_location=data_location.location,
             src_path=data_location.path,
             dst_locations=[
-                ExecutionLocation(deployment=LOCAL_LOCATION, name=LOCAL_LOCATION)
+                ExecutionLocation(
+                    deployment=LocalTarget.deployment_name,
+                    local=True,
+                    name="__LOCAL__",
+                )
             ],
             dst_path=local_path,
         )

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -10,7 +10,6 @@ from streamflow.core import utils
 from streamflow.core.data import DataType
 from streamflow.core.deployment import Connector, ExecutionLocation
 from streamflow.data import remotepath
-from streamflow.deployment.connector import LocalConnector
 from tests.utils.deployment import get_location
 
 
@@ -39,16 +38,16 @@ async def test_data_locations(
     context, src_connector, src_location, dst_connector, dst_location
 ):
     """Test the existence of data locations after the transfer data"""
-    if isinstance(src_connector, LocalConnector):
-        src_path = os.path.join(
-            tempfile.gettempdir(), utils.random_name(), utils.random_name()
-        )
-    else:
-        src_path = posixpath.join("/tmp", utils.random_name(), utils.random_name())
-    if isinstance(dst_connector, LocalConnector):
-        dst_path = os.path.join(tempfile.gettempdir(), utils.random_name())
-    else:
-        dst_path = posixpath.join("/tmp", utils.random_name())
+    src_path = (
+        os.path.join(tempfile.gettempdir(), utils.random_name(), utils.random_name())
+        if src_location.local
+        else posixpath.join("/tmp", utils.random_name(), utils.random_name())
+    )
+    dst_path = (
+        os.path.join(tempfile.gettempdir(), utils.random_name())
+        if dst_location.local
+        else posixpath.join("/tmp", utils.random_name())
+    )
 
     # Create working directories in src and dst locations
     await remotepath.mkdir(src_connector, [src_location], str(Path(src_path).parent))

--- a/tests/test_remotepath.py
+++ b/tests/test_remotepath.py
@@ -13,7 +13,6 @@ from streamflow.core.data import FileType
 from streamflow.core.deployment import Connector, ExecutionLocation
 from streamflow.core.exception import WorkflowExecutionException
 from streamflow.data import remotepath
-from streamflow.deployment.connector import LocalConnector
 from streamflow.deployment.utils import get_path_processor
 from tests.utils.deployment import get_location, get_docker_deployment_config
 
@@ -21,7 +20,7 @@ from tests.utils.deployment import get_location, get_docker_deployment_config
 async def _symlink(
     connector: Connector, location: ExecutionLocation | None, src: str, path: str
 ) -> None:
-    if isinstance(connector, LocalConnector):
+    if location.local:
         src = os.path.abspath(src)
         if os.path.isdir(path):
             path = os.path.join(path, os.path.basename(src))
@@ -92,9 +91,7 @@ async def test_download(context, connector, location):
         "https://raw.githubusercontent.com/alpha-unito/streamflow/master/LICENSE",
         "https://github.com/alpha-unito/streamflow/archive/refs/tags/0.1.6.zip",
     ]
-    parent_dir = (
-        tempfile.gettempdir() if isinstance(connector, LocalConnector) else "/tmp"
-    )
+    parent_dir = tempfile.gettempdir() if location.local else "/tmp"
     path_processor = get_path_processor(connector)
     paths = [
         path_processor.join(parent_dir, "LICENSE"),

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -1,5 +1,6 @@
 import json
 import os
+import posixpath
 import tempfile
 from collections.abc import MutableMapping
 from pathlib import PurePosixPath
@@ -10,7 +11,6 @@ import pytest
 
 from streamflow.config.config import WorkflowConfig
 from streamflow.config.validator import SfValidator
-from streamflow.core.deployment import _init_workdir
 from streamflow.cwl.token import CWLFileToken
 from streamflow.cwl.workflow import CWLWorkflow
 
@@ -210,8 +210,10 @@ def test_workdir_inheritance() -> None:
     # Get default `workdir` because `handsome` deployment does NOT has a `workdir` either
     assert binding_config.targets[3].deployment.name == "wrapper_4"
     assert binding_config.targets[3].deployment.workdir is None
-    assert binding_config.targets[3].workdir == _init_workdir(
-        binding_config.targets[3].deployment.name
+    assert binding_config.targets[3].workdir == (
+        os.path.join(os.path.realpath(tempfile.gettempdir()), "streamflow")
+        if binding_config.targets[3].deployment == "local"
+        else posixpath.join("/tmp", "streamflow")
     )
 
 

--- a/tests/utils/deployment.py
+++ b/tests/utils/deployment.py
@@ -16,7 +16,6 @@ from streamflow.core.context import StreamFlowContext
 from streamflow.core.deployment import (
     DeploymentConfig,
     ExecutionLocation,
-    LOCAL_LOCATION,
     WrapsConfig,
     BindingFilter,
     Target,
@@ -29,7 +28,7 @@ from tests.utils.data import get_data_path
 
 def get_deployment(_context: StreamFlowContext, deployment_t: str) -> str:
     if deployment_t == "local":
-        return LOCAL_LOCATION
+        return "__LOCAL__"
     elif deployment_t == "docker":
         return "alpine-docker"
     elif deployment_t == "docker-wrapper":
@@ -148,7 +147,7 @@ def get_local_deployment_config():
     )
     os.makedirs(workdir, exist_ok=True)
     return DeploymentConfig(
-        name=LOCAL_LOCATION,
+        name="__LOCAL__",
         type="local",
         config={},
         external=True,


### PR DESCRIPTION
Before this commit, the way to distinguish between local and remote `ExecutionLocation` objects was depending on the location's `name`, which was forced to be `__LOCAL__` for all local `ExecutionLocation` objects. This method was fragile and not portable to custom `Connector` plugins.

This commit introduces a new `local` field to the `ExecutionLocation` object, which defaults to `False` and is set to `True` in the `LocalConnector` logic. Plus, this field is now used across the StreamFlow codebase to identify local locations.