### PR TITLE
Removed residual Python 3.8 code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ format-check:
 	black --diff --check streamflow tests
 
 pyupgrade:
-	pyupgrade --py3-only --py38-plus $(shell git ls-files | grep .py | grep -v streamflow/cwl/antlr)
+	pyupgrade --py3-only --py39-plus $(shell git ls-files | grep .py | grep -v streamflow/cwl/antlr)
 
 test:
 	python -m pytest -rs ${PYTEST_EXTRA}

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -10,11 +10,10 @@ from pathlib import PurePosixPath
 from types import ModuleType
 from typing import (
     Any,
-    MutableMapping,
-    MutableSequence,
     cast,
     get_args,
 )
+from collections.abc import MutableMapping, MutableSequence
 
 import cwl_utils.parser
 import cwl_utils.parser.utils

--- a/tests/test_build_wf.py
+++ b/tests/test_build_wf.py
@@ -1,6 +1,5 @@
-from typing import Type, cast
-
 import pytest
+from typing import cast
 
 from streamflow.core import utils
 from streamflow.core.config import BindingConfig
@@ -74,7 +73,7 @@ async def _clone_step(step, workflow, context):
     return new_workflow, new_step
 
 
-async def _general_test_port(context: StreamFlowContext, cls_port: Type[Port]):
+async def _general_test_port(context: StreamFlowContext, cls_port: type[Port]):
     workflow, ports = await create_workflow(context)
     port = workflow.create_port(cls_port)
     await workflow.save(context)
@@ -325,7 +324,7 @@ async def test_schedule_step(context: StreamFlowContext):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("port_cls", [Port, JobPort, ConnectorPort])
-async def test_port(context: StreamFlowContext, port_cls: Type[Port]):
+async def test_port(context: StreamFlowContext, port_cls: type[Port]):
     """Test saving Port on database and re-load it in a new Workflow"""
     await _general_test_port(context, port_cls)
 

--- a/tests/test_cwl_build_wf.py
+++ b/tests/test_cwl_build_wf.py
@@ -1,7 +1,7 @@
-import posixpath
-from typing import Type, cast
-
 import pytest
+import posixpath
+from typing import cast
+
 
 from streamflow.core import utils
 from streamflow.core.context import StreamFlowContext
@@ -45,7 +45,7 @@ from tests.utils.workflow import create_workflow
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("step_cls", [CWLLoopOutputAllStep, CWLLoopOutputLastStep])
-async def test_cwl_loop_output(context: StreamFlowContext, step_cls: Type[Step]):
+async def test_cwl_loop_output(context: StreamFlowContext, step_cls: type[Step]):
     """Test saving CWLLoopOutputAllStep on database and re-load it in a new Workflow"""
     workflow, _ = await create_workflow(context, num_port=0)
     await _base_step_test_process(
@@ -181,7 +181,7 @@ async def test_loop_value_from_transformer(context: StreamFlowContext):
     [AllNonNullTransformer, FirstNonNullTransformer, OnlyNonNullTransformer],
 )
 async def test_non_null_transformer(
-    context: StreamFlowContext, transformer_cls: Type[Step]
+    context: StreamFlowContext, transformer_cls: type[Step]
 ):
     """Test saving All/First/Only NonNullTransformer on database and re-load it in a new Workflow"""
     workflow, _ = await create_workflow(context, num_port=0)


### PR DESCRIPTION
This commit upgrades the `pyupgrade` target Python version to Python 3.9 and it adapts the code accordingly, completing the work initiated in #561 
