### PR TITLE
Improve mount handling on `SingularityConnector`

### DIFF
--- a/streamflow/deployment/connector/base.py
+++ b/streamflow/deployment/connector/base.py
@@ -28,6 +28,28 @@ from streamflow.deployment.stream import (
 from streamflow.log_handler import logger
 
 
+FS_TYPES_TO_SKIP = {
+    "-",
+    "bpf",
+    "cgroup",
+    "cgroup2",
+    "configfs",
+    "debugfs",
+    "devpts",
+    "devtmpfs",
+    "fusectl",
+    "hugetlbfs",
+    "mqueue",
+    "proc",
+    "pstore",
+    "securityfs",
+    "selinuxfs",
+    "sysfs",
+    "tmpfs",
+    "tracefs",
+}
+
+
 async def extract_tar_stream(
     tar: aiotarstream.AioTarStream,
     src: str,

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -18,6 +18,7 @@ from streamflow.core.exception import WorkflowExecutionException
 from streamflow.core.scheduling import AvailableLocation, Hardware, Storage
 from streamflow.deployment.connector.base import (
     BaseConnector,
+    FS_TYPES_TO_SKIP,
     copy_remote_to_remote,
     copy_same_connector,
 )
@@ -445,22 +446,7 @@ class SSHConnector(BaseConnector):
                         ) from None
                     for line in dir_info_list:
                         mount_point, fs_type, size = line.split(" ")
-                        if fs_type not in [
-                            "-",
-                            "cgroup",
-                            "cgroup2",
-                            "configfs",
-                            "debugfs",
-                            "devpts",
-                            "devtmpfs",
-                            "hugetlbfs",
-                            "mqueue",
-                            "proc",
-                            "securityfs",
-                            "selinuxfs",
-                            "sysfs",
-                            "tmpfs",
-                        ]:
+                        if fs_type not in FS_TYPES_TO_SKIP:
                             self.hardware[location].storage[mount_point] = Storage(
                                 mount_point=mount_point,
                                 size=float(size) / 2**10,


### PR DESCRIPTION
Since `singularity` and `apptainer` frameworks do not allow users to query instances to list actual mount points, the StreamFlow `SingularityConnector` class relies on the `/proc/1/mountinfo` interface. However, it is not trivial to reconstruct host/container binds through this mechanism.

This commit improves the logic to identify and map mounts between container and host, handling special cases like `nfs` filesystems or direct device mounts with specific logic.