### PR TITLE
Modernize pytest suite

### DIFF
--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -48,7 +48,7 @@ def _get_connector_method_params(method_name: str) -> MutableSequence[Any]:
         raise pytest.fail(f"Unknown method_name: {method_name}")
 
 
-@pytest_asyncio.fixture(scope="module", loop_scope="module")
+@pytest_asyncio.fixture(scope="module")
 async def curr_location(context, deployment_src) -> ExecutionLocation:
     return await get_location(context, deployment_src)
 

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -14,7 +14,7 @@ from streamflow.deployment.connector import LocalConnector
 from tests.utils.deployment import get_location
 
 
-@pytest_asyncio.fixture(scope="module", loop_scope="module")
+@pytest_asyncio.fixture(scope="module")
 async def src_location(context, deployment_src) -> ExecutionLocation:
     return await get_location(context, deployment_src)
 
@@ -24,7 +24,7 @@ def src_connector(context, src_location) -> Connector:
     return context.deployment_manager.get_connector(src_location.deployment)
 
 
-@pytest_asyncio.fixture(scope="module", loop_scope="module")
+@pytest_asyncio.fixture(scope="module")
 async def dst_location(context, deployment_dst) -> ExecutionLocation:
     return await get_location(context, deployment_dst)
 

--- a/tests/test_remotepath.py
+++ b/tests/test_remotepath.py
@@ -36,7 +36,7 @@ async def _symlink(
         await connector.run(location=location, command=["ln", "-snf", src, path])
 
 
-@pytest_asyncio.fixture(scope="module", loop_scope="module")
+@pytest_asyncio.fixture(scope="module")
 async def location(context, deployment_src) -> ExecutionLocation:
     return await get_location(context, deployment_src)
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -12,7 +12,7 @@ from streamflow.report import create_report
 from tests.utils.data import get_data_path
 
 
-@pytest_asyncio.fixture(scope="module", loop_scope="module")
+@pytest_asyncio.fixture(scope="module")
 async def context() -> StreamFlowContext:
     _context = build_context(
         {

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -67,7 +67,7 @@ def _prepare_connector(context: StreamFlowContext, num_jobs: int = 1):
     )
 
 
-@pytest_asyncio.fixture(scope="module", loop_scope="module")
+@pytest_asyncio.fixture(scope="module")
 async def deployment_config(context, deployment) -> DeploymentConfig:
     return await get_deployment_config(context, deployment)
 

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -118,7 +118,7 @@ async def _create_tmp_dir(context, connector, location, root=None, lvl=None, n_f
     return dir_path
 
 
-@pytest_asyncio.fixture(scope="module", loop_scope="module")
+@pytest_asyncio.fixture(scope="module")
 async def src_location(context, deployment_src) -> ExecutionLocation:
     return await get_location(context, deployment_src)
 
@@ -128,7 +128,7 @@ def src_connector(context, src_location) -> Connector:
     return context.deployment_manager.get_connector(src_location.deployment)
 
 
-@pytest_asyncio.fixture(scope="module", loop_scope="module")
+@pytest_asyncio.fixture(scope="module")
 async def dst_location(context, deployment_dst) -> ExecutionLocation:
     return await get_location(context, deployment_dst)
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,8 @@ envlist =
 skip_missing_interpreters = True
 
 [pytest]
-asyncio_default_fixture_loop_scope = function
-asyncio_mode = auto
+asyncio_default_fixture_loop_scope = module
+asyncio_mode = strict
 testpaths = tests
 
 [testenv]


### PR DESCRIPTION
This commit modernizes the StreamFlow test suite, based on the `pytest-asyncio` library. In detail, this commit:
 - Moves the `asyncio_mode` from `auto` to `strict`
 - Moves the `asyncio_default_fixture_loop_scope` value from `function` to `module` and removes the explicit `loop_scope` definitions from async fixtures
 - Removes the deprecated `event_loop` fixture and replaces it with the recommended `pytest_collection_modifyitems` call to force all tests to declare `loop_scope="session"`