### PR TITLE
Modernize base Docker image and Helm version

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -129,7 +129,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           build-args: |
-            HELM_VERSION=v3.7.2
+            HELM_VERSION=v3.17.0
           load: true
           tags: alphaunito/streamflow:latest
       - name: "Run test with Docker"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           build-args: |
-            HELM_VERSION=v3.7.2
+            HELM_VERSION=v3.17.0
           push: true
           tags: |
             alphaunito/streamflow:${{ env.STREAMFLOW_VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine3.16 AS builder
+FROM python:3.13-alpine3.21 AS builder
 ARG HELM_VERSION
 
 ENV VIRTUAL_ENV="/opt/streamflow"
@@ -38,7 +38,7 @@ RUN apk --no-cache add \
     && python -m venv ${VIRTUAL_ENV} \
     && pip install .
 
-FROM python:3.11-alpine3.16
+FROM python:3.13-alpine3.21
 LABEL maintainer="iacopo.colonnelli@unito.it"
 
 ENV VIRTUAL_ENV="/opt/streamflow"


### PR DESCRIPTION
This commit migrates the StreamFlow Docker image from Python 3.11 to Python 3.13 and from Alpine 3.16 to Alpine 3.21. In addition, it bumps Helm in the Docker container from v3.7.2 to v3.17.0.
