### PR TITLE
Stop loading contents on `Directory` objects

### DIFF
--- a/streamflow/cwl/utils.py
+++ b/streamflow/cwl/utils.py
@@ -1023,7 +1023,8 @@ async def update_file_token(
     load_listing: LoadListing | None = None,
 ):
     filepath = get_path_from_token(token_value)
-    if load_contents is not None:
+    # Process contents
+    if get_token_class(token_value) == "File" and load_contents is not None:
         if load_contents and "contents" not in token_value:
             token_value |= {
                 "contents": await _get_contents(


### PR DESCRIPTION
The `loadContents` CWL option only applies to `File` objects. This commit fixes a wrong behaviour in the `update_file_token` function, which was trying to load contents also for `Directory` objects.