### PR TITLE
Fixed `ChannelOpenError` handling on the `SSHConnector`

### DIFF
--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -124,7 +124,7 @@ class SSHContext:
                             f"SSH connection to {self.get_hostname()} failed: connection timed out"
                         )
                     else:
-                        raise
+                        raise err
                 finally:
                     self._connect_event.set()
             else:

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -27,13 +27,24 @@ from streamflow.deployment.template import CommandTemplateMap
 from streamflow.log_handler import logger
 
 
-def _parse_hostname(hostname):
+def parse_hostname(hostname):
     if ":" in hostname:
         hostname, port = hostname.split(":")
         port = int(port)
     else:
         port = 22
     return hostname, port
+
+
+def get_param_from_file(
+    file_path: str | None, workdir: str | None = None
+) -> str | None:
+    if file_path is None:
+        return None
+    if not os.path.isabs(file_path):
+        file_path = os.path.join(workdir, file_path)
+    with open(file_path) as f:
+        return f.read().strip()
 
 
 class SSHContext:
@@ -56,7 +67,7 @@ class SSHContext:
     ) -> asyncssh.SSHClientConnection | None:
         if config is None:
             return None
-        (hostname, port) = _parse_hostname(config.hostname)
+        (hostname, port) = parse_hostname(config.hostname)
         return await asyncssh.connect(
             client_keys=config.client_keys,
             compression_algs=None,
@@ -68,25 +79,24 @@ class SSHContext:
             ],
             known_hosts=() if config.check_host_key else None,
             host=hostname,
-            passphrase=self._get_param_from_file(config.ssh_key_passphrase_file),
-            password=self._get_param_from_file(config.password_file),
+            passphrase=get_param_from_file(
+                config.ssh_key_passphrase_file, self._streamflow_config_dir
+            ),
+            password=get_param_from_file(
+                config.password_file, self._streamflow_config_dir
+            ),
             port=port,
             tunnel=await self._get_connection(config.tunnel),
             username=config.username,
             connect_timeout=config.connect_timeout,
         )
 
-    def _get_param_from_file(self, file_path: str | None) -> str | None:
-        if file_path is None:
-            return None
-        if not os.path.isabs(file_path):
-            file_path = os.path.join(self._streamflow_config_dir, file_path)
-        with open(file_path) as f:
-            return f.read().strip()
-
     async def close(self):
         if self._ssh_connection is not None:
-            if len(self._ssh_connection._channels) > 0:
+            if (
+                logger.isEnabledFor(logging.WARNING)
+                and len(self._ssh_connection._channels) > 0
+            ):
                 logger.warning(
                     f"Channels still open after closing the SSH connection to {self.get_hostname()}. Forcing closing."
                 )
@@ -208,13 +218,17 @@ class SSHContextManager:
                             ConnectionLost,
                             DisconnectError,
                             asyncio.TimeoutError,
-                        ) as exc:
+                        ) as err:
                             if logger.isEnabledFor(logging.WARNING):
                                 logger.warning(
-                                    f"Error {type(exc).__name__} opening SSH session to {context.get_hostname()} "
-                                    f"to execute command `{self.command}`: {str(exc)}"
+                                    f"Error {type(err).__name__} opening SSH session to {context.get_hostname()} "
+                                    f"to execute command `{self.command}`: "
+                                    f"{f'({err.code}) ' if isinstance(err, asyncssh.Error) else ''}{str(err)}"
                                 )
-                            if not isinstance(exc, ChannelOpenError):
+                            if (
+                                not isinstance(err, ChannelOpenError)
+                                or ssh_connection.is_closed()
+                            ):
                                 if logger.isEnabledFor(logging.WARNING):
                                     logger.warning(
                                         f"Connection to {context.get_hostname()}: attempt {context.connection_attempts}"


### PR DESCRIPTION
This commit fixes an issue in the `SSHConnector` where an infinite loop occurred when `asyncssh` threw a `ChannelOpenError`. The `asyncssh.SSHConnection` threw this exception on the `create_process` method in different scenarios. 

Before this commit, the assumption was that the connection was always open after this error, and it was possible to create a new channel just by retrying on the same connection.  For this reason, the context wasn’t reset when this exception occurred. 
However, the same exception can be thrown when the connection is lost and closed. The connection status was not checked, and trying to create new channels on the closed connection threw the same exception at each attempt.
Moreover, these attempts were not counted in the `SSHConnector` retry mechanism because the context wasn't reset.

Now, when the exception is thrown and the connection is closed, the context is reset, and a new connection is created in the next attempt. Otherwise, the connection is still open and, in the next attempt, is used to create a new channel.

Futhermore, the `parse_hostname` and `get_param_from_file` became public functions for possible plugins extending the `SSHConnector` class.