### PR TITLE
Add `isort` to the lint pipeline

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -71,7 +71,7 @@ jobs:
         with:
           node-version: "20"
       - name: "Install Docker (MacOS X)"
-        uses: douglascamata/setup-docker-macos-action@main
+        uses: douglascamata/setup-docker-macos-action@v1-alpha.15
         with:
           colima-additional-options: '--mount /private/var/folders:w --mount-type virtiofs'
         if: ${{ startsWith(matrix.on, 'macos-') }}
@@ -242,7 +242,7 @@ jobs:
         with:
           node-version: "20"
       - name: "Install Docker (MacOs X)"
-        uses: douglascamata/setup-docker-macos-action@main
+        uses: douglascamata/setup-docker-macos-action@v1-alpha.15
         with:
           colima-additional-options: '--mount /private/var/folders:w --mount-type virtiofs'
         if: ${{ startsWith(matrix.on, 'macos-') }}

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,11 @@ flake8:
 	flake8 --exclude streamflow/cwl/antlr streamflow tests
 
 format:
+	isort streamflow tests
 	black streamflow tests
 
 format-check:
+	isort --check-only streamflow tests
 	black --diff --check streamflow tests
 
 pyupgrade:

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,4 +1,5 @@
 black==24.10.0
 codespell==2.3.0
 flake8-bugbear==24.10.31
+isort==5.13.2
 pyupgrade==3.19.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,3 +115,7 @@ omit = [
 
 [tool.black]
 exclude = "streamflow/cwl/antlr"
+
+[tool.isort]
+profile = "black"
+skip = "streamflow/cwl/antlr"

--- a/streamflow/config/schema.py
+++ b/streamflow/config/schema.py
@@ -2,18 +2,13 @@ from importlib.resources import files
 
 from streamflow.config import ext_schemas
 from streamflow.core.config import Schema
-from streamflow.cwl.requirement.docker import (
-    cwl_docker_translator_classes,
-)
+from streamflow.cwl.requirement.docker import cwl_docker_translator_classes
 from streamflow.data import data_manager_classes
 from streamflow.deployment import deployment_manager_classes
 from streamflow.deployment.connector import connector_classes
 from streamflow.deployment.filter import binding_filter_classes
 from streamflow.persistence import database_classes
-from streamflow.recovery import (
-    checkpoint_manager_classes,
-    failure_manager_classes,
-)
+from streamflow.recovery import checkpoint_manager_classes, failure_manager_classes
 from streamflow.scheduling import scheduler_classes
 from streamflow.scheduling.policy import policy_classes
 

--- a/streamflow/core/config.py
+++ b/streamflow/core/config.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import asyncio
 import json
 import posixpath
-from collections.abc import MutableSequence, MutableMapping
-from typing import Any, TYPE_CHECKING, cast
+from collections.abc import MutableMapping, MutableSequence
+from typing import TYPE_CHECKING, Any, cast
 
 from referencing import Registry, Resource
 
@@ -12,7 +12,7 @@ from streamflow.core.exception import WorkflowDefinitionException
 
 if TYPE_CHECKING:
     from streamflow.core.context import SchemaEntity, StreamFlowContext
-    from streamflow.core.deployment import Target, FilterConfig
+    from streamflow.core.deployment import FilterConfig, Target
     from streamflow.core.persistence import DatabaseLoadingContext
 
 

--- a/streamflow/core/context.py
+++ b/streamflow/core/context.py
@@ -4,7 +4,7 @@ import asyncio
 from abc import ABC, abstractmethod
 from collections.abc import MutableMapping
 from concurrent.futures import ProcessPoolExecutor
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from streamflow.log_handler import logger
 

--- a/streamflow/core/data.py
+++ b/streamflow/core/data.py
@@ -9,9 +9,10 @@ from typing import TYPE_CHECKING
 from streamflow.core.context import SchemaEntity
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from streamflow.core.context import StreamFlowContext
     from streamflow.core.deployment import ExecutionLocation
-    from typing import Any
 
 
 class DataType(Enum):

--- a/streamflow/core/deployment.py
+++ b/streamflow/core/deployment.py
@@ -15,11 +15,12 @@ from streamflow.core.context import SchemaEntity
 from streamflow.core.persistence import DatabaseLoadingContext, PersistableEntity
 
 if TYPE_CHECKING:
-    from streamflow.core.data import StreamWrapperContextManager
+    from typing import Any
+
     from streamflow.core.context import StreamFlowContext
+    from streamflow.core.data import StreamWrapperContextManager
     from streamflow.core.scheduling import AvailableLocation
     from streamflow.core.workflow import Job
-    from typing import Any
 
 
 class ExecutionLocation:

--- a/streamflow/core/persistence.py
+++ b/streamflow/core/persistence.py
@@ -4,12 +4,12 @@ from abc import ABC, abstractmethod
 from asyncio import Lock
 from collections.abc import MutableMapping, MutableSequence
 from enum import Enum
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from streamflow.core.context import SchemaEntity, StreamFlowContext
 
 if TYPE_CHECKING:
-    from streamflow.core.deployment import DeploymentConfig, Target, FilterConfig
+    from streamflow.core.deployment import DeploymentConfig, FilterConfig, Target
     from streamflow.core.workflow import Port, Step, Token, Workflow
 
 

--- a/streamflow/core/provenance.py
+++ b/streamflow/core/provenance.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from collections.abc import MutableSequence, MutableMapping
+from collections.abc import MutableMapping, MutableSequence
 from typing import TYPE_CHECKING
 
 from streamflow.core.persistence import DatabaseLoadingContext

--- a/streamflow/core/recovery.py
+++ b/streamflow/core/recovery.py
@@ -7,10 +7,11 @@ from typing import TYPE_CHECKING
 from streamflow.core.context import SchemaEntity
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from streamflow.core.context import StreamFlowContext
     from streamflow.core.data import DataLocation
-    from streamflow.core.workflow import Job, CommandOutput, Step
-    from typing import Any
+    from streamflow.core.workflow import CommandOutput, Job, Step
 
 
 class CheckpointManager(SchemaEntity):

--- a/streamflow/core/scheduling.py
+++ b/streamflow/core/scheduling.py
@@ -4,10 +4,10 @@ import copy
 import os
 from abc import ABC, abstractmethod
 from collections.abc import (
-    MutableSequence,
-    MutableMapping,
-    Iterable,
     Callable,
+    Iterable,
+    MutableMapping,
+    MutableSequence,
     MutableSet,
 )
 from typing import TYPE_CHECKING, cast
@@ -20,9 +20,10 @@ from streamflow.core.exception import WorkflowExecutionException
 from streamflow.core.persistence import DatabaseLoadingContext
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from streamflow.core.deployment import Connector, Target
     from streamflow.core.workflow import Job, Status
-    from typing import Any
 
 
 def _check_storages(hardware_a: Hardware, hardware_b: Hardware) -> None:

--- a/streamflow/core/utils.py
+++ b/streamflow/core/utils.py
@@ -9,8 +9,8 @@ import os
 import posixpath
 import shlex
 import uuid
-from collections.abc import MutableSequence, MutableMapping, Iterable
-from typing import Any, TYPE_CHECKING
+from collections.abc import Iterable, MutableMapping, MutableSequence
+from typing import TYPE_CHECKING, Any
 
 from streamflow.core.exception import WorkflowExecutionException
 

--- a/streamflow/core/workflow.py
+++ b/streamflow/core/workflow.py
@@ -18,8 +18,9 @@ from streamflow.core.persistence import (
 )
 
 if TYPE_CHECKING:
-    from streamflow.core.context import StreamFlowContext
     from typing import Any
+
+    from streamflow.core.context import StreamFlowContext
 
 
 class Executor(ABC):

--- a/streamflow/cwl/combinator.py
+++ b/streamflow/cwl/combinator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import MutableSequence, MutableMapping, AsyncIterable
+from collections.abc import AsyncIterable, MutableMapping, MutableSequence
 from typing import Any, cast
 
 from streamflow.core.context import StreamFlowContext

--- a/streamflow/cwl/command.py
+++ b/streamflow/cwl/command.py
@@ -8,10 +8,10 @@ import posixpath
 import shlex
 import time
 from asyncio.subprocess import STDOUT
-from collections.abc import MutableSequence, MutableMapping
+from collections.abc import MutableMapping, MutableSequence
 from decimal import Decimal
 from types import ModuleType
-from typing import Any, IO, cast
+from typing import IO, Any, cast
 
 from ruamel.yaml import RoundTripRepresenter
 from ruamel.yaml.scalarfloat import ScalarFloat
@@ -35,17 +35,8 @@ from streamflow.core.exception import (
     WorkflowExecutionException,
 )
 from streamflow.core.persistence import DatabaseLoadingContext
-from streamflow.core.utils import (
-    flatten_list,
-    get_tag,
-)
-from streamflow.core.workflow import (
-    Job,
-    Status,
-    Step,
-    Token,
-    Workflow,
-)
+from streamflow.core.utils import flatten_list, get_tag
+from streamflow.core.workflow import Job, Status, Step, Token, Workflow
 from streamflow.cwl import utils
 from streamflow.cwl.processor import (
     CWLCommandOutput,

--- a/streamflow/cwl/hardware.py
+++ b/streamflow/cwl/hardware.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import math
 import os
-from collections.abc import MutableSequence, MutableMapping
-from typing import Any, TYPE_CHECKING
+from collections.abc import MutableMapping, MutableSequence
+from typing import TYPE_CHECKING, Any
 
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.persistence import DatabaseLoadingContext

--- a/streamflow/cwl/processor.py
+++ b/streamflow/cwl/processor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from collections.abc import MutableSequence, MutableMapping, Callable
+from collections.abc import Callable, MutableMapping, MutableSequence
 from typing import Any, cast
 
 import cwl_utils.file_formats
@@ -11,11 +11,7 @@ from schema_salad.exceptions import ValidationException
 
 from streamflow.core.command import CommandOutput, CommandOutputProcessor
 from streamflow.core.context import StreamFlowContext
-from streamflow.core.deployment import (
-    Connector,
-    LocalTarget,
-    Target,
-)
+from streamflow.core.deployment import Connector, LocalTarget, Target
 from streamflow.core.exception import (
     WorkflowDefinitionException,
     WorkflowExecutionException,

--- a/streamflow/cwl/requirement/docker/docker.py
+++ b/streamflow/cwl/requirement/docker/docker.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 import posixpath
 from collections.abc import MutableSequence
-
 from importlib.resources import files
 
 from streamflow.core import utils

--- a/streamflow/cwl/requirement/docker/kubernetes.py
+++ b/streamflow/cwl/requirement/docker/kubernetes.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import tempfile
-
 from importlib.resources import files
+
 from jinja2 import Template
 
 from streamflow.core import utils

--- a/streamflow/cwl/requirement/docker/singularity.py
+++ b/streamflow/cwl/requirement/docker/singularity.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 import posixpath
 from collections.abc import MutableSequence
-
 from importlib.resources import files
 
 from streamflow.core import utils

--- a/streamflow/cwl/step.py
+++ b/streamflow/cwl/step.py
@@ -5,7 +5,7 @@ import json
 import logging
 import urllib.parse
 from abc import ABC
-from collections.abc import MutableSequence, MutableMapping
+from collections.abc import MutableMapping, MutableSequence
 from typing import Any, cast
 
 from streamflow.core.context import StreamFlowContext
@@ -36,9 +36,9 @@ from streamflow.workflow.step import (
     ConditionalStep,
     InputInjectorStep,
     LoopOutputStep,
+    ScheduleStep,
     TransferStep,
     _get_token_ids,
-    ScheduleStep,
 )
 from streamflow.workflow.token import IterationTerminationToken, ListToken, ObjectToken
 

--- a/streamflow/cwl/transformer.py
+++ b/streamflow/cwl/transformer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import functools
 import json
-from collections.abc import MutableSequence, MutableMapping
+from collections.abc import MutableMapping, MutableSequence
 from typing import Any, cast
 
 from streamflow.core.context import StreamFlowContext

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -5,15 +5,11 @@ import logging
 import os
 import posixpath
 import urllib.parse
+from collections.abc import MutableMapping, MutableSequence
 from enum import Enum
 from pathlib import PurePosixPath
 from types import ModuleType
-from typing import (
-    Any,
-    cast,
-    get_args,
-)
-from collections.abc import MutableMapping, MutableSequence
+from typing import Any, cast, get_args
 
 import cwl_utils.parser
 import cwl_utils.parser.utils
@@ -34,13 +30,7 @@ from streamflow.core.deployment import (
     Target,
 )
 from streamflow.core.exception import WorkflowDefinitionException
-from streamflow.core.workflow import (
-    Port,
-    Step,
-    Token,
-    TokenProcessor,
-    Workflow,
-)
+from streamflow.core.workflow import Port, Step, Token, TokenProcessor, Workflow
 from streamflow.cwl import utils
 from streamflow.cwl.combinator import ListMergeCombinator
 from streamflow.cwl.command import (
@@ -79,9 +69,9 @@ from streamflow.cwl.step import (
 )
 from streamflow.cwl.transformer import (
     AllNonNullTransformer,
-    CWLTokenTransformer,
     CartesianProductSizeTransformer,
     CloneTransformer,
+    CWLTokenTransformer,
     DefaultRetagTransformer,
     DefaultTransformer,
     DotProductSizeTransformer,

--- a/streamflow/data/remotepath.py
+++ b/streamflow/data/remotepath.py
@@ -15,7 +15,7 @@ import aiohttp
 from aiohttp import ClientResponse
 
 from streamflow.core import utils
-from streamflow.core.data import FileType, DataType
+from streamflow.core.data import DataType, FileType
 from streamflow.core.exception import WorkflowExecutionException
 
 if TYPE_CHECKING:

--- a/streamflow/deployment/connector/base.py
+++ b/streamflow/deployment/connector/base.py
@@ -13,10 +13,7 @@ from typing import Any
 
 from streamflow.core import utils
 from streamflow.core.data import StreamWrapperContextManager
-from streamflow.core.deployment import (
-    Connector,
-    ExecutionLocation,
-)
+from streamflow.core.deployment import Connector, ExecutionLocation
 from streamflow.core.exception import WorkflowExecutionException
 from streamflow.core.utils import get_local_to_remote_destination
 from streamflow.deployment import aiotarstream
@@ -26,7 +23,6 @@ from streamflow.deployment.stream import (
     SubprocessStreamWriterWrapperContextManager,
 )
 from streamflow.log_handler import logger
-
 
 FS_TYPES_TO_SKIP = {
     "-",

--- a/streamflow/deployment/connector/container.py
+++ b/streamflow/deployment/connector/container.py
@@ -28,8 +28,8 @@ from streamflow.core.utils import (
     random_name,
 )
 from streamflow.deployment.connector.base import (
-    BatchConnector,
     FS_TYPES_TO_SKIP,
+    BatchConnector,
     copy_local_to_remote,
     copy_remote_to_local,
     copy_remote_to_remote,

--- a/streamflow/deployment/connector/local.py
+++ b/streamflow/deployment/connector/local.py
@@ -16,7 +16,7 @@ import psutil
 from streamflow.core import utils
 from streamflow.core.deployment import Connector, ExecutionLocation
 from streamflow.core.scheduling import AvailableLocation, Hardware, Storage
-from streamflow.deployment.connector.base import BaseConnector, FS_TYPES_TO_SKIP
+from streamflow.deployment.connector.base import FS_TYPES_TO_SKIP, BaseConnector
 from streamflow.log_handler import logger
 
 

--- a/streamflow/deployment/connector/occam.py
+++ b/streamflow/deployment/connector/occam.py
@@ -5,11 +5,11 @@ import logging
 import os
 import posixpath
 import re
-from collections.abc import MutableSequence, MutableMapping
+from collections.abc import MutableMapping, MutableSequence
+from importlib.resources import files
 from typing import Any
 
 import asyncssh
-from importlib.resources import files
 from ruamel.yaml import YAML
 
 from streamflow.core import utils

--- a/streamflow/deployment/connector/queue_manager.py
+++ b/streamflow/deployment/connector/queue_manager.py
@@ -9,10 +9,10 @@ import shlex
 from abc import ABC, abstractmethod
 from collections.abc import MutableMapping, MutableSequence
 from functools import partial
+from importlib.resources import files
 from typing import Any, cast
 
 import cachetools
-from importlib.resources import files
 
 from streamflow.core import utils
 from streamflow.core.asyncache import cachedmethod

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -17,8 +17,8 @@ from streamflow.core.deployment import Connector, ExecutionLocation
 from streamflow.core.exception import WorkflowExecutionException
 from streamflow.core.scheduling import AvailableLocation, Hardware, Storage
 from streamflow.deployment.connector.base import (
-    BaseConnector,
     FS_TYPES_TO_SKIP,
+    BaseConnector,
     copy_remote_to_remote,
     copy_same_connector,
 )

--- a/streamflow/deployment/filter/shuffle.py
+++ b/streamflow/deployment/filter/shuffle.py
@@ -1,6 +1,5 @@
 import random
 from collections.abc import MutableSequence
-
 from importlib.resources import files
 
 from streamflow.core.deployment import BindingFilter, Target

--- a/streamflow/deployment/future.py
+++ b/streamflow/deployment/future.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from abc import ABCMeta
 from collections.abc import MutableMapping, MutableSequence
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from streamflow.core.deployment import Connector, ExecutionLocation
 from streamflow.core.exception import WorkflowExecutionException

--- a/streamflow/deployment/utils.py
+++ b/streamflow/deployment/utils.py
@@ -6,7 +6,7 @@ import posixpath
 from collections.abc import MutableMapping
 from pathlib import PurePosixPath
 from types import ModuleType
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from streamflow.core.config import BindingConfig
 from streamflow.core.deployment import (

--- a/streamflow/deployment/wrapper.py
+++ b/streamflow/deployment/wrapper.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from abc import ABC
-from collections.abc import MutableSequence, MutableMapping
+from collections.abc import MutableMapping, MutableSequence
 from typing import Any
 
 from streamflow.core.data import StreamWrapperContextManager

--- a/streamflow/ext/plugin.py
+++ b/streamflow/ext/plugin.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import MutableSequence, MutableMapping
+from collections.abc import MutableMapping, MutableSequence
 from typing import Any
 
 from streamflow.config import ext_schemas

--- a/streamflow/persistence/sqlite.py
+++ b/streamflow/persistence/sqlite.py
@@ -4,10 +4,10 @@ import asyncio
 import json
 import os
 from collections.abc import MutableMapping, MutableSequence
+from importlib.resources import files
 from typing import Any, cast
 
 import aiosqlite
-from importlib.resources import files
 
 from streamflow.core import utils
 from streamflow.core.asyncache import cachedmethod

--- a/streamflow/recovery/checkpoint_manager.py
+++ b/streamflow/recovery/checkpoint_manager.py
@@ -4,9 +4,8 @@ import asyncio
 import os
 import tempfile
 from collections.abc import MutableSequence
-from typing import TYPE_CHECKING
-
 from importlib.resources import files
+from typing import TYPE_CHECKING
 
 from streamflow.core import utils
 from streamflow.core.data import DataLocation

--- a/streamflow/recovery/failure_manager.py
+++ b/streamflow/recovery/failure_manager.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import MutableMapping
-from typing import cast
-
 from importlib.resources import files
+from typing import cast
 
 from streamflow.core.command import CommandOutput
 from streamflow.core.context import StreamFlowContext
@@ -15,13 +14,7 @@ from streamflow.core.exception import (
     UnrecoverableTokenException,
 )
 from streamflow.core.recovery import FailureManager, ReplayRequest, ReplayResponse
-from streamflow.core.workflow import (
-    Job,
-    Status,
-    Step,
-    Token,
-    TokenProcessor,
-)
+from streamflow.core.workflow import Job, Status, Step, Token, TokenProcessor
 from streamflow.data import remotepath
 from streamflow.log_handler import logger
 from streamflow.recovery.recovery import JobVersion

--- a/streamflow/scheduling/policy/data_locality.py
+++ b/streamflow/scheduling/policy/data_locality.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import MutableMapping
-from typing import TYPE_CHECKING
-
 from importlib.resources import files
+from typing import TYPE_CHECKING
 
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.data import DataType

--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -6,9 +6,8 @@ import logging
 import os
 import posixpath
 from collections.abc import MutableMapping, MutableSequence
-from typing import TYPE_CHECKING, cast
-
 from importlib.resources import files
+from typing import TYPE_CHECKING, cast
 
 from streamflow.core.config import BindingConfig, Config
 from streamflow.core.deployment import BindingFilter, Connector, FilterConfig, Target

--- a/streamflow/workflow/combinator.py
+++ b/streamflow/workflow/combinator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import deque
-from collections.abc import MutableMapping, MutableSequence, AsyncIterable
+from collections.abc import AsyncIterable, MutableMapping, MutableSequence
 from typing import Any, cast
 
 from streamflow.core import utils

--- a/streamflow/workflow/executor.py
+++ b/streamflow/workflow/executor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from collections.abc import MutableSequence, MutableMapping
+from collections.abc import MutableMapping, MutableSequence
 from typing import TYPE_CHECKING, cast
 
 from streamflow.core import utils
@@ -13,8 +13,9 @@ from streamflow.workflow.token import TerminationToken
 from streamflow.workflow.utils import get_token_value
 
 if TYPE_CHECKING:
-    from streamflow.core.workflow import Workflow
     from typing import Any
+
+    from streamflow.core.workflow import Workflow
 
 
 class StreamFlowExecutor(Executor):

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -6,7 +6,7 @@ import logging
 import posixpath
 from abc import ABC, abstractmethod
 from collections import deque
-from collections.abc import MutableSequence, MutableMapping, AsyncIterable, MutableSet
+from collections.abc import AsyncIterable, MutableMapping, MutableSequence, MutableSet
 from types import ModuleType
 from typing import Any, cast
 
@@ -27,14 +27,7 @@ from streamflow.core.exception import (
 )
 from streamflow.core.persistence import DatabaseLoadingContext
 from streamflow.core.scheduling import HardwareRequirement
-from streamflow.core.workflow import (
-    Job,
-    Port,
-    Status,
-    Step,
-    Token,
-    Workflow,
-)
+from streamflow.core.workflow import Job, Port, Status, Step, Token, Workflow
 from streamflow.data import remotepath
 from streamflow.deployment.utils import get_path_processor
 from streamflow.log_handler import logger

--- a/streamflow/workflow/token.py
+++ b/streamflow/workflow/token.py
@@ -9,7 +9,7 @@ from typing import Any
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.exception import WorkflowExecutionException
 from streamflow.core.persistence import DatabaseLoadingContext
-from streamflow.core.workflow import Job, Token, Status
+from streamflow.core.workflow import Job, Status, Token
 
 
 class IterationTerminationToken(Token):

--- a/tests/test_build_wf.py
+++ b/tests/test_build_wf.py
@@ -1,5 +1,6 @@
-import pytest
 from typing import cast
+
+import pytest
 
 from streamflow.core import utils
 from streamflow.core.config import BindingConfig

--- a/tests/test_cwl_build_wf.py
+++ b/tests/test_cwl_build_wf.py
@@ -2,6 +2,7 @@ import pytest
 import posixpath
 from typing import cast
 
+
 from streamflow.core import utils
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.workflow import Step

--- a/tests/test_cwl_build_wf.py
+++ b/tests/test_cwl_build_wf.py
@@ -1,7 +1,7 @@
-import pytest
 import posixpath
 from typing import cast
 
+import pytest
 
 from streamflow.core import utils
 from streamflow.core.context import StreamFlowContext

--- a/tests/test_cwl_provenance.py
+++ b/tests/test_cwl_provenance.py
@@ -21,9 +21,9 @@ from streamflow.cwl.step import (
 )
 from streamflow.cwl.transformer import (
     AllNonNullTransformer,
-    CWLTokenTransformer,
     CartesianProductSizeTransformer,
     CloneTransformer,
+    CWLTokenTransformer,
     DefaultRetagTransformer,
     DefaultTransformer,
     DotProductSizeTransformer,


### PR DESCRIPTION
This commit adds the `isort` library to the StreamFlow lint pipeline, in order to uniform the way `import` statements are managed and avoid useless conflicts in GitHub merges.