### PR TITLE
Propagate `DataLocation` relations to stacked envs

### DIFF
--- a/.github/codeql/config.yml
+++ b/.github/codeql/config.yml
@@ -11,3 +11,6 @@ query-filters:
   # Reason: false positive on function body ellipsis (issue 11351)
   - exclude:
       id: py/ineffectual-statement
+  # Reason: no support for the TYPE_CHECKING directive (issue 4258)
+  - exclude:
+      id:  py/unsafe-cyclic-import

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -72,6 +72,8 @@ jobs:
           node-version: "20"
       - name: "Install Docker (MacOS X)"
         uses: douglascamata/setup-docker-macos-action@main
+        with:
+          colima-additional-options: '--mount /private/var/folders:w --mount-type virtiofs'
         if: ${{ startsWith(matrix.on, 'macos-') }}
       - uses: docker/setup-qemu-action@v3
         if: ${{ startsWith(matrix.on, 'ubuntu-') }}
@@ -241,6 +243,8 @@ jobs:
           node-version: "20"
       - name: "Install Docker (MacOs X)"
         uses: douglascamata/setup-docker-macos-action@main
+        with:
+          colima-additional-options: '--mount /private/var/folders:w --mount-type virtiofs'
         if: ${{ startsWith(matrix.on, 'macos-') }}
       - uses: docker/setup-qemu-action@v3
         if: ${{ startsWith(matrix.on, 'ubuntu-') }}

--- a/streamflow/core/deployment.py
+++ b/streamflow/core/deployment.py
@@ -28,6 +28,7 @@ class ExecutionLocation:
         "environment",
         "hostname",
         "local",
+        "mounts",
         "name",
         "service",
         "stacked",
@@ -41,6 +42,7 @@ class ExecutionLocation:
         environment: MutableMapping[str, str] | None = None,
         hostname: str | None = None,
         local: bool | None = False,
+        mounts: MutableMapping[str, str] | None = None,
         service: str | None = None,
         stacked: bool | None = False,
         wraps: ExecutionLocation | None = None,
@@ -49,6 +51,7 @@ class ExecutionLocation:
         self.environment: MutableMapping[str, str] = environment or {}
         self.hostname: str | None = hostname
         self.local: bool = local
+        self.mounts: MutableMapping[str, str] = mounts or {}
         self.name: str = name
         self.service: str | None = service
         self.stacked: bool = stacked

--- a/streamflow/core/scheduling.py
+++ b/streamflow/core/scheduling.py
@@ -15,11 +15,12 @@ from typing import TYPE_CHECKING, cast
 from streamflow.core import utils
 from streamflow.core.config import BindingConfig, Config
 from streamflow.core.context import SchemaEntity, StreamFlowContext
-from streamflow.core.deployment import Connector, ExecutionLocation, Target
+from streamflow.core.deployment import ExecutionLocation
 from streamflow.core.exception import WorkflowExecutionException
 from streamflow.core.persistence import DatabaseLoadingContext
 
 if TYPE_CHECKING:
+    from streamflow.core.deployment import Connector, Target
     from streamflow.core.workflow import Job, Status
     from typing import Any
 
@@ -96,29 +97,6 @@ class Hardware:
 
     def __repr__(self):
         return f"Hardware(cores={self.cores}, memory={self.memory}, storage={self.storage})"
-
-    def bind(self, path_processor) -> Hardware:
-        return Hardware(
-            cores=self.cores,
-            memory=self.memory,
-            storage={
-                key: Storage(
-                    mount_point=disk.bind,
-                    size=disk.size,
-                    paths={
-                        path_processor.normpath(
-                            path_processor.join(
-                                disk.bind,
-                                path_processor.relpath(p, disk.mount_point),
-                            )
-                        )
-                        for p in disk.paths
-                    },
-                )
-                for key, disk in self.storage.items()
-                if disk.bind is not None
-            },
-        )
 
     def __add__(self, other: Any) -> Hardware:
         if not isinstance(other, Hardware):

--- a/streamflow/core/scheduling.py
+++ b/streamflow/core/scheduling.py
@@ -300,6 +300,15 @@ class AvailableLocation:
             deployment=deployment,
             hostname=hostname,
             local=local,
+            mounts=(
+                {
+                    storage.mount_point: storage.bind
+                    for storage in self.hardware.storage.values()
+                    if storage.bind is not None
+                }
+                if hardware is not None
+                else {}
+            ),
             name=name,
             service=service,
             stacked=stacked,

--- a/streamflow/core/utils.py
+++ b/streamflow/core/utils.py
@@ -244,13 +244,14 @@ async def get_remote_to_remote_write_command(
 
 def get_size(path: str) -> int:
     if os.path.isfile(path):
-        return os.path.getsize(path)
+        return os.path.getsize(path) if not os.path.islink(path) else 0
     else:
         total_size = 0
-        for dirpath, _, filenames in os.walk(path, followlinks=True):
+        for dirpath, _, filenames in os.walk(path):
             for f in filenames:
                 fp = os.path.join(dirpath, f)
-                total_size += os.path.getsize(fp)
+                if not os.path.islink(fp):
+                    total_size += os.path.getsize(fp)
         return total_size
 
 

--- a/streamflow/cwl/command.py
+++ b/streamflow/cwl/command.py
@@ -360,7 +360,14 @@ async def _prepare_work_dir(
                         dest_path, path_processor.basename(src_path)
                     )
                 if listing_class == "Directory":
-                    await remotepath.mkdir(connector, locations, dest_path)
+                    await asyncio.gather(
+                        *(
+                            asyncio.create_task(
+                                remotepath.mkdir(connector, location, dest_path)
+                            )
+                            for location in locations
+                        )
+                    )
                 else:
                     await utils.write_remote_file(
                         context=streamflow_context,
@@ -372,7 +379,14 @@ async def _prepare_work_dir(
             if "listing" in listing:
                 if "basename" in listing:
                     folder_path = path_processor.join(base_path, listing["basename"])
-                    await remotepath.mkdir(connector, locations, folder_path)
+                    await asyncio.gather(
+                        *(
+                            asyncio.create_task(
+                                remotepath.mkdir(connector, location, folder_path)
+                            )
+                            for location in locations
+                        )
+                    )
                 else:
                     folder_path = dest_path or base_path
                 await asyncio.gather(

--- a/streamflow/cwl/command.py
+++ b/streamflow/cwl/command.py
@@ -340,7 +340,7 @@ async def _prepare_work_dir(
                 )
                 await streamflow_context.data_manager.transfer_data(
                     src_location=selected_location.location,
-                    src_path=src_path,
+                    src_path=selected_location.path,
                     dst_locations=locations,
                     dst_path=dest_path,
                     writable=writable,

--- a/streamflow/cwl/command.py
+++ b/streamflow/cwl/command.py
@@ -262,14 +262,17 @@ def _merge_tokens(token: CommandToken) -> Any:
         return [_merge_tokens(t) for t in token.value if t is not None]
     elif isinstance(token, ObjectCommandToken):
         tokens = sorted(
-            flatten_list(
-                [_merge_tokens(t) for t in token.value.values() if t is not None]
+            filter(
+                lambda t: t.position is not None,
+                flatten_list(
+                    [_merge_tokens(t) for t in token.value.values() if t is not None]
+                ),
             ),
             key=lambda t: (
                 [t.position, t.name] if t.name is not None else [t.position]
             ),
         )
-        return [t for t in tokens if t.position is not None] or [
+        return tokens or [
             CommandToken(name=token.name, position=token.position, value="")
         ]
     elif token is None:

--- a/streamflow/cwl/processor.py
+++ b/streamflow/cwl/processor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from collections.abc import MutableSequence, MutableMapping, Callable
 from typing import Any, cast
 
@@ -27,6 +28,7 @@ from streamflow.cwl.token import CWLFileToken
 from streamflow.cwl.utils import LoadListing, SecondaryFile
 from streamflow.cwl.workflow import CWLWorkflow
 from streamflow.deployment.utils import get_path_processor
+from streamflow.log_handler import logger
 from streamflow.workflow.token import ListToken, ObjectToken
 
 
@@ -213,6 +215,10 @@ class CWLTokenProcessor(TokenProcessor):
                     path=filepath, dst_deployment=LocalTarget.deployment_name
                 )
             if data_location:
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        f"Processing {filepath} on location {data_location.location}."
+                    )
                 connector = self.workflow.context.deployment_manager.get_connector(
                     data_location.deployment
                 )

--- a/streamflow/cwl/step.py
+++ b/streamflow/cwl/step.py
@@ -548,13 +548,17 @@ class CWLTransferStep(TransferStep):
                 job.input_directory, utils.random_name(), selected_location.relpath
             )
             # Perform and transfer
-            await self.workflow.context.data_manager.transfer_data(
-                src_location=selected_location.location,
-                src_path=selected_location.path,
-                dst_locations=dst_locations,
-                dst_path=filepath,
-                writable=self.writable,
-            )
+            try:
+                await self.workflow.context.data_manager.transfer_data(
+                    src_location=selected_location.location,
+                    src_path=selected_location.path,
+                    dst_locations=dst_locations,
+                    dst_path=filepath,
+                    writable=self.writable,
+                )
+            except WorkflowExecutionException:
+                logger.error(f"Job {job.name} failed transfer data")
+                raise
             # Transform token value
             new_token_value = {
                 "class": token_class,

--- a/streamflow/cwl/step.py
+++ b/streamflow/cwl/step.py
@@ -548,17 +548,13 @@ class CWLTransferStep(TransferStep):
                 job.input_directory, utils.random_name(), selected_location.relpath
             )
             # Perform and transfer
-            try:
-                await self.workflow.context.data_manager.transfer_data(
-                    src_location=selected_location.location,
-                    src_path=selected_location.path,
-                    dst_locations=dst_locations,
-                    dst_path=filepath,
-                    writable=self.writable,
-                )
-            except WorkflowExecutionException:
-                logger.error(f"Job {job.name} failed transfer data")
-                raise
+            await self.workflow.context.data_manager.transfer_data(
+                src_location=selected_location.location,
+                src_path=selected_location.path,
+                dst_locations=dst_locations,
+                dst_path=filepath,
+                writable=self.writable,
+            )
             # Transform token value
             new_token_value = {
                 "class": token_class,

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -2746,15 +2746,13 @@ class CWLTranslator:
                     transformer_step.add_input_port(port_name, port)
                     # If there are format dependencies, search for inputs in the port's input steps
                     for dep in format_deps:
-                        port_found = False
                         for step in port.get_input_steps():
                             if dep in step.input_ports:
                                 transformer_step.add_input_port(
                                     dep, step.get_input_port(dep)
                                 )
-                                port_found = True
                                 break
-                        if not port_found:
+                        else:
                             raise WorkflowDefinitionException(
                                 f"Cannot retrieve {dep} input port."
                             )

--- a/streamflow/data/manager.py
+++ b/streamflow/data/manager.py
@@ -58,9 +58,11 @@ def _get_inner_path(location: ExecutionLocation, path: str) -> str | None:
     if location.wraps:
         for mount in sorted(location.mounts.keys(), reverse=True):
             if path.startswith(mount):
-                return (posixpath if location.wraps.local else os.path).join(
-                    location.mounts[mount],
-                    (posixpath if location.local else os.path).relpath(path, mount),
+                return os.path.normpath(
+                    (posixpath if location.wraps.local else os.path).join(
+                        location.mounts[mount],
+                        (posixpath if location.local else os.path).relpath(path, mount),
+                    )
                 )
     return None
 
@@ -339,7 +341,10 @@ class DefaultDataManager(DataManager):
             *(
                 asyncio.create_task(src_data_loc.available.wait())
                 for src_data_loc in self.get_data_locations(
-                    src_path, src_location.deployment, src_location.name
+                    path=src_path,
+                    deployment=src_connector.deployment_name,
+                    location_name=src_location.name,
+                    data_type=DataType.PRIMARY,
                 )
             )
         )

--- a/streamflow/data/remotepath.py
+++ b/streamflow/data/remotepath.py
@@ -174,22 +174,14 @@ async def follow_symlink(
     if location.local:
         return os.path.realpath(path) if os.path.exists(path) else None
     else:
-        # If at least one primary location is present on the site
+        # If at least one primary location is present on the site, return its path
         if locations := context.data_manager.get_data_locations(
             path=path,
             deployment=connector.deployment_name,
             location_name=location.name,
             data_type=DataType.PRIMARY,
         ):
-            # If there is only one primary location on the site, return its path
-            if len(locations) == 1:
-                return locations[0].path
-            # If multiple primary locations are present for the same path, raise an Exception
-            else:
-                raise WorkflowExecutionException(
-                    f"Multiple primary locations on site {location} for path {path} "
-                    f": {[loc.path for loc in locations]}"
-                )
+            return next(iter(locations)).path
         # Otherwise, analyse the remote path
         command = [f'test -e "{path}" && readlink -f "{path}"']
         result, status = await connector.run(

--- a/streamflow/data/remotepath.py
+++ b/streamflow/data/remotepath.py
@@ -492,15 +492,15 @@ async def size(
             path = [path]
         return sum(utils.get_size(p) for p in path)
     else:
-        if isinstance(path, MutableSequence):
-            path = " ".join([f'"{p}"' for p in path])
-        else:
-            path = f'"{path}"'
         command = [
             "".join(
                 [
                     "find -L ",
-                    path,
+                    (
+                        " ".join([f'"{p}"' for p in path])
+                        if isinstance(path, MutableSequence)
+                        else f'"{path}"'
+                    ),
                     " -type f -exec ls -ln {} \\+ | ",
                     "awk 'BEGIN {sum=0} {sum+=$5} END {print sum}'; ",
                 ]

--- a/streamflow/data/utils.py
+++ b/streamflow/data/utils.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from streamflow.core.context import StreamFlowContext
+from streamflow.core.scheduling import Hardware, Storage
+from streamflow.data.remotepath import follow_symlink
+from streamflow.deployment.utils import get_path_processor
+
+if TYPE_CHECKING:
+    from streamflow.core.deployment import Connector
+    from streamflow.core.scheduling import AvailableLocation
+
+
+async def bind_mount_point(
+    hardware: Hardware,
+    context: StreamFlowContext,
+    connector: Connector,
+    location: AvailableLocation,
+) -> Hardware:
+    path_processor = get_path_processor(connector)
+    return Hardware(
+        cores=hardware.cores,
+        memory=hardware.memory,
+        storage={
+            key: Storage(
+                mount_point=await get_mount_point(
+                    context, connector, location, disk.bind
+                ),
+                size=disk.size,
+                paths={
+                    path_processor.normpath(
+                        path_processor.join(
+                            disk.bind,
+                            path_processor.relpath(p, disk.mount_point),
+                        )
+                    )
+                    for p in disk.paths
+                },
+            )
+            for key, disk in hardware.storage.items()
+            if disk.bind is not None
+        },
+    )
+
+
+async def get_mount_point(
+    context: StreamFlowContext,
+    connector: Connector,
+    location: AvailableLocation,
+    path: str,
+) -> str:
+    """
+    Get the mount point of a path in the given `location`
+
+    :param context: the `StreamFlowContext` object with global application status.
+    :param connector: the `Connector` object to communicate with the location
+    :param location: the `AvailableLocation` object with the location information
+    :param path: the path whose mount point should be returned
+    :return: the mount point containing the given path
+    """
+    try:
+        return location.hardware.get_mount_point(path)
+    except KeyError:
+        path_processor = get_path_processor(connector)
+        path_to_resolve = path
+        while (
+            mount_point := await follow_symlink(
+                context, connector, location.location, path_to_resolve
+            )
+        ) is None:
+            path_to_resolve = path_processor.dirname(path_to_resolve)
+        location_mount_points = location.hardware.get_mount_points()
+        while mount_point != os.sep and mount_point not in location_mount_points:
+            mount_point = path_processor.dirname(mount_point)
+        location.hardware.get_storage(mount_point).add_path(path)
+        return mount_point

--- a/streamflow/deployment/connector/container.py
+++ b/streamflow/deployment/connector/container.py
@@ -58,7 +58,7 @@ async def _get_storage_from_binds(
             "+2",
             "|",
             "awk",
-            "'{print $7, $2, $3}'",
+            "'{print $7, $2, $5}'",
         ],
         capture_output=True,
     )

--- a/streamflow/deployment/connector/container.py
+++ b/streamflow/deployment/connector/container.py
@@ -58,7 +58,7 @@ async def _get_storage_from_binds(
             "+2",
             "|",
             "awk",
-            "'NF == 1 {device = $1; getline; $0 = device $0} {print $7, $2, $3}'",
+            "'{print $7, $2, $3}'",
         ],
         capture_output=True,
     )
@@ -219,27 +219,16 @@ class ContainerConnector(ConnectorWrapper, ABC):
                     is not None
                 ):
                     # If yes, then create a symbolic link
-                    if self._wraps_local() and not os.path.exists(adjusted_dst):
-                        if logger.isEnabledFor(logging.INFO):
-                            logger.info(
-                                f"COPYING from {adjusted_src} to {adjusted_dst} on local file-system"
-                            )
-                        os.symlink(adjusted_src, adjusted_dst)
-                        if logger.isEnabledFor(logging.INFO):
-                            logger.info(
-                                f"COMPLETED copy from {adjusted_src} to {adjusted_dst} on local file-system"
-                            )
-                    else:
-                        copy_tasks.append(
-                            asyncio.create_task(
-                                self._local_copy(
-                                    src=adjusted_src,
-                                    dst=dst,
-                                    location=location,
-                                    read_only=read_only,
-                                )
+                    copy_tasks.append(
+                        asyncio.create_task(
+                            self._local_copy(
+                                src=adjusted_src,
+                                dst=dst,
+                                location=location,
+                                read_only=read_only,
                             )
                         )
+                    )
                 # Otherwise, delegate transfer to the inner connector
                 else:
                     if logger.isEnabledFor(logging.DEBUG):
@@ -303,26 +292,19 @@ class ContainerConnector(ConnectorWrapper, ABC):
             # If data is read_only, check if the destination path is bound to a mounted volume, too
             if (
                 read_only
-                and (adjusted_dst := self._get_container_path(instance, dst))
-                is not None
+                and self._wraps_local()
+                and not os.path.exists(dst)
+                and self._get_container_path(instance, dst) is not None
             ):
                 # If yes, then create a symbolic link
-                if self._wraps_local() and not os.path.exists(dst):
-                    if logger.isEnabledFor(logging.INFO):
-                        logger.info(
-                            f"COPYING from {adjusted_src} to {dst} on local file-system"
-                        )
-                    os.symlink(adjusted_src, dst)
-                    if logger.isEnabledFor(logging.INFO):
-                        logger.info(
-                            f"COMPLETED copy from {adjusted_src} to {dst} on local file-system"
-                        )
-                else:
-                    await self._local_copy(
-                        src=src,
-                        dst=adjusted_dst,
-                        location=location,
-                        read_only=read_only,
+                if logger.isEnabledFor(logging.INFO):
+                    logger.info(
+                        f"COPYING from {adjusted_src} to {dst} on local file-system"
+                    )
+                os.symlink(adjusted_src, dst)
+                if logger.isEnabledFor(logging.INFO):
+                    logger.info(
+                        f"COMPLETED copy from {adjusted_src} to {dst} on local file-system"
                     )
             # Otherwise, delegate transfer to the inner connector
             else:
@@ -1688,6 +1670,7 @@ class SingularityConnector(ContainerConnector):
             wraps=self._inner_location.location,
         )
         # Get IP address
+        ip_address = None
         stdout, returncode = await self.connector.run(
             location=self._inner_location.location,
             command=[
@@ -1704,7 +1687,7 @@ class SingularityConnector(ContainerConnector):
                 if instance["instance"] == name:
                     ip_address = instance["ip"]
                     break
-            else:
+            if ip_address is None:
                 raise WorkflowExecutionException(
                     f"FAILED retrieving instance '{name}' from running Singularity instances "
                     f"in deployment {self.deployment_name}: [{returncode}] {stdout}"

--- a/streamflow/deployment/connector/container.py
+++ b/streamflow/deployment/connector/container.py
@@ -58,7 +58,7 @@ async def _get_storage_from_binds(
             "+2",
             "|",
             "awk",
-            "'{print $7, $2, $3}'",
+            "'NF == 1 {device = $1; getline; $0 = device $0} {print $7, $2, $3}'",
         ],
         capture_output=True,
     )
@@ -1688,7 +1688,6 @@ class SingularityConnector(ContainerConnector):
             wraps=self._inner_location.location,
         )
         # Get IP address
-        ip_address = None
         stdout, returncode = await self.connector.run(
             location=self._inner_location.location,
             command=[
@@ -1705,7 +1704,7 @@ class SingularityConnector(ContainerConnector):
                 if instance["instance"] == name:
                     ip_address = instance["ip"]
                     break
-            if ip_address is None:
+            else:
                 raise WorkflowExecutionException(
                     f"FAILED retrieving instance '{name}' from running Singularity instances "
                     f"in deployment {self.deployment_name}: [{returncode}] {stdout}"

--- a/streamflow/deployment/connector/kubernetes.py
+++ b/streamflow/deployment/connector/kubernetes.py
@@ -357,23 +357,23 @@ class KubernetesBaseConnector(BaseConnector, ABC):
         valid_targets = {}
         for pod in pods.items:
             # Check if pod is ready
-            is_ready = True
             for condition in pod.status.conditions:
                 if condition.status != "True":
-                    is_ready = False
                     break
-            # Filter out not ready and Terminating locations
-            if is_ready and pod.metadata.deletion_timestamp is None:
-                for container in pod.spec.containers:
-                    if not service or service == container.name:
-                        location_name = pod.metadata.name + ":" + service
-                        valid_targets[location_name] = AvailableLocation(
-                            name=location_name,
-                            deployment=self.deployment_name,
-                            service=service,
-                            hostname=pod.status.pod_ip,
-                        )
-                        break
+            # Otherwise
+            else:
+                # Filter out not ready and Terminating locations
+                if pod.metadata.deletion_timestamp is None:
+                    for container in pod.spec.containers:
+                        if not service or service == container.name:
+                            location_name = pod.metadata.name + ":" + service
+                            valid_targets[location_name] = AvailableLocation(
+                                name=location_name,
+                                deployment=self.deployment_name,
+                                service=service,
+                                hostname=pod.status.pod_ip,
+                            )
+                            break
         return valid_targets
 
     async def get_stream_reader(

--- a/streamflow/deployment/connector/local.py
+++ b/streamflow/deployment/connector/local.py
@@ -14,15 +14,9 @@ from typing import Any
 import psutil
 
 from streamflow.core import utils
-from streamflow.core.deployment import (
-    Connector,
-    ExecutionLocation,
-)
+from streamflow.core.deployment import Connector, ExecutionLocation
 from streamflow.core.scheduling import AvailableLocation, Hardware, Storage
-from streamflow.deployment.connector.base import (
-    BaseConnector,
-    FS_TYPES_TO_SKIP,
-)
+from streamflow.deployment.connector.base import BaseConnector, FS_TYPES_TO_SKIP
 from streamflow.log_handler import logger
 
 

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -429,7 +429,7 @@ class SSHConnector(BaseConnector):
                 location=location,
                 command="nproc && "
                 "free | grep Mem | awk '{print $2}' && "
-                "df -aT | tail -n +2 | awk '{print $7, $2, $3}'",
+                "df -aT | tail -n +2 | awk 'NF == 1 {device = $1; getline; $0 = device $0} {print $7, $2, $3}'",
                 stderr=asyncio.subprocess.STDOUT,
             ) as proc:
                 result = await proc.wait()

--- a/streamflow/deployment/future.py
+++ b/streamflow/deployment/future.py
@@ -39,7 +39,6 @@ class FutureConnector(Connector):
     async def _safe_deploy_event_wait(self):
         await self.deploy_event.wait()
         if self._connector is None:
-            logger.error(f"FAILED deployment of {self.deployment_name}")
             raise WorkflowExecutionException(
                 f"FAILED deployment of {self.deployment_name}"
             )

--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -22,10 +22,9 @@ from streamflow.core.scheduling import (
     Storage,
 )
 from streamflow.core.workflow import Job, Status
-from streamflow.data import remotepath
+from streamflow.data import remotepath, utils
 from streamflow.deployment.connector import LocalConnector
 from streamflow.deployment.filter import binding_filter_classes
-from streamflow.deployment.utils import get_path_processor
 from streamflow.deployment.wrapper import ConnectorWrapper
 from streamflow.log_handler import logger
 from streamflow.scheduling.policy import policy_classes
@@ -378,7 +377,7 @@ class DefaultScheduler(Scheduler):
                 storage = {}
                 for key, disk in hardware_requirement.storage.items():
                     for path in disk.paths:
-                        mount_point = await remotepath.get_mount_point(
+                        mount_point = await utils.get_mount_point(
                             self.context, connector, location, path
                         )
                         storage[key] = Storage(
@@ -408,8 +407,9 @@ class DefaultScheduler(Scheduler):
             # If AvailableLocation is stacked and wraps another location, compute the inner requirement
             if location := location.wraps if location.stacked else None:
                 connector = cast(ConnectorWrapper, connector).connector
-                path_processor = get_path_processor(connector)
-                hardware_requirement = current_hw.bind(path_processor)
+                hardware_requirement = await utils.bind_mount_point(
+                    current_hw, self.context, connector, location
+                )
         return hardware
 
     async def close(self):
@@ -470,8 +470,22 @@ class DefaultScheduler(Scheduler):
                                         loc.wraps for loc in locations if loc.stacked
                                     ]:
                                         conn = cast(ConnectorWrapper, conn).connector
-                                        path_processor = get_path_processor(conn)
-                                        job_hardware = job_hardware.bind(path_processor)
+                                        for execution_loc in locations:
+                                            job_hardware = await utils.bind_mount_point(
+                                                job_hardware,
+                                                self.context,
+                                                conn,
+                                                next(
+                                                    available_loc
+                                                    for available_loc in (
+                                                        await conn.get_available_locations(
+                                                            execution_loc.service
+                                                        )
+                                                    ).values()
+                                                    if available_loc.name
+                                                    == execution_loc.name
+                                                ),
+                                            )
                         self.wait_queues[connector.deployment_name].notify_all()
 
     async def schedule(

--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -408,7 +408,7 @@ class DefaultScheduler(Scheduler):
             if location := location.wraps if location.stacked else None:
                 connector = cast(ConnectorWrapper, connector).connector
                 hardware_requirement = await utils.bind_mount_point(
-                    current_hw, self.context, connector, location
+                    self.context, connector, location, current_hw
                 )
         return hardware
 
@@ -472,7 +472,6 @@ class DefaultScheduler(Scheduler):
                                         conn = cast(ConnectorWrapper, conn).connector
                                         for execution_loc in locations:
                                             job_hardware = await utils.bind_mount_point(
-                                                job_hardware,
                                                 self.context,
                                                 conn,
                                                 next(
@@ -485,6 +484,7 @@ class DefaultScheduler(Scheduler):
                                                     if available_loc.name
                                                     == execution_loc.name
                                                 ),
+                                                job_hardware,
                                             )
                         self.wait_queues[connector.deployment_name].notify_all()
 

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -1443,10 +1443,21 @@ class ScheduleStep(BaseStep):
             path_processor, job.tmp_directory, allocation.target
         )
         # Create directories
-        await remotepath.mkdirs(
-            connector=connector,
-            locations=locations,
-            paths=[job.input_directory, job.output_directory, job.tmp_directory],
+        await asyncio.gather(
+            *(
+                asyncio.create_task(
+                    remotepath.mkdir(
+                        connector=connector,
+                        location=location,
+                        path=[
+                            job.input_directory,
+                            job.output_directory,
+                            job.tmp_directory,
+                        ],
+                    )
+                )
+                for location in locations
+            )
         )
         job.input_directory = await remotepath.follow_symlink(
             self.workflow.context, connector, locations[0], job.input_directory

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -75,9 +75,7 @@ async def test_data_locations(
     )
 
     # Create working directories in src and dst locations
-    await remotepath.mkdir(
-        src_connector, src_location, str(PurePath(src_path).parent)
-    )
+    await remotepath.mkdir(src_connector, src_location, str(PurePath(src_path).parent))
     await remotepath.mkdir(dst_connector, dst_location, dst_path)
 
     try:

--- a/tests/test_remotepath.py
+++ b/tests/test_remotepath.py
@@ -50,7 +50,7 @@ async def test_directory(context, connector, location):
     """Test directory creation and deletion."""
     path = utils.random_name()
     try:
-        await remotepath.mkdir(connector, [location], path)
+        await remotepath.mkdir(connector, location, path)
         assert await remotepath.exists(connector, location, path)
         assert await remotepath.isdir(connector, location, path)
         # ./
@@ -58,9 +58,9 @@ async def test_directory(context, connector, location):
         #   file2.csv
         #   dir1/
         #   dir2/
-        await remotepath.mkdirs(
+        await remotepath.mkdir(
             connector,
-            [location],
+            location,
             [posixpath.join(path, "dir1"), posixpath.join(path, "dir2")],
         )
         await remotepath.write(
@@ -101,7 +101,7 @@ async def test_download(context, connector, location):
     path = None
     for i, url in enumerate(urls):
         try:
-            path = await remotepath.download(connector, [location], url, parent_dir)
+            path = await remotepath.download(connector, location, url, parent_dir)
             assert path == paths[i]
             assert await remotepath.exists(connector, location, path)
         finally:
@@ -145,10 +145,10 @@ async def test_mkdir_failure(context):
     path = utils.random_name()
     await remotepath.write(connector, location, path, "StreamFlow")
     with pytest.raises(WorkflowExecutionException) as err:
-        await remotepath.mkdirs(
+        await remotepath.mkdir(
             connector,
-            [location],
-            [path],
+            location,
+            path,
         )
     expected_msg_err = f"1 Command 'mkdir -p {path}' on location {location}: mkdir: can't create directory '{path}': File exists"
     assert str(err.value) == expected_msg_err
@@ -159,7 +159,7 @@ async def test_resolve(context, connector, location):
     """Test glob resolution."""
     path_processor = get_path_processor(connector)
     path = utils.random_name()
-    await remotepath.mkdir(connector, [location], path)
+    await remotepath.mkdir(connector, location, path)
     try:
         # ./
         #   file1.txt
@@ -177,7 +177,7 @@ async def test_resolve(context, connector, location):
             connector, location, path_processor.join(path, "file2.csv"), "StreamFlow"
         )
         await remotepath.mkdir(
-            connector, [location], path_processor.join(path, "dir1", "dir2")
+            connector, location, path_processor.join(path, "dir1", "dir2")
         )
         await remotepath.write(
             connector,
@@ -248,7 +248,7 @@ async def test_symlink(context, connector, location):
         assert not await remotepath.exists(connector, location, path)
         await remotepath.rm(connector, location, src)
         # Test symlink to directory
-        await remotepath.mkdir(connector, [location], src)
+        await remotepath.mkdir(connector, location, src)
         await _symlink(connector, location, src, path)
         assert await remotepath.exists(connector, location, path)
         assert await remotepath.islink(connector, location, path)

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -101,7 +101,7 @@ async def _create_tmp_dir(context, connector, location, root=None, lvl=None, n_f
             root if root else "/tmp", f"dir{dir_lvl}-{utils.random_name()}"
         )
     )
-    await remotepath.mkdir(connector, [location], dir_path)
+    await remotepath.mkdir(connector, location, dir_path)
 
     dir_path = await remotepath.follow_symlink(context, connector, location, dir_path)
     file_lvl = f"-{lvl}" if lvl else ""
@@ -238,7 +238,7 @@ async def test_file_to_directory(
         if dst_location.local
         else posixpath.join("/tmp", utils.random_name())
     )
-    await remotepath.mkdir(dst_connector, [dst_location], dst_path)
+    await remotepath.mkdir(dst_connector, dst_location, dst_path)
     try:
         await remotepath.write(src_connector, src_location, src_path, "StreamFlow")
         src_path = await remotepath.follow_symlink(

--- a/tests/utils/deployment.py
+++ b/tests/utils/deployment.py
@@ -92,9 +92,16 @@ def get_docker_deployment_config():
     return DeploymentConfig(
         name="alpine-docker",
         type="docker",
-        config={"image": "alpine:3.16.2"},
+        config={
+            "image": "alpine:3.16.2",
+            "volume": [
+                f"{get_local_deployment_config().workdir}:/tmp/streamflow",
+                f"{get_local_deployment_config().workdir}:/home/output",
+            ],
+        },
         external=False,
         lazy=False,
+        workdir="/tmp/streamflow",
     )
 
 

--- a/tests/utils/workflow.py
+++ b/tests/utils/workflow.py
@@ -52,7 +52,6 @@ def create_schedule_step(
             targets=[
                 Target(
                     deployment=deploy_step.deployment_config,
-                    workdir=utils.random_name(),
                 )
                 for deploy_step in deploy_steps
             ]


### PR DESCRIPTION
This commit allows the `DataManager` class to propagate `DataLocation` relations when a path is mapped onto a volume in a stacked inner `ExecutionLocation` object. To accomplish this goal, a new `mounts` field has been added to the `ExecutionLocation` object, allowing it to carry information about volume bindings.