### PR TITLE
Fixed tag hierarchy check

### DIFF
--- a/streamflow/cwl/utils.py
+++ b/streamflow/cwl/utils.py
@@ -709,7 +709,7 @@ def process_embedded_tool(
     step_name: str,
     name_prefix: str,
     context: MutableMapping[str, Any],
-):
+) -> tuple[cwl_utils.parser.Process, str, MutableMapping[str, Any]]:
     run_command = cwl_element.run
     inner_context = dict(context)
     # If the `run` options contains an inline CWL object
@@ -740,7 +740,7 @@ def process_embedded_tool(
             )
     # Otherwise, the `run` options contains an URI
     else:
-        # Fetch and translare the target file
+        # Fetch and translate the target file
         run_command = cwl_utils.parser.load_document_by_uri(
             path=cwl_element.loadingOptions.fetcher.urljoin(
                 base_url=cwl_element.loadingOptions.fileuri, url=run_command

--- a/tests/test_remotepath.py
+++ b/tests/test_remotepath.py
@@ -155,7 +155,7 @@ async def test_mkdir_failure(context):
     with pytest.raises(WorkflowExecutionException) as err:
         await path.mkdir(mode=mode)
     expected_msg_err = f"1 Command 'mkdir -m {mode:o} {path}' on location {location}: mkdir: can't create directory '{path}': File exists"
-    assert str(err.value) == expected_msg_err
+    assert expected_msg_err in str(err.value)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This commit introduces a proper way to check if a `Token` derives from another `Token` based on their tags. Before this commit, tags were compared using the `startswith` method of the `str` class. However, this could lead to incorrect results because tags are represented by numbers. Now, a dedicated `_is_parent_tag` method has been introduced.
