### PR TITLE
Added `timeout` to `SSHConnector`

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -157,7 +157,7 @@ jobs:
           python -m pip install -r docs/requirements.txt
       - name: "Build documentation and check for consistency"
         env:
-          CHECKSUM: "b59239241d3529a179df6158271dd00ba7a86e807a37a11ac8e078ad9c377f94"
+          CHECKSUM: "32fa2a0dd0bbb96a69946d22eebf3bed279697f7a1cac093e7cbad2e7e0edfec"
         run: |
           cd docs
           HASH="$(make checksum | tail -n1)"

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -157,7 +157,7 @@ jobs:
           python -m pip install -r docs/requirements.txt
       - name: "Build documentation and check for consistency"
         env:
-          CHECKSUM: "32fa2a0dd0bbb96a69946d22eebf3bed279697f7a1cac093e7cbad2e7e0edfec"
+          CHECKSUM: "198f61804843130d3cae0675c67cad121d980c4648cf27c7541d87219afa3d6e"
         run: |
           cd docs
           HASH="$(make checksum | tail -n1)"

--- a/streamflow/deployment/connector/schemas/ssh.json
+++ b/streamflow/deployment/connector/schemas/ssh.json
@@ -72,7 +72,7 @@
     },
     "connectTimeout": {
       "type": "integer",
-      "description": "Time (in seconds) to wait for establish the connection. When an attempt fails, the time to wait is increased.",
+      "description": "Max time (in seconds) to wait for establishing an SSH connection.",
       "default": 30
     },
     "dataTransferConnection": {

--- a/streamflow/deployment/connector/schemas/ssh.json
+++ b/streamflow/deployment/connector/schemas/ssh.json
@@ -70,6 +70,11 @@
       "description": "Perform a strict validation of the host SSH keys (and return exception if key is not recognized as valid)",
       "default": true
     },
+    "connectTimeout": {
+      "type": "integer",
+      "description": "Time (in seconds) to wait for establish the connection. When an attempt fails, the time to wait is increased.",
+      "default": 30
+    },
     "dataTransferConnection": {
       "oneOf": [
         {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -181,11 +181,11 @@ def test_schema_generation():
     """Check that the `streamflow schema` command generates a correct JSON Schema."""
     assert (
         hashlib.sha256(SfSchema().dump("v1.0", False).encode()).hexdigest()
-        == "f8e3f739678510fc34afe419b215b54d1467d84ee6433fbb0c107bc30eb1f062"
+        == "bed6608171b77a8d7665532a6ea2405f53e9bab45c6d7719e052856eeff0f6fb"
     )
     assert (
         hashlib.sha256(SfSchema().dump("v1.0", True).encode()).hexdigest()
-        == "b91f949c055e3f5de305751540725eeba7e1a6deb1082c11bca3c6e7cfa09929"
+        == "7ccfaf9c38100ed943ebc3b57dbb3edfe7e2512e4784d87858c4dd470970768b"
     )
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -181,11 +181,11 @@ def test_schema_generation():
     """Check that the `streamflow schema` command generates a correct JSON Schema."""
     assert (
         hashlib.sha256(SfSchema().dump("v1.0", False).encode()).hexdigest()
-        == "bed6608171b77a8d7665532a6ea2405f53e9bab45c6d7719e052856eeff0f6fb"
+        == "c60eabe4335124cb1a241496ac370667a1525b8ab5847584f8dbf3877419282e"
     )
     assert (
         hashlib.sha256(SfSchema().dump("v1.0", True).encode()).hexdigest()
-        == "7ccfaf9c38100ed943ebc3b57dbb3edfe7e2512e4784d87858c4dd470970768b"
+        == "d62e2dc7b71778c6aa278ee28562bbc1b0a534e286296825162ce56ecd4aeb3c"
     )
 
 


### PR DESCRIPTION
This commit adds the timeout in the `asyncssh.connect()` call. The user chooses the time to wait using the `connectTimeout` option.

Updated documentation checksum because the `connectTimeout` option was added in the `SSHConnector` schema