### PR TITLE
Uniform StreamFlow output format to CWL ecosystem

### DIFF
--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -2858,6 +2858,7 @@ class CWLTranslator:
                         cls=CWLTransferStep,
                         name=f"{output_name}-collector",
                         job_port=schedule_step.get_output_port(),
+                        prefix_path=False,
                         writable=True,
                     )
                     transfer_step.add_input_port(

--- a/streamflow/cwl/workflow.py
+++ b/streamflow/cwl/workflow.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import json
-from collections.abc import MutableMapping
+from collections.abc import MutableMapping, MutableSet
 from typing import TYPE_CHECKING, Any, cast
 
 from rdflib import Graph
 
+from streamflow.core.data import DataLocation
 from streamflow.core.persistence import DatabaseLoadingContext
+from streamflow.core.utils import random_name
 from streamflow.core.workflow import Workflow
+from streamflow.data.remotepath import StreamFlowPath
 
 if TYPE_CHECKING:
     from streamflow.core.context import StreamFlowContext
@@ -26,6 +29,7 @@ class CWLWorkflow(Workflow):
         self.cwl_version: str = cwl_version
         self.format_graph: Graph | None = format_graph
         self.type: str = "cwl"
+        self._output_data: MutableMapping[str, MutableSet[tuple[str, str, str]]] = {}
 
     async def _save_additional_params(
         self, context: StreamFlowContext
@@ -56,3 +60,33 @@ class CWLWorkflow(Workflow):
                 else None
             ),
         )
+
+    def get_unique_output_path(
+        self, path: StreamFlowPath, src_location: DataLocation | None = None
+    ) -> StreamFlowPath:
+        # If a source location exists, use the deployment name, location name, and path as the key
+        # Otherwise, since literal files should always be created, generate random values to prevent collisions
+        key = (
+            (src_location.deployment, src_location.name, src_location.path)
+            if src_location is not None
+            else (random_name(), random_name(), random_name())
+        )
+        # Verify if the output path has already been registered
+        if str(path) in self._output_data:
+            # If the exact same file has already been transferred, throw exception
+            if key in self._output_data[str(path)]:
+                raise FileExistsError(f"File exists: {path}")
+            # Otherwise
+            else:
+                # Register the new key
+                self._output_data[str(path)].add(key)
+                # Generate a unique file name by appending a counter to the file
+                idx = len(self._output_data[str(path)]) - 1
+                return (
+                    path.parent
+                    / f"{path.stem}-{idx}{f'{path.suffix}' if path.suffix else ''}"
+                )
+        else:
+            # If the output has never been transferred before, simply register it
+            self._output_data[str(path)] = {key}
+        return path

--- a/streamflow/deployment/connector/container.py
+++ b/streamflow/deployment/connector/container.py
@@ -467,14 +467,14 @@ class ContainerConnector(ConnectorWrapper, ABC):
     async def _get_effective_locations(
         self,
         locations: MutableSequence[ExecutionLocation],
-        dest_path: str,
+        dst_path: str,
         source_location: ExecutionLocation | None = None,
     ) -> MutableSequence[ExecutionLocation]:
         common_paths = {}
         effective_locations = []
         for location in locations:
             common_paths, effective_locations = await self._check_effective_location(
-                common_paths, effective_locations, location, dest_path, source_location
+                common_paths, effective_locations, location, dst_path, source_location
             )
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(

--- a/streamflow/deployment/connector/kubernetes.py
+++ b/streamflow/deployment/connector/kubernetes.py
@@ -303,7 +303,7 @@ class KubernetesBaseConnector(BaseConnector, ABC):
     async def _get_effective_locations(
         self,
         locations: MutableSequence[ExecutionLocation],
-        dest_path: str,
+        dst_path: str,
         source_location: ExecutionLocation | None = None,
     ) -> MutableSequence[ExecutionLocation]:
         # Get containers
@@ -318,8 +318,8 @@ class KubernetesBaseConnector(BaseConnector, ABC):
             container = containers[location.name.split(":")[1]]
             add_location = True
             for volume in container.volume_mounts:
-                if dest_path.startswith(volume.mount_path):
-                    path = ":".join([volume.name, dest_path])
+                if dst_path.startswith(volume.mount_path):
+                    path = ":".join([volume.name, dst_path])
                     if path not in common_paths:
                         common_paths[path] = location
                     elif location.name == source_location.name:

--- a/streamflow/deployment/connector/occam.py
+++ b/streamflow/deployment/connector/occam.py
@@ -54,12 +54,12 @@ class OccamConnector(SSHConnector):
     def _get_effective_locations(
         self,
         locations: MutableSequence[ExecutionLocation],
-        dest_path: str,
+        dst_path: str,
         source_location: ExecutionLocation,
     ) -> MutableSequence[ExecutionLocation]:
         # If destination path is in a shared location, transfer only on the first location
         for shared_path in self.sharedPaths:
-            if dest_path.startswith(shared_path):
+            if dst_path.startswith(shared_path):
                 if source_location.name in [loc.name for loc in locations]:
                     return [source_location]
                 else:
@@ -68,7 +68,7 @@ class OccamConnector(SSHConnector):
         common_paths = {}
         effective_locations = []
         for location in locations:
-            shared_path = self._get_shared_path(location.name, dest_path)
+            shared_path = self._get_shared_path(location.name, dst_path)
             if shared_path is not None:
                 if shared_path not in common_paths:
                     common_paths[shared_path] = location


### PR DESCRIPTION
This commit uniforms the StreamFlow output layout to the one of other CWL engines (e.g., Toil and cwltool). In detail, it removes additional uuid-based folders that had been introduced to prevent name conflicts when multiple workflow outputs had the same name. Now these conflicts are solved by renaming duplicated files with a numeric suffix.