### PR TITLE
Refactored unit tests

### DIFF
--- a/tests/test_build_wf.py
+++ b/tests/test_build_wf.py
@@ -177,7 +177,7 @@ async def test_combinator_step(context: StreamFlowContext, combinator: Combinato
 @pytest.mark.asyncio
 async def test_deploy_step(context: StreamFlowContext):
     """Test saving DeployStep on database and re-load it in a new Workflow"""
-    workflow = (await create_workflow(context, num_port=0))[0]
+    workflow, _ = await create_workflow(context, num_port=0)
     step = create_deploy_step(workflow)
     await workflow.save(context)
     new_workflow, new_step = await _clone_step(step, workflow, context)
@@ -236,11 +236,11 @@ async def test_execute_step(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_gather_step(context: StreamFlowContext):
     """Test saving GatherStep on database and re-load it in a new Workflow"""
-    workflow, ports = await create_workflow(context, num_port=1)
+    workflow, (port,) = await create_workflow(context, num_port=1)
     await _base_step_test_process(
         workflow,
         GatherStep,
-        {"name": utils.random_name() + "-gather", "depth": 1, "size_port": ports[0]},
+        {"name": utils.random_name() + "-gather", "depth": 1, "size_port": port},
         context,
     )
 
@@ -280,7 +280,7 @@ async def test_loop_combinator_step(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_scatter_step(context: StreamFlowContext):
     """Test saving ScatterStep on database and re-load it in a new Workflow"""
-    workflow = (await create_workflow(context, num_port=0))[0]
+    workflow, _ = await create_workflow(context, num_port=0)
     await _base_step_test_process(
         workflow, ScatterStep, {"name": utils.random_name() + "-scatter"}, context
     )
@@ -289,7 +289,7 @@ async def test_scatter_step(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_schedule_step(context: StreamFlowContext):
     """Test saving ScheduleStep on database and re-load it in a new Workflow"""
-    workflow = (await create_workflow(context, num_port=0))[0]
+    workflow, _ = await create_workflow(context, num_port=0)
     deploy_step = create_deploy_step(workflow)
     nof_deployments = 2
     step = create_schedule_step(
@@ -356,7 +356,7 @@ async def test_workflow(context: StreamFlowContext):
     exec_step.add_input_port(in_port_name, in_port)
     await workflow.save(context)
 
-    new_workflow = (await create_workflow(context, num_port=0))[0]
+    new_workflow, _ = await create_workflow(context, num_port=0)
     loading_context = WorkflowBuilder(new_workflow)
     new_workflow = await loading_context.load_workflow(context, workflow.persistent_id)
 

--- a/tests/test_cwl_build_wf.py
+++ b/tests/test_cwl_build_wf.py
@@ -47,7 +47,7 @@ from tests.utils.workflow import create_workflow
 @pytest.mark.parametrize("step_cls", [CWLLoopOutputAllStep, CWLLoopOutputLastStep])
 async def test_cwl_loop_output(context: StreamFlowContext, step_cls: Type[Step]):
     """Test saving CWLLoopOutputAllStep on database and re-load it in a new Workflow"""
-    workflow = next(iter(await create_workflow(context, num_port=1)))
+    workflow, _ = await create_workflow(context, num_port=0)
     await _base_step_test_process(
         workflow,
         step_cls,
@@ -85,7 +85,7 @@ async def test_default_transformer(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_forward_transformer(context: StreamFlowContext):
     """Test saving ForwardTransformer on database and re-load it in a new Workflow"""
-    workflow = next(iter(await create_workflow(context, num_port=0)))
+    workflow, _ = await create_workflow(context, num_port=0)
     await _base_step_test_process(
         workflow,
         ForwardTransformer,
@@ -129,7 +129,7 @@ async def test_list_merge_combinator(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_list_to_element_transformer(context: StreamFlowContext):
     """Test saving ListToElementTransformer on database and re-load it in a new Workflow"""
-    workflow = next(iter(await create_workflow(context, num_port=0)))
+    workflow, _ = await create_workflow(context, num_port=0)
     await _base_step_test_process(
         workflow,
         ListToElementTransformer,
@@ -184,7 +184,7 @@ async def test_non_null_transformer(
     context: StreamFlowContext, transformer_cls: Type[Step]
 ):
     """Test saving All/First/Only NonNullTransformer on database and re-load it in a new Workflow"""
-    workflow = next(iter(await create_workflow(context, num_port=0)))
+    workflow, _ = await create_workflow(context, num_port=0)
     await _base_step_test_process(
         workflow,
         transformer_cls,
@@ -231,7 +231,7 @@ async def test_value_from_transformer(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_cwl_conditional_step(context: StreamFlowContext):
     """Test saving CWLConditionalStep on database and re-load it in a new Workflow"""
-    workflow = next(iter(await create_workflow(context, num_port=0)))
+    workflow, _ = await create_workflow(context, num_port=0)
     await _base_step_test_process(
         workflow,
         CWLConditionalStep,
@@ -247,7 +247,7 @@ async def test_cwl_conditional_step(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_cwl_empty_scatter_conditional_step(context: StreamFlowContext):
     """Test saving CWLEmptyScatterConditionalStep on database and re-load it in a new Workflow"""
-    workflow = next(iter(await create_workflow(context, num_port=1)))
+    workflow, _ = await create_workflow(context, num_port=0)
     await _base_step_test_process(
         workflow,
         CWLEmptyScatterConditionalStep,
@@ -277,7 +277,7 @@ async def test_cwl_input_injector_step(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_cwl_loop_conditional_step(context: StreamFlowContext):
     """Test saving CWLLoopConditionalStep on database and re-load it in a new Workflow"""
-    workflow = next(iter(await create_workflow(context, num_port=0)))
+    workflow, _ = await create_workflow(context, num_port=0)
     await _base_step_test_process(
         workflow,
         CWLLoopConditionalStep,
@@ -293,7 +293,7 @@ async def test_cwl_loop_conditional_step(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_cwl_token_transformer(context: StreamFlowContext):
     """Test saving CWLTokenTransformer on database and re-load it in a new Workflow"""
-    workflow = next(iter(await create_workflow(context, num_port=0)))
+    workflow, _ = await create_workflow(context, num_port=0)
     step_name = utils.random_name()
     step, new_workflow, new_step = await _base_step_test_process(
         workflow,

--- a/tests/test_cwl_build_wf.py
+++ b/tests/test_cwl_build_wf.py
@@ -47,7 +47,7 @@ from tests.utils.workflow import create_workflow
 @pytest.mark.parametrize("step_cls", [CWLLoopOutputAllStep, CWLLoopOutputLastStep])
 async def test_cwl_loop_output(context: StreamFlowContext, step_cls: Type[Step]):
     """Test saving CWLLoopOutputAllStep on database and re-load it in a new Workflow"""
-    workflow = (await create_workflow(context, num_port=1))[0]
+    workflow = next(iter(await create_workflow(context, num_port=1)))
     await _base_step_test_process(
         workflow,
         step_cls,
@@ -85,7 +85,7 @@ async def test_default_transformer(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_forward_transformer(context: StreamFlowContext):
     """Test saving ForwardTransformer on database and re-load it in a new Workflow"""
-    workflow = (await create_workflow(context, num_port=1))[0]
+    workflow = next(iter(await create_workflow(context, num_port=0)))
     await _base_step_test_process(
         workflow,
         ForwardTransformer,
@@ -129,7 +129,7 @@ async def test_list_merge_combinator(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_list_to_element_transformer(context: StreamFlowContext):
     """Test saving ListToElementTransformer on database and re-load it in a new Workflow"""
-    workflow = (await create_workflow(context, num_port=1))[0]
+    workflow = next(iter(await create_workflow(context, num_port=0)))
     await _base_step_test_process(
         workflow,
         ListToElementTransformer,
@@ -184,7 +184,7 @@ async def test_non_null_transformer(
     context: StreamFlowContext, transformer_cls: Type[Step]
 ):
     """Test saving All/First/Only NonNullTransformer on database and re-load it in a new Workflow"""
-    workflow = (await create_workflow(context, num_port=1))[0]
+    workflow = next(iter(await create_workflow(context, num_port=0)))
     await _base_step_test_process(
         workflow,
         transformer_cls,
@@ -231,7 +231,7 @@ async def test_value_from_transformer(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_cwl_conditional_step(context: StreamFlowContext):
     """Test saving CWLConditionalStep on database and re-load it in a new Workflow"""
-    workflow = (await create_workflow(context, num_port=1))[0]
+    workflow = next(iter(await create_workflow(context, num_port=0)))
     await _base_step_test_process(
         workflow,
         CWLConditionalStep,
@@ -247,7 +247,7 @@ async def test_cwl_conditional_step(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_cwl_empty_scatter_conditional_step(context: StreamFlowContext):
     """Test saving CWLEmptyScatterConditionalStep on database and re-load it in a new Workflow"""
-    workflow = (await create_workflow(context, num_port=1))[0]
+    workflow = next(iter(await create_workflow(context, num_port=1)))
     await _base_step_test_process(
         workflow,
         CWLEmptyScatterConditionalStep,
@@ -277,7 +277,7 @@ async def test_cwl_input_injector_step(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_cwl_loop_conditional_step(context: StreamFlowContext):
     """Test saving CWLLoopConditionalStep on database and re-load it in a new Workflow"""
-    workflow, (port,) = await create_workflow(context, num_port=1)
+    workflow = next(iter(await create_workflow(context, num_port=0)))
     await _base_step_test_process(
         workflow,
         CWLLoopConditionalStep,
@@ -293,7 +293,7 @@ async def test_cwl_loop_conditional_step(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_cwl_token_transformer(context: StreamFlowContext):
     """Test saving CWLTokenTransformer on database and re-load it in a new Workflow"""
-    workflow = (await create_workflow(context, num_port=1))[0]
+    workflow = next(iter(await create_workflow(context, num_port=0)))
     step_name = utils.random_name()
     step, new_workflow, new_step = await _base_step_test_process(
         workflow,

--- a/tests/test_cwl_persistence.py
+++ b/tests/test_cwl_persistence.py
@@ -385,7 +385,7 @@ async def test_cwl_map_command_token_processor(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_list_merge_combinator(context: StreamFlowContext):
     """Test saving and loading CombinatorStep with ListMergeCombinator from database"""
-    workflow, (port, *_) = await create_workflow(context=context, num_port=1)
+    workflow, (port,) = await create_workflow(context=context, num_port=1)
     name = utils.random_name()
     step = workflow.create_step(
         cls=CombinatorStep,
@@ -404,7 +404,7 @@ async def test_list_merge_combinator(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_default_transformer(context: StreamFlowContext):
     """Test saving and loading DefaultTransformer from database"""
-    workflow, (port, *_) = await create_workflow(context=context, num_port=1)
+    workflow, (port,) = await create_workflow(context=context, num_port=1)
     transformer = workflow.create_step(
         cls=DefaultTransformer,
         name=utils.random_name() + "-transformer",
@@ -416,7 +416,7 @@ async def test_default_transformer(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_default_retag_transformer(context: StreamFlowContext):
     """Test saving and loading DefaultRetagTransformer from database"""
-    workflow, (port, *_) = await create_workflow(context=context, num_port=1)
+    workflow, (port,) = await create_workflow(context=context, num_port=1)
     transformer = workflow.create_step(
         cls=DefaultRetagTransformer,
         name=utils.random_name() + "-transformer",
@@ -658,7 +658,7 @@ async def test_cwl_empty_scatter_conditional_step(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_cwl_conditional_step(context: StreamFlowContext):
     """Test saving and loading CWLConditionalStep from database"""
-    workflow, (skip_port, *_) = await create_workflow(context=context, num_port=1)
+    workflow, (skip_port,) = await create_workflow(context=context, num_port=1)
     step = workflow.create_step(
         cls=CWLConditionalStep,
         name=utils.random_name() + "-when",
@@ -673,7 +673,7 @@ async def test_cwl_conditional_step(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_cwl_loop_conditional_step(context: StreamFlowContext):
     """Test saving and loading CWLLoopConditionalStep from database"""
-    workflow, (skip_port, *_) = await create_workflow(context=context, num_port=1)
+    workflow, (skip_port,) = await create_workflow(context=context, num_port=1)
     step = workflow.create_step(
         cls=CWLLoopConditionalStep,
         name=utils.random_name() + "-when",

--- a/tests/test_cwl_persistence.py
+++ b/tests/test_cwl_persistence.py
@@ -116,12 +116,15 @@ async def test_cwl_file_token(context: StreamFlowContext):
     """Test saving and loading CWLFileToken from database"""
     token = CWLFileToken(
         value={
-            "location": "file:///home/ubuntu/output.txt",
-            "basename": "output.txt",
+            "basename": "version.py",
+            "checksum": "sha1$a4a8b0c0b19d3187a1ab8c9346fc105978115781",
             "class": "File",
-            "checksum": "sha1$aaaaaaaaaaaaaaaaaaaaaaaa",
-            "size": 100,
-            "path": "/home/ubuntu/output.txt",
+            "dirname": "/home/ubuntu/streamflow/streamflow",
+            "location": "file:///home/ubuntu/streamflow/streamflow/version.py",
+            "nameext": ".py",
+            "nameroot": "version",
+            "path": "/home/ubuntu/streamflow/streamflow/version.py",
+            "size": 24,
         }
     )
     await save_load_and_test(token, context)
@@ -745,12 +748,9 @@ async def test_cwl_schedule_step(context: StreamFlowContext):
 
     schedule_step = workflow.create_step(
         cls=CWLScheduleStep,
-        name=posixpath.join(utils.random_name(), "__schedule__"),
+        name=posixpath.join(posixpath.sep, utils.random_name(), "__schedule__"),
         job_prefix="something",
         connector_ports=connector_ports,
-        input_directory=posixpath.join(*(utils.random_name() for _ in range(2))),
-        output_directory=posixpath.join(*(utils.random_name() for _ in range(2))),
-        tmp_directory=posixpath.join(*(utils.random_name() for _ in range(2))),
         binding_config=binding_config,
         hardware_requirement=CWLHardwareRequirement(
             CWL_VERSION,

--- a/tests/test_cwl_provenance.py
+++ b/tests/test_cwl_provenance.py
@@ -728,25 +728,9 @@ async def test_nested_crossproduct_combinator(context: StreamFlowContext):
     executor = StreamFlowExecutor(workflow)
     await executor.run()
 
-    nested_crossproduct_1 = [(t1, t2) for t2 in list_token_2 for t1 in list_token_1]
-    nested_crossproduct_2 = [(t1, t2) for t1 in list_token_1 for t2 in list_token_2]
+    nested_crossproduct_1 = [[t1, t2] for t2 in list_token_2 for t1 in list_token_1]
+    nested_crossproduct_2 = [[t1, t2] for t1 in list_token_1 for t2 in list_token_2]
 
-    for t in list_token_1:
-        print(f"{t.persistent_id}, {t.tag}, {[tt.value for tt in t.value]}")
-
-    for t in list_token_2:
-        print(f"{t.persistent_id}, {t.tag}, {[tt.value for tt in t.value]}")
-    print()
-
-    for out_token in out_port_1.token_list[:-1]:
-        print(
-            f"{out_token.persistent_id}, {out_token.tag}, {[tt.value for tt in out_token.value]}"
-        )
-    for out_token in out_port_2.token_list[:-1]:
-        print(
-            f"{out_token.persistent_id}, {out_token.tag}, {[tt.value for tt in out_token.value]}"
-        )
-    print()
     # The tokens id produced by combinators depend on the order of input tokens.
     # The use of the alternative_expected_dependee parameter is necessary
     # For example:

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -74,10 +74,9 @@ async def test_combinator_step(context: StreamFlowContext):
     """Test saving and loading CombinatorStep with CartesianProductCombinator from database"""
     workflow = Workflow(context=context, name=utils.random_name(), config={})
     await workflow.save(context)
-    name = utils.random_name()
     step = workflow.create_step(
         cls=CombinatorStep,
-        name=name + "-combinator",
+        name=utils.random_name() + "-combinator",
         combinator=CartesianProductCombinator(
             name=utils.random_name(), workflow=workflow, depth=1
         ),
@@ -91,10 +90,9 @@ async def test_loop_combinator_step(context: StreamFlowContext):
     workflow = Workflow(context=context, name=utils.random_name(), config={})
     await workflow.save(context)
 
-    name = utils.random_name()
     step = workflow.create_step(
         cls=LoopCombinatorStep,
-        name=name + "-combinator",
+        name=utils.random_name() + "-loop-combinator",
         combinator=CartesianProductCombinator(
             name=utils.random_name(), workflow=workflow, depth=1
         ),
@@ -144,9 +142,6 @@ async def test_schedule_step(context: StreamFlowContext):
         name=posixpath.join(utils.random_name(), "__schedule__"),
         job_prefix="something",
         connector_ports=connector_ports,
-        input_directory=posixpath.join(*(utils.random_name() for _ in range(2))),
-        output_directory=posixpath.join(*(utils.random_name() for _ in range(2))),
-        tmp_directory=posixpath.join(*(utils.random_name() for _ in range(2))),
         binding_config=binding_config,
     )
     await save_load_and_test(schedule_step, context)
@@ -270,7 +265,7 @@ async def test_job_token(context: StreamFlowContext):
         value=Job(
             workflow_id=0,
             name=utils.random_name(),
-            inputs={"test": Token(value="jobtoken")},
+            inputs={"test": Token(value="job_token")},
             input_directory=utils.random_name(),
             output_directory=utils.random_name(),
             tmp_directory=utils.random_name(),

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -163,14 +163,14 @@ async def test_execute_step(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_gather_step(context: StreamFlowContext):
     """Test saving and loading GatherStep from database"""
-    workflow, ports = await create_workflow(context, num_port=1)
+    workflow, (port,) = await create_workflow(context, num_port=1)
     await workflow.save(context)
 
     step = workflow.create_step(
         cls=GatherStep,
         name=utils.random_name() + "-gather",
         depth=1,
-        size_port=ports[0],
+        size_port=port,
     )
     await save_load_and_test(step, context)
 

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -181,7 +181,7 @@ async def test_scatter_step(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_deploy_step(context: StreamFlowContext):
     """Test token provenance for DeployStep"""
-    workflow = (await create_workflow(context, num_port=0))[0]
+    workflow, _ = await create_workflow(context, num_port=0)
     step = create_deploy_step(workflow)
 
     await workflow.save(context)
@@ -199,7 +199,7 @@ async def test_deploy_step(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_schedule_step(context: StreamFlowContext):
     """Test token provenance for ScheduleStep"""
-    workflow = (await create_workflow(context, num_port=0))[0]
+    workflow, _ = await create_workflow(context, num_port=0)
     deploy_step = create_deploy_step(workflow)
     schedule_step = create_schedule_step(workflow, [deploy_step])
 

--- a/tests/test_remotepath.py
+++ b/tests/test_remotepath.py
@@ -98,13 +98,14 @@ async def test_download(context, connector, location):
         path_processor.join(parent_dir, "streamflow-0.1.6.zip"),
     ]
 
+    path = None
     for i, url in enumerate(urls):
         try:
             path = await remotepath.download(connector, [location], url, parent_dir)
             assert path == paths[i]
             assert await remotepath.exists(connector, location, path)
         finally:
-            if await remotepath.exists(connector, location, path):
+            if path and await remotepath.exists(connector, location, path):
                 await remotepath.rm(connector, location, path)
 
 

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -139,11 +139,9 @@ def dst_connector(context, dst_location) -> Connector:
 
 @pytest.mark.asyncio
 async def test_directory_to_directory(
-    context, src_connector, src_location, dst_connector, dst_location
-):
+    context: StreamFlowContext, communication_pattern: tuple[str, str]
+) -> None:
     """Test transferring a directory and its content from one location to another."""
-    src_path = None
-    dst_path = None
     # dir
     #   |- file_0
     #   |- file_1
@@ -161,6 +159,15 @@ async def test_directory_to_directory(
     #   |   |- file_1_2
     #   |- dir_2
     #   |   |   empty
+
+    src_location = await get_location(context, communication_pattern[0])
+    src_connector = context.deployment_manager.get_connector(src_location.deployment)
+    src_path = None
+
+    dst_location = await get_location(context, communication_pattern[1])
+    dst_connector = context.deployment_manager.get_connector(dst_location.deployment)
+    dst_path = None
+
     try:
         # create src structure
         src_path = await _create_tmp_dir(

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -4,7 +4,6 @@ import posixpath
 import tempfile
 
 import pytest
-import pytest_asyncio
 
 from streamflow.core import utils
 from streamflow.core.context import StreamFlowContext
@@ -117,26 +116,6 @@ async def _create_tmp_dir(context, connector, location, root=None, lvl=None, n_f
     return dir_path
 
 
-@pytest_asyncio.fixture(scope="module")
-async def src_location(context, deployment_src) -> ExecutionLocation:
-    return await get_location(context, deployment_src)
-
-
-@pytest.fixture(scope="module")
-def src_connector(context, src_location) -> Connector:
-    return context.deployment_manager.get_connector(src_location.deployment)
-
-
-@pytest_asyncio.fixture(scope="module")
-async def dst_location(context, deployment_dst) -> ExecutionLocation:
-    return await get_location(context, deployment_dst)
-
-
-@pytest.fixture(scope="module")
-def dst_connector(context, dst_location) -> Connector:
-    return context.deployment_manager.get_connector(dst_location.deployment)
-
-
 @pytest.mark.asyncio
 async def test_directory_to_directory(
     context: StreamFlowContext, communication_pattern: tuple[str, str]
@@ -241,9 +220,14 @@ async def test_directory_to_directory(
 
 @pytest.mark.asyncio
 async def test_file_to_directory(
-    context, src_connector, src_location, dst_connector, dst_location
-):
+    context: StreamFlowContext, communication_pattern: tuple[str, str]
+) -> None:
     """Test transferring a file from one location to a directory into another location."""
+    src_location = await get_location(context, communication_pattern[0])
+    src_connector = context.deployment_manager.get_connector(src_location.deployment)
+    dst_location = await get_location(context, communication_pattern[1])
+    dst_connector = context.deployment_manager.get_connector(dst_location.deployment)
+
     src_path = (
         os.path.join(tempfile.gettempdir(), utils.random_name())
         if src_location.local
@@ -297,9 +281,13 @@ async def test_file_to_directory(
 
 @pytest.mark.asyncio
 async def test_file_to_file(
-    context, src_connector, src_location, dst_connector, dst_location
+    context: StreamFlowContext, communication_pattern: tuple[str, str]
 ):
     """Test transferring a file from one location to another."""
+    src_location = await get_location(context, communication_pattern[0])
+    src_connector = context.deployment_manager.get_connector(src_location.deployment)
+    dst_location = await get_location(context, communication_pattern[1])
+    dst_connector = context.deployment_manager.get_connector(dst_location.deployment)
     src_path = (
         os.path.join(tempfile.gettempdir(), utils.random_name())
         if src_location.local
@@ -350,16 +338,12 @@ async def test_file_to_file(
 
 @pytest.mark.asyncio
 async def test_multiple_files(
-    context, src_connector, src_location, dst_connector, dst_location
+    context: StreamFlowContext, communication_pattern: tuple[str, str]
 ):
     """Test transferring multiple files simultaneously from one location to another."""
     await asyncio.gather(
         *(
-            asyncio.create_task(
-                test_file_to_file(
-                    context, src_connector, src_location, dst_connector, dst_location
-                )
-            )
+            asyncio.create_task(test_file_to_file(context, communication_pattern))
             for _ in range(20)
         )
     )


### PR DESCRIPTION
This commit refactors some unit tests.
- Improved `test_data_manager.py` using the appropriate library, `posixpath` or `os.path`, based on the connectors involved in the tests.
- Reduced number of tests on the remote-to-remote case in the `test_transfer`. Before this commit, all locations were tested with all the locations. However, it was redundant for the remote-to-remote case because it is enough to test a location if it is a sender and a receiver.
- Avoid a possible `undefined variable` error in a `try-except`, defining the variable before.