### PR TITLE
Remove useless `LocalConnector` deps

### DIFF
--- a/streamflow/cwl/command.py
+++ b/streamflow/cwl/command.py
@@ -48,7 +48,6 @@ from streamflow.cwl.processor import (
 from streamflow.cwl.step import build_token
 from streamflow.cwl.workflow import CWLWorkflow
 from streamflow.data.remotepath import StreamFlowPath
-from streamflow.deployment.connector import LocalConnector
 from streamflow.deployment.utils import get_path_processor
 from streamflow.log_handler import logger
 from streamflow.workflow.step import ExecuteStep
@@ -779,17 +778,15 @@ class CWLCommand(TokenizedCommand):
             else cmd
         )
         if logger.isEnabledFor(logging.INFO):
-            is_local = isinstance(
-                self.step.workflow.context.deployment_manager.get_connector(
-                    locations[0].deployment
-                ),
-                LocalConnector,
-            )
             logger.info(
                 "EXECUTING step {step} (job {job}) {location} into directory {outdir}:\n{command}".format(
                     step=self.step.name,
                     job=job.name,
-                    location="locally" if is_local else f"on location {locations[0]}",
+                    location=(
+                        "locally"
+                        if locations[0].local
+                        else f"on location {locations[0]}"
+                    ),
                     outdir=job.output_directory,
                     command=cmd_string,
                 )

--- a/streamflow/cwl/workflow.py
+++ b/streamflow/cwl/workflow.py
@@ -25,7 +25,7 @@ class CWLWorkflow(Workflow):
         super().__init__(context, config, name)
         self.cwl_version: str = cwl_version
         self.format_graph: Graph | None = format_graph
-        self.type: str | None = "cwl"
+        self.type: str = "cwl"
 
     async def _save_additional_params(
         self, context: StreamFlowContext

--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -22,7 +22,6 @@ from streamflow.core.scheduling import (
 )
 from streamflow.core.workflow import Job, Status
 from streamflow.data import remotepath, utils
-from streamflow.deployment.connector import LocalConnector
 from streamflow.deployment.filter import binding_filter_classes
 from streamflow.deployment.wrapper import ConnectorWrapper
 from streamflow.log_handler import logger
@@ -74,18 +73,12 @@ class DefaultScheduler(Scheduler):
     ):
         if logger.isEnabledFor(logging.DEBUG):
             if len(selected_locations) == 1:
-                is_local = isinstance(
-                    self.context.deployment_manager.get_connector(
-                        selected_locations[0].location.deployment
-                    ),
-                    LocalConnector,
-                )
                 logger.debug(
                     "Job {name} allocated {location}".format(
                         name=job.name,
                         location=(
                             "locally"
-                            if is_local
+                            if selected_locations[0].local
                             else f"on location {selected_locations[0]}"
                         ),
                     )


### PR DESCRIPTION
This commit removes useless `LocalConnector` dependencies whenever the locality of an `ExecutionLocation` was checked by inspecting the class of the relative `Connector` object instead of inspecting the `local` property directly.