### PR TITLE
Fix CWL `pickValue` with `all_non_null` option

### DIFF
--- a/streamflow/cwl/combinator.py
+++ b/streamflow/cwl/combinator.py
@@ -69,7 +69,6 @@ class ListMergeCombinator(DotProductCombinator):
         if not isinstance(token, IterationTerminationToken):
             async for schema in super().combine(port_name, token):
                 # If there is only one input, merge its value
-                input_token_ids = []
                 if len(self.input_names) == 1:
                     if isinstance(
                         outputs := schema[self.input_names[0]]["token"], ListToken

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -507,25 +507,10 @@ def _create_list_merger(
         transformer = workflow.create_step(
             cls=AllNonNullTransformer, name=name + "-transformer"
         )
-        if link_merge is None:
-            list_to_element = workflow.create_step(
-                cls=ListToElementTransformer, name=name + "-list-to-element"
-            )
-            list_to_element.add_input_port(
-                output_port_name, combinator.get_output_port()
-            )
-            list_to_element.add_output_port(output_port_name, workflow.create_port())
-            transformer.add_input_port(
-                output_port_name, list_to_element.get_output_port()
-            )
-            transformer.add_output_port(
-                output_port_name, output_port or workflow.create_port()
-            )
-        else:
-            transformer.add_input_port(output_port_name, combinator.get_output_port())
-            transformer.add_output_port(
-                output_port_name, output_port or workflow.create_port()
-            )
+        transformer.add_input_port(output_port_name, combinator.get_output_port())
+        transformer.add_output_port(
+            output_port_name, output_port or workflow.create_port()
+        )
         return transformer
     elif link_merge is None:
         combinator.add_output_port(output_port_name, workflow.create_port())


### PR DESCRIPTION
This commit fixes a wrong behaviour when a CWL step input configured with `pickValue` of type `all_non_null` had a single input source. In this case, since the `all_non_null` option works with lists, the input value should not be trsnsformed from a single-element list to a single element.