### PR TITLE
Improve MacOS CI performance

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -71,9 +71,10 @@ jobs:
         with:
           node-version: "20"
       - name: "Install Docker (MacOS X)"
-        uses: douglascamata/setup-docker-macos-action@v1-alpha.14
+        uses: douglascamata/setup-docker-macos-action@main
         if: ${{ startsWith(matrix.on, 'macos-') }}
       - uses: docker/setup-qemu-action@v3
+        if: ${{ startsWith(matrix.on, 'ubuntu-') }}
       - name: "Install Apptainer"
         uses: eWaterCycle/setup-apptainer@v2
         with:
@@ -239,9 +240,10 @@ jobs:
         with:
           node-version: "20"
       - name: "Install Docker (MacOs X)"
-        uses: douglascamata/setup-docker-macos-action@v1-alpha.14
+        uses: douglascamata/setup-docker-macos-action@main
         if: ${{ startsWith(matrix.on, 'macos-') }}
       - uses: docker/setup-qemu-action@v3
+        if: ${{ startsWith(matrix.on, 'ubuntu-') }}
       - name: "Install Apptainer"
         uses: eWaterCycle/setup-apptainer@v2
         with:


### PR DESCRIPTION
This commit updates the `douglascamata/setup-docker-macos-action` in the GitHub CI to the latest version, which replaces QEMU with the native virtualization provided by the MacOS X virtualization framework. This new technology provides significant stability and performance improvements.