### PR TITLE
Refactored `remotepath` module

### DIFF
--- a/streamflow/core/data.py
+++ b/streamflow/core/data.py
@@ -112,11 +112,6 @@ class DataManager(SchemaEntity):
     ) -> None: ...
 
 
-class FileType(Enum):
-    FILE = 1
-    DIRECTORY = 2
-
-
 class StreamWrapper(ABC):
     def __init__(self, stream: Any):
         self.stream: Any = stream

--- a/streamflow/core/utils.py
+++ b/streamflow/core/utils.py
@@ -242,19 +242,6 @@ async def get_remote_to_remote_write_command(
             return ["tar", "xf", "-", "-C", posixpath.dirname(dst)]
 
 
-def get_size(path: str) -> int:
-    if os.path.isfile(path):
-        return os.path.getsize(path) if not os.path.islink(path) else 0
-    else:
-        total_size = 0
-        for dirpath, _, filenames in os.walk(path):
-            for f in filenames:
-                fp = os.path.join(dirpath, f)
-                if not os.path.islink(fp):
-                    total_size += os.path.getsize(fp)
-        return total_size
-
-
 def get_tag(tokens: Iterable[Token]) -> str:
     output_tag = "0"
     for tag in [t.tag for t in tokens]:

--- a/streamflow/core/workflow.py
+++ b/streamflow/core/workflow.py
@@ -436,12 +436,15 @@ class Token(PersistableEntity):
     async def save(self, context: StreamFlowContext, port_id: int | None = None):
         async with self.persistence_lock:
             if not self.persistent_id:
-                self.persistent_id = await context.database.add_token(
-                    port=port_id,
-                    tag=self.tag,
-                    type=type(self),
-                    value=json.dumps(await self._save_value(context)),
-                )
+                try:
+                    self.persistent_id = await context.database.add_token(
+                        port=port_id,
+                        tag=self.tag,
+                        type=type(self),
+                        value=json.dumps(await self._save_value(context)),
+                    )
+                except TypeError as e:
+                    raise WorkflowExecutionException from e
 
     def update(self, value: Any) -> Token:
         return self.__class__(tag=self.tag, value=value)

--- a/streamflow/cwl/processor.py
+++ b/streamflow/cwl/processor.py
@@ -485,7 +485,6 @@ class CWLCommandOutputProcessor(CommandOutputProcessor):
         command_output: CWLCommandOutput,
         connector: Connector | None,
         context: MutableMapping[str, Any],
-        output_directory: str,
     ):
         connector = self._get_connector(connector, job)
         locations = await self._get_locations(connector, job)
@@ -528,7 +527,6 @@ class CWLCommandOutputProcessor(CommandOutputProcessor):
                     globpath if isinstance(globpath, MutableSequence) else [globpath]
                 )
             # Resolve glob
-            path_processor = get_path_processor(connector)
             resolve_tasks = []
             for location in locations:
                 for path in globpaths:
@@ -553,11 +551,7 @@ class CWLCommandOutputProcessor(CommandOutputProcessor):
                                     if self.target
                                     else job.tmp_directory
                                 ),
-                                path=(
-                                    path_processor.join(output_directory, path)
-                                    if not path_processor.isabs(path)
-                                    else path
-                                ),
+                                path=cast(str, path),
                             )
                         )
                     )
@@ -690,7 +684,10 @@ class CWLCommandOutputProcessor(CommandOutputProcessor):
             hardware=self.workflow.context.scheduler.get_hardware(job.name),
         )
         token_value = await self._process_command_output(
-            job, command_output, connector, context, output_directory
+            job,
+            command_output,
+            connector,
+            context,
         )
         if isinstance(token_value, MutableSequence):
             for value in token_value:

--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -460,7 +460,9 @@ class DefaultScheduler(Scheduler):
                                                     )
                                                     for k, size in (
                                                         await remotepath.get_storage_usages(
-                                                            conn, loc, job_hardware
+                                                            self.context,
+                                                            loc,
+                                                            job_hardware,
                                                         )
                                                     ).items()
                                                 }

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -1,16 +1,14 @@
 import asyncio
 import os
-import posixpath
 import tempfile
 
 import pytest
 
 from streamflow.core import utils
 from streamflow.core.context import StreamFlowContext
-from streamflow.core.data import DataType, FileType
+from streamflow.core.data import DataType
 from streamflow.core.deployment import Connector, ExecutionLocation
-from streamflow.data import remotepath
-from streamflow.deployment.utils import get_path_processor
+from streamflow.data.remotepath import StreamFlowPath
 from tests.utils.deployment import get_location
 
 
@@ -18,56 +16,26 @@ async def _compare_remote_dirs(
     context: StreamFlowContext,
     src_connector: Connector,
     src_location: ExecutionLocation,
-    src_path: str,
+    src_path: StreamFlowPath,
     dst_connector: Connector,
     dst_location: ExecutionLocation,
-    dst_path: str,
+    dst_path: StreamFlowPath,
 ):
-    assert await remotepath.exists(dst_connector, dst_location, dst_path)
+    assert await dst_path.exists()
 
     # the two dirs must have the same elements order
-    src_files, dst_files = await asyncio.gather(
-        asyncio.create_task(
-            remotepath.listdir(src_connector, src_location, src_path, FileType.FILE)
-        ),
-        asyncio.create_task(
-            remotepath.listdir(dst_connector, dst_location, dst_path, FileType.FILE)
-        ),
-    )
+    src_path, src_dirs, src_files = await src_path.walk(
+        follow_symlinks=True
+    ).__anext__()
+    dst_path, dst_dirs, dst_files = await dst_path.walk(
+        follow_symlinks=True
+    ).__anext__()
     assert len(src_files) == len(dst_files)
     for src_file, dst_file in zip(sorted(src_files), sorted(dst_files)):
-        checksums = await asyncio.gather(
-            asyncio.create_task(
-                remotepath.checksum(
-                    context,
-                    src_connector,
-                    src_location,
-                    get_path_processor(src_connector).join(src_path, src_file),
-                )
-            ),
-            asyncio.create_task(
-                remotepath.checksum(
-                    context,
-                    dst_connector,
-                    dst_location,
-                    get_path_processor(dst_connector).join(dst_path, dst_file),
-                )
-            ),
+        assert (
+            await (src_path / src_file).checksum()
+            == await (dst_path / dst_file).checksum()
         )
-        assert checksums[0] == checksums[1]
-
-    src_dirs, dst_dirs = await asyncio.gather(
-        asyncio.create_task(
-            remotepath.listdir(
-                src_connector, src_location, src_path, FileType.DIRECTORY
-            )
-        ),
-        asyncio.create_task(
-            remotepath.listdir(
-                dst_connector, dst_location, dst_path, FileType.DIRECTORY
-            )
-        ),
-    )
     assert len(src_dirs) == len(dst_dirs)
     tasks = []
     for src_dir, dst_dir in zip(sorted(src_dirs), sorted(dst_dirs)):
@@ -78,41 +46,37 @@ async def _compare_remote_dirs(
                     context,
                     src_connector,
                     src_location,
-                    src_dir,
+                    src_path / src_dir,
                     dst_connector,
                     dst_location,
-                    dst_dir,
+                    dst_path / dst_dir,
                 )
             )
         )
     await asyncio.gather(*tasks)
 
 
-async def _create_tmp_dir(context, connector, location, root=None, lvl=None, n_files=0):
-    path_processor = get_path_processor(connector)
+async def _create_tmp_dir(
+    context, connector, location, root=None, lvl=None, n_files=0
+) -> StreamFlowPath:
     dir_lvl = f"-{lvl}" if lvl else ""
-    dir_path = (
-        os.path.join(
-            root if root else tempfile.gettempdir(),
-            f"dir{dir_lvl}-{utils.random_name()}",
-        )
-        if location.local
-        else os.path.join(
-            root if root else "/tmp", f"dir{dir_lvl}-{utils.random_name()}"
-        )
+    dir_path = StreamFlowPath(
+        (
+            root
+            if root is not None
+            else tempfile.gettempdir() if location.local else "/tmp"
+        ),
+        f"dir{dir_lvl}-{utils.random_name()}",
+        context=context,
+        location=location,
     )
-    await remotepath.mkdir(connector, location, dir_path)
+    await dir_path.mkdir(mode=0o777, parents=True)
 
-    dir_path = await remotepath.follow_symlink(context, connector, location, dir_path)
+    dir_path = await dir_path.resolve()
     file_lvl = f"-{lvl}" if lvl else ""
     for i in range(n_files):
         file_name = f"file{file_lvl}-{i}-{utils.random_name()}"
-        await remotepath.write(
-            connector,
-            location,
-            path_processor.join(dir_path, file_name),
-            f"Hello from {file_name}",
-        )
+        await (dir_path / file_name).write_text(f"Hello from {file_name}")
     return dir_path
 
 
@@ -170,36 +134,35 @@ async def test_directory_to_directory(
                     n_files=2,
                     lvl=f"{i}-0",
                 )
-        src_path = await remotepath.follow_symlink(
-            context, src_connector, src_location, src_path
-        )
+        src_path = await src_path.resolve()
 
         # dst init
-        dst_path = (
-            os.path.join(tempfile.gettempdir(), utils.random_name())
-            if dst_location.local
-            else posixpath.join("/tmp", utils.random_name())
+        dst_path = StreamFlowPath(
+            tempfile.gettempdir() if dst_location.local else "/tmp",
+            utils.random_name(),
+            context=context,
+            location=dst_location,
         )
 
         # save src_path into StreamFlow
         context.data_manager.register_path(
             location=src_location,
-            path=src_path,
-            relpath=src_path,
+            path=str(src_path),
+            relpath=str(src_path),
             data_type=DataType.PRIMARY,
         )
 
         # transfer src_path to dst_path
         await context.data_manager.transfer_data(
             src_location=src_location,
-            src_path=src_path,
+            src_path=str(src_path),
             dst_locations=[dst_location],
-            dst_path=dst_path,
+            dst_path=str(dst_path),
             writable=False,
         )
 
         # check if dst exists
-        await remotepath.exists(dst_connector, dst_location, dst_path)
+        await dst_path.exists()
 
         # check that src and dst have the same sub dirs and files
         await _compare_remote_dirs(
@@ -212,10 +175,8 @@ async def test_directory_to_directory(
             dst_path,
         )
     finally:
-        if src_path:
-            await remotepath.rm(src_connector, src_location, src_path)
-        if dst_path:
-            await remotepath.rm(dst_connector, dst_location, dst_path)
+        await src_path.rmtree()
+        await dst_path.rmtree()
 
 
 @pytest.mark.asyncio
@@ -224,59 +185,43 @@ async def test_file_to_directory(
 ) -> None:
     """Test transferring a file from one location to a directory into another location."""
     src_location = await get_location(context, communication_pattern[0])
-    src_connector = context.deployment_manager.get_connector(src_location.deployment)
     dst_location = await get_location(context, communication_pattern[1])
-    dst_connector = context.deployment_manager.get_connector(dst_location.deployment)
 
-    src_path = (
-        os.path.join(tempfile.gettempdir(), utils.random_name())
-        if src_location.local
-        else posixpath.join("/tmp", utils.random_name())
+    src_path = StreamFlowPath(
+        tempfile.gettempdir() if src_location.local else "/tmp",
+        utils.random_name(),
+        context=context,
+        location=src_location,
     )
-    dst_path = (
-        os.path.join(tempfile.gettempdir(), utils.random_name())
-        if dst_location.local
-        else posixpath.join("/tmp", utils.random_name())
+    dst_path = StreamFlowPath(
+        tempfile.gettempdir() if src_location.local else "/tmp",
+        utils.random_name(),
+        context=context,
+        location=dst_location,
     )
-    await remotepath.mkdir(dst_connector, dst_location, dst_path)
+    await dst_path.mkdir(mode=0o777, exist_ok=True)
     try:
-        await remotepath.write(src_connector, src_location, src_path, "StreamFlow")
-        src_path = await remotepath.follow_symlink(
-            context, src_connector, src_location, src_path
-        )
-        src_digest = await remotepath.checksum(
-            context, src_connector, src_location, src_path
-        )
-        src_name = get_path_processor(src_connector).basename(src_path)
+        await src_path.write_text("StreamFlow")
+        src_path = await src_path.resolve()
         context.data_manager.register_path(
             location=src_location,
-            path=await remotepath.follow_symlink(
-                context, src_connector, src_location, src_path
-            ),
-            relpath=src_path,
+            path=str(src_path),
+            relpath=str(src_path),
             data_type=DataType.PRIMARY,
         )
         await context.data_manager.transfer_data(
             src_location=src_location,
-            src_path=src_path,
+            src_path=str(src_path),
             dst_locations=[dst_location],
-            dst_path=dst_path,
+            dst_path=str(dst_path),
             writable=False,
         )
-        path_processor = get_path_processor(dst_connector)
-        assert await remotepath.exists(
-            dst_connector, dst_location, path_processor.join(dst_path, src_name)
-        )
-        dst_digest = await remotepath.checksum(
-            context,
-            dst_connector,
-            dst_location,
-            path_processor.join(dst_path, src_name),
-        )
-        assert src_digest == dst_digest
+        dst_file = dst_path / src_path.name
+        assert await dst_file.exists()
+        assert await src_path.checksum() == await dst_file.checksum()
     finally:
-        await remotepath.rm(src_connector, src_location, src_path)
-        await remotepath.rm(dst_connector, dst_location, dst_path)
+        await src_path.rmtree()
+        await dst_path.rmtree()
 
 
 @pytest.mark.asyncio
@@ -285,55 +230,41 @@ async def test_file_to_file(
 ):
     """Test transferring a file from one location to another."""
     src_location = await get_location(context, communication_pattern[0])
-    src_connector = context.deployment_manager.get_connector(src_location.deployment)
     dst_location = await get_location(context, communication_pattern[1])
-    dst_connector = context.deployment_manager.get_connector(dst_location.deployment)
-    src_path = (
-        os.path.join(tempfile.gettempdir(), utils.random_name())
-        if src_location.local
-        else posixpath.join("/tmp", utils.random_name())
+
+    src_path = StreamFlowPath(
+        tempfile.gettempdir() if src_location.local else "/tmp",
+        utils.random_name(),
+        context=context,
+        location=src_location,
     )
-    dst_path = (
-        os.path.join(tempfile.gettempdir(), utils.random_name())
-        if dst_location.local
-        else posixpath.join("/tmp", utils.random_name())
+    dst_path = StreamFlowPath(
+        tempfile.gettempdir() if src_location.local else "/tmp",
+        utils.random_name(),
+        context=context,
+        location=dst_location,
     )
     try:
-        await remotepath.write(
-            src_connector,
-            src_location,
-            src_path,
-            "StreamFlow",
-        )
-        src_path = await remotepath.follow_symlink(
-            context, src_connector, src_location, src_path
-        )
-        src_digest = await remotepath.checksum(
-            context, src_connector, src_location, src_path
-        )
+        await src_path.write_text("StreamFlow")
+        src_path = await src_path.resolve()
         context.data_manager.register_path(
             location=src_location,
-            path=await remotepath.follow_symlink(
-                context, src_connector, src_location, src_path
-            ),
-            relpath=src_path,
+            path=str(src_path),
+            relpath=str(src_path),
             data_type=DataType.PRIMARY,
         )
         await context.data_manager.transfer_data(
             src_location=src_location,
-            src_path=src_path,
+            src_path=str(src_path),
             dst_locations=[dst_location],
-            dst_path=dst_path,
+            dst_path=str(dst_path),
             writable=False,
         )
-        assert await remotepath.exists(dst_connector, dst_location, dst_path)
-        dst_digest = await remotepath.checksum(
-            context, dst_connector, dst_location, dst_path
-        )
-        assert src_digest == dst_digest
+        assert await dst_path.exists()
+        assert await src_path.checksum() == await dst_path.checksum()
     finally:
-        await remotepath.rm(src_connector, src_location, src_path)
-        await remotepath.rm(dst_connector, dst_location, dst_path)
+        await src_path.rmtree()
+        await dst_path.rmtree()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This commit modifies the `remotepath` module by encapsulating the path management logic inside a `StreamFlowPath` abstract class, which in turn translates to two alternative concrete implementations: `LocalStreamFlowPath` for local files and `RemoteStreamFlowPath` for remote ones. The implemented logic mimics the Python `pathlib` module, with two important differences:
- All the potentially-remote functions are `async`;
- Some additional functions (e.g., `size` or `checksum`) have been added to simplify fiel management in StreamFlow.