### PR TITLE
Fix `ANTLR4` script generator

### DIFF
--- a/antlr4-generator.sh
+++ b/antlr4-generator.sh
@@ -6,7 +6,7 @@ WORKDIR=$(mktemp -d)
 
 cd "${WORKDIR}" || exit
 curl -fsSLO "https://www.antlr.org/download/antlr-${ANTLR4_VERSION}-complete.jar"
-curl -fsSLO "https://raw.githubusercontent.com/antlr/grammars-v4/master/javascript/ecmascript/Python/ECMAScript.g4"
+curl -fsSLO "https://raw.githubusercontent.com/antlr/grammars-v4/master/javascript/ecmascript/Python3/ECMAScript.g4"
 java -jar "antlr-${ANTLR4_VERSION}-complete.jar" -Dlanguage=Python3 ECMAScript.g4
 mv ./*.py "${SCRIPT_DIRECTORY}/streamflow/cwl/antlr/"
 rm -rf "${WORKDIR}"


### PR DESCRIPTION
This commit fixes the ANTLR4 script generator by updating the URL pointing to the `ECMAScript.g4` grammar.