### PR TITLE
Improve logging of copy methods

### DIFF
--- a/examples/flux/README.md
+++ b/examples/flux/README.md
@@ -34,7 +34,7 @@ uses `mpirun`, but since Flux has MPI bindings, we replace this with flux run.
 You'll see the streamflow result printed to the screen:
 
 ```console
-2023-04-02 19:35:18.426 INFO     COMPLETED Workflow execution
+2023-04-02 19:35:18.426 INFO     COMPLETED workflow execution
 {
     "result": {
         "basename": "mpi_output.log",
@@ -49,7 +49,7 @@ You'll see the streamflow result printed to the screen:
     }
 }
 2023-04-02 19:35:18.428 INFO     UNDEPLOYING dc-mpi
-2023-04-02 19:35:18.443 INFO     COMPLETED Undeployment of dc-mpi
+2023-04-02 19:35:18.443 INFO     COMPLETED undeployment of dc-mpi
 ```
 
 And the output directory will be in your working directory:

--- a/streamflow/cwl/main.py
+++ b/streamflow/cwl/main.py
@@ -89,11 +89,11 @@ async def main(
         return
     await workflow.save(context)
     if logger.isEnabledFor(logging.INFO):
-        logger.info("COMPLETED Building of workflow execution plan")
+        logger.info("COMPLETED building of workflow execution plan")
     executor = StreamFlowExecutor(workflow)
     if logger.isEnabledFor(logging.INFO):
-        logger.info(f"Running workflow {args.name}")
+        logger.info(f"EXECUTING workflow {args.name}")
     output_tokens = await executor.run()
     if logger.isEnabledFor(logging.INFO):
-        logger.info("COMPLETED Workflow execution")
+        logger.info("COMPLETED workflow execution")
     print(json.dumps(output_tokens, sort_keys=True, indent=4))

--- a/streamflow/deployment/connector/local.py
+++ b/streamflow/deployment/connector/local.py
@@ -7,11 +7,11 @@ import os
 import shutil
 import sys
 import tempfile
-from collections.abc import MutableSequence, MutableMapping
+from collections.abc import MutableMapping, MutableSequence
+from importlib.resources import files
 from typing import Any
 
 import psutil
-from importlib.resources import files
 
 from streamflow.core import utils
 from streamflow.core.deployment import (
@@ -20,7 +20,9 @@ from streamflow.core.deployment import (
     LOCAL_LOCATION,
 )
 from streamflow.core.scheduling import AvailableLocation, Hardware, Storage
-from streamflow.deployment.connector.base import BaseConnector
+from streamflow.deployment.connector.base import (
+    BaseConnector,
+)
 from streamflow.log_handler import logger
 
 
@@ -66,21 +68,29 @@ class LocalConnector(BaseConnector):
         else:
             return "sh"
 
-    async def _copy_local_to_remote(
+    async def copy_local_to_remote(
         self,
         src: str,
         dst: str,
         locations: MutableSequence[ExecutionLocation],
         read_only: bool = False,
     ) -> None:
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(f"COPYING from {src} to {dst} on local file-system")
         _local_copy(src, dst, read_only)
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(f"COMPLETED copy from {src} to {dst} on local file-system")
 
-    async def _copy_remote_to_local(
+    async def copy_remote_to_local(
         self, src: str, dst: str, location: ExecutionLocation, read_only: bool = False
     ) -> None:
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(f"COPYING from {src} to {dst} on local file-system")
         _local_copy(src, dst, read_only)
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(f"COMPLETED copy from {src} to {dst} on local file-system")
 
-    async def _copy_remote_to_remote(
+    async def copy_remote_to_remote(
         self,
         src: str,
         dst: str,
@@ -91,7 +101,11 @@ class LocalConnector(BaseConnector):
     ) -> None:
         source_connector = source_connector or self
         if isinstance(source_connector, LocalConnector):
+            if logger.isEnabledFor(logging.INFO):
+                logger.info(f"COPYING from {src} to {dst} on local file-system")
             _local_copy(src, dst, read_only)
+            if logger.isEnabledFor(logging.INFO):
+                logger.info(f"COMPLETED copy from {src} to {dst} on local file-system")
         else:
             await source_connector.copy_remote_to_local(
                 src=src,

--- a/streamflow/deployment/connector/queue_manager.py
+++ b/streamflow/deployment/connector/queue_manager.py
@@ -659,7 +659,7 @@ class QueueManagerConnector(BatchConnector, ConnectorWrapper, ABC):
             await self.connector.undeploy(external)
             if logger.isEnabledFor(logging.INFO):
                 logger.warning(
-                    f"COMPLETED Undeployment of inner SSH connector for {self.deployment_name} deployment."
+                    f"COMPLETED undeployment of inner SSH connector for {self.deployment_name} deployment."
                 )
 
 

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import posixpath
 from abc import ABC
-from collections.abc import MutableSequence, MutableMapping
+from collections.abc import MutableMapping, MutableSequence
+from importlib.resources import files
 from typing import Any
 
 import asyncssh
 from asyncssh import ChannelOpenError, ConnectionLost
-from importlib.resources import files
 
 from streamflow.core import utils
 from streamflow.core.data import StreamWrapper, StreamWrapperContextManager
@@ -387,7 +386,7 @@ class SSHConnector(BaseConnector):
         }
         self.hardware: MutableMapping[str, Hardware] = {}
 
-    async def _copy_remote_to_remote(
+    async def copy_remote_to_remote(
         self,
         src: str,
         dst: str,
@@ -417,17 +416,10 @@ class SSHConnector(BaseConnector):
                 await copy_remote_to_remote(
                     connector=self,
                     locations=location_group,
+                    src=src,
+                    dst=dst,
                     source_connector=source_connector,
                     source_location=source_location,
-                    reader_command=["tar", "chf", "-", "-C", *posixpath.split(src)],
-                    writer_command=await utils.get_remote_to_remote_write_command(
-                        src_connector=source_connector,
-                        src_location=source_location,
-                        src=src,
-                        dst_connector=self,
-                        dst_locations=location_group,
-                        dst=dst,
-                    ),
                 )
 
     async def _get_available_location(self, location: str) -> Hardware:

--- a/streamflow/deployment/future.py
+++ b/streamflow/deployment/future.py
@@ -39,9 +39,9 @@ class FutureConnector(Connector):
     async def _safe_deploy_event_wait(self):
         await self.deploy_event.wait()
         if self._connector is None:
-            logger.error(f"Deploying of {self.deployment_name} failed")
+            logger.error(f"FAILED deployment of {self.deployment_name}")
             raise WorkflowExecutionException(
-                f"Deploying of {self.deployment_name} failed"
+                f"FAILED deployment of {self.deployment_name}"
             )
 
     @property
@@ -134,7 +134,7 @@ class FutureConnector(Connector):
             raise
         if logger.isEnabledFor(logging.INFO):
             if not external:
-                logger.info(f"COMPLETED Deployment of {self.deployment_name}")
+                logger.info(f"COMPLETED deployment of {self.deployment_name}")
         self._connector = connector
         self.deploy_event.set()
 

--- a/streamflow/deployment/manager.py
+++ b/streamflow/deployment/manager.py
@@ -79,14 +79,14 @@ class DefaultDeploymentManager(DeploymentManager):
                         raise
                     if logger.isEnabledFor(logging.INFO):
                         if not deployment_config.external:
-                            logger.info(f"COMPLETED Deployment of {deployment_name}")
+                            logger.info(f"COMPLETED deployment of {deployment_name}")
                     self.events_map[deployment_name].set()
                     break
             else:
                 await self.events_map[deployment_name].wait()
                 if deployment_name not in self.deployments_map:
                     raise WorkflowExecutionException(
-                        f"Deploying of {deployment_name} failed"
+                        f"FAILED deployment of {deployment_name}"
                     )
                 if deployment_name in self.config_map:
                     break
@@ -212,7 +212,7 @@ class DefaultDeploymentManager(DeploymentManager):
                 await connector.undeploy(config.external)
                 if logger.isEnabledFor(logging.INFO):
                     if not config.external:
-                        logger.info(f"COMPLETED Undeployment of {deployment_name}")
+                        logger.info(f"COMPLETED undeployment of {deployment_name}")
                 self.events_map[deployment_name].set()
             # Remove the current environment from all the other dependency graphs
             for name, deps in list(

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -93,7 +93,7 @@ async def test_deployment_manager_deploy_fails(context: StreamFlowContext) -> No
     ):
         assert isinstance(result, FailureConnectorException) or (
             isinstance(result, WorkflowExecutionException)
-            and result.args[0] == "Deploying of failure-test failed"
+            and result.args[0] == f"FAILED deployment of {deployment_config.name}"
         )
 
 
@@ -106,10 +106,9 @@ async def test_future_connector_multiple_request_fail(
     context: StreamFlowContext, method: Callable
 ) -> None:
     """Test FutureConnector with multiple requests but the deployment fails"""
-    deployment_name = "failure-test"
     deployment_config = get_failure_deployment_config()
     connector = FutureConnector(
-        name=deployment_name,
+        name=deployment_config.name,
         config_dir=os.path.dirname(context.config["path"]),
         connector_type=FailureConnector,
         external=deployment_config.external,
@@ -127,7 +126,7 @@ async def test_future_connector_multiple_request_fail(
     ):
         assert isinstance(result, FailureConnectorException) or (
             isinstance(result, WorkflowExecutionException)
-            and result.args[0] == "Deploying of failure-test failed"
+            and result.args[0] == f"FAILED deployment of {deployment_config.name}"
         )
 
 


### PR DESCRIPTION
This commit extracts the log messages of the `BaseConnector` copy methods into separate functions, which can be easily invoked from other `Connector` classes. Tha aim is to uniform the logging messages for all the StreamFLow `Connector` classes.

In addition, this commit fixes an issue with remote-to-remote copy inside the `ContainerConnector` logic.