### PR TITLE
Fixed remote ports

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -71,7 +71,7 @@ jobs:
         with:
           node-version: "20"
       - name: "Install Docker (MacOS X)"
-        uses: douglascamata/setup-docker-macos-action@v1-alpha.15
+        uses: douglascamata/setup-docker-macos-action@v1-alpha.16
         with:
           colima-additional-options: '--mount /private/var/folders:w --mount-type virtiofs'
         if: ${{ startsWith(matrix.on, 'macos-') }}
@@ -249,7 +249,7 @@ jobs:
         with:
           node-version: "20"
       - name: "Install Docker (MacOs X)"
-        uses: douglascamata/setup-docker-macos-action@v1-alpha.15
+        uses: douglascamata/setup-docker-macos-action@v1-alpha.16
         with:
           colima-additional-options: '--mount /private/var/folders:w --mount-type virtiofs'
         if: ${{ startsWith(matrix.on, 'macos-') }}

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -1252,38 +1252,39 @@ def _process_input_value(
             _process_input_value(path_processor, output_directory, target, v)
             for v in value
         ]
+    elif isinstance(
+        value, (get_args(cwl_utils.parser.File), get_args(cwl_utils.parser.Directory))
+    ):
+        if value.path:
+            value.path = _remap_path(
+                path_processor=path_processor,
+                path=value.path,
+                old_dir=output_directory,
+                new_dir=target.workdir,
+            )
+        if value.location:
+            value.location = _remap_path(
+                path_processor=path_processor,
+                path=value.location,
+                old_dir=output_directory,
+                new_dir=target.workdir,
+            )
+        if value.secondaryFiles:
+            value.secondaryFiles = [
+                _process_input_value(path_processor, output_directory, target, sf)
+                for sf in value.secondaryFiles
+            ]
+        if isinstance(value, get_args(cwl_utils.parser.Directory)) and value.listing:
+            value.listing = [
+                _process_input_value(path_processor, output_directory, target, sf)
+                for sf in value["listing"]
+            ]
+        return value
     elif isinstance(value, MutableMapping):
-        if utils.get_token_class(value) in ["File", "Directory"]:
-            if "location" in value:
-                value["location"] = _remap_path(
-                    path_processor=path_processor,
-                    path=value["location"],
-                    old_dir=output_directory,
-                    new_dir=target.workdir,
-                )
-            if "path" in value:
-                value["path"] = _remap_path(
-                    path_processor=path_processor,
-                    path=value["path"],
-                    old_dir=output_directory,
-                    new_dir=target.workdir,
-                )
-            if "secondaryFiles" in value:
-                value["secondaryFiles"] = [
-                    _process_input_value(path_processor, output_directory, target, sf)
-                    for sf in value["secondaryFiles"]
-                ]
-            if "listing" in value:
-                value["listing"] = [
-                    _process_input_value(path_processor, output_directory, target, sf)
-                    for sf in value["listing"]
-                ]
-            return value
-        else:
-            return {
-                k: _process_input_value(path_processor, output_directory, target, v)
-                for k, v in value.items()
-            }
+        return {
+            k: _process_input_value(path_processor, output_directory, target, v)
+            for k, v in value.items()
+        }
     else:
         return value
 


### PR DESCRIPTION
This commit fixes the injection of remote inputs using the `cwl_utils` objects. Also, the unit test for input injection has been improved. Now, other than checking the path of the output token of the `InputInjectorStep,` the input file is copied to the same location, and a checksum check is performed.

This commit also updates the Docker MacOS  GitHub Action to the latest version.