### PR TITLE
Always wait for `DataLocation` to be `available`

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -157,7 +157,7 @@ jobs:
           python -m pip install -r docs/requirements.txt
       - name: "Build documentation and check for consistency"
         env:
-          CHECKSUM: "a01e3dac2d706c032faf5dde9f194a236aa98a09bbaab06d7b105d4e4c1e67a6"
+          CHECKSUM: "58f3bbfd503244fb06971b86ca12f7b59d66b479850982544ccb991589ebc3c3"
         run: |
           cd docs
           HASH="$(make checksum | tail -n1)"

--- a/docs/source/ext/data-manager.rst
+++ b/docs/source/ext/data-manager.rst
@@ -18,7 +18,7 @@ The ``DataManager`` interface performs data transfers to and from remote executi
     ) -> MutableSequence[DataLocation]:
         ...
 
-    def get_source_location(
+    await def get_source_location(
         self, path: str, dst_deployment: str
     ) -> DataLocation | None:
         ...
@@ -62,7 +62,7 @@ The ``invalidate_location`` method informs the ``DataManager`` that the data reg
 
 The ``get_data_locations`` method retrieves all the valid  ``DataLocation`` objects related to the ``path`` received in input. Plus, the set of locations can be further filtered by the ``deployment`` to which the location belongs, the name of the location on which the data object resides (``location_name``), or a given ``data_type``. Note that all the ``DataLocation`` objects that are marked ``INVALID`` should not be returned by this method.
 
-The ``get_source_location`` method receives in input a ``path`` and the name of the destination deployment ``dst_deployment``, and it returns the ``DataLocation`` object that is most suitable to act as source location for performing the data transfer. The logic used to identify the best location is implementation-dependent. If no suitable location can be found, the method returns ``None``.
+The ``get_source_location`` method receives in input a ``path`` and the name of the destination deployment ``dst_deployment``, and it returns the ``DataLocation`` object that is most suitable to act as source location for performing the data transfer. The logic used to identify the best location is implementation-dependent. The returned ``DataLocation`` must be ``available``, i.e., the related transfer operation must be already finished. If no suitable location can be found, the method returns ``None``.
 
 The ``close`` method receives no input parameter and does not return anything. It frees stateful resources potentially allocated during the object’s lifetime, e.g., network or database connections.
 

--- a/streamflow/core/data.py
+++ b/streamflow/core/data.py
@@ -80,7 +80,7 @@ class DataManager(SchemaEntity):
     ) -> MutableSequence[DataLocation]: ...
 
     @abstractmethod
-    def get_source_location(
+    async def get_source_location(
         self, path: str, dst_deployment: str
     ) -> DataLocation | None: ...
 

--- a/streamflow/cwl/command.py
+++ b/streamflow/cwl/command.py
@@ -221,7 +221,7 @@ async def _get_source_location(
         base_path=base_path,
     )
     # Return the best source location ofr the current transfer
-    return workflow.context.data_manager.get_source_location(
+    return await workflow.context.data_manager.get_source_location(
         src_path, connector.deployment_name
     )
 

--- a/streamflow/cwl/processor.py
+++ b/streamflow/cwl/processor.py
@@ -207,8 +207,10 @@ class CWLTokenProcessor(TokenProcessor):
                 )
             except StopIteration:
                 # If such location does not exist, apply the standard heuristic to select the best one
-                data_location = self.workflow.context.data_manager.get_source_location(
-                    path=filepath, dst_deployment=LocalTarget.deployment_name
+                data_location = (
+                    await self.workflow.context.data_manager.get_source_location(
+                        path=filepath, dst_deployment=LocalTarget.deployment_name
+                    )
                 )
             if data_location:
                 if logger.isEnabledFor(logging.DEBUG):

--- a/streamflow/cwl/step.py
+++ b/streamflow/cwl/step.py
@@ -595,7 +595,7 @@ class CWLTransferStep(TransferStep):
             dst_path = (dst_path or dst_dir) / token_value["basename"]
         # If source data exist, get source locations
         if location and (
-            selected_location := self.workflow.context.data_manager.get_source_location(
+            selected_location := await self.workflow.context.data_manager.get_source_location(
                 path=location, dst_deployment=dst_connector.deployment_name
             )
         ):


### PR DESCRIPTION
When StreamFlow selects the best source location to perform a transfer, it must ensure that the selected `DataLocation` is `available`, i.e., the related transfer operation is terminated. Otherwise, it may happen that other execution flows try to perform operations on a file that does not exist yet.