### PR TITLE
Refactor unit tests

### DIFF
--- a/streamflow/workflow/utils.py
+++ b/streamflow/workflow/utils.py
@@ -46,7 +46,7 @@ def get_token_value(token: Token) -> Any:
         return token.value
 
 
-def get_job_token(job_name: str, token_list: MutableSequence[Token]):
+def get_job_token(job_name: str, token_list: MutableSequence[Token]) -> JobToken:
     for token in token_list:
         if isinstance(token, JobToken) and token.value.name == job_name:
             return token

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,7 +186,7 @@ def are_equals(elem1, elem2, obj_compared=None):
     """
     obj_compared = obj_compared if obj_compared else []
 
-    # if the objects are of different types, they are definitely not the same
+    # If the objects are of different types, they are definitely not the same
     if type(elem1) is not type(elem2):
         return False
 
@@ -215,7 +215,7 @@ def are_equals(elem1, elem2, obj_compared=None):
     if dict1.keys() != dict2.keys():
         return False
 
-    # if their references are in the obj_compared list there is a circular reference to break
+    # If their references are in the obj_compared list there is a circular reference to break
     if elem1 in obj_compared:
         return True
     else:
@@ -226,7 +226,7 @@ def are_equals(elem1, elem2, obj_compared=None):
     else:
         obj_compared.append(elem2)
 
-    # save the different values on the same attribute in the two dicts in a list:
+    # Save the different values on the same attribute in the two dicts in a list:
     #   - if we find objects in the list, they must be checked recursively on their attributes
     #   - if we find elems of primitive types, their values are actually different
     differences = [
@@ -235,7 +235,7 @@ def are_equals(elem1, elem2, obj_compared=None):
         if dict1[attr] != dict2[attr]
     ]
     for value1, value2 in differences:
-        # check recursively the elements
+        # Check recursively the elements
         if not are_equals(value1, value2, obj_compared):
             return False
     return True
@@ -246,7 +246,7 @@ async def save_load_and_test(elem: PersistableEntity, context):
     await elem.save(context)
     assert elem.persistent_id is not None
 
-    # created a new DefaultDatabaseLoadingContext to have the objects fetched from the database
+    # Created a new DefaultDatabaseLoadingContext to have the objects fetched from the database
     # (and not take their reference saved in the attributes)
     loading_context = DefaultDatabaseLoadingContext()
     loaded = await type(elem).load(context, elem.persistent_id, loading_context)

--- a/tests/test_remotepath.py
+++ b/tests/test_remotepath.py
@@ -26,7 +26,12 @@ def connector(context, location) -> Connector:
 @pytest.mark.asyncio
 async def test_directory(context, connector, location):
     """Test directory creation and deletion."""
-    path = StreamFlowPath(utils.random_name(), context=context, location=location)
+    path = StreamFlowPath(
+        tempfile.gettempdir() if location.local else "/tmp",
+        utils.random_name(),
+        context=context,
+        location=location,
+    )
     try:
         await path.mkdir(mode=0o777)
         assert await path.exists()
@@ -63,6 +68,7 @@ async def test_download(context, connector, location):
     ]
     parent_dir = StreamFlowPath(
         tempfile.gettempdir() if location.local else "/tmp",
+        utils.random_name(),
         context=context,
         location=location,
     )
@@ -83,8 +89,18 @@ async def test_download(context, connector, location):
 @pytest.mark.asyncio
 async def test_file(context, connector, location):
     """Test file creation, size, checksum and deletion."""
-    path = StreamFlowPath(utils.random_name(), context=context, location=location)
-    path2 = StreamFlowPath(utils.random_name(), context=context, location=location)
+    path = StreamFlowPath(
+        tempfile.gettempdir() if location.local else "/tmp",
+        utils.random_name(),
+        context=context,
+        location=location,
+    )
+    path2 = StreamFlowPath(
+        tempfile.gettempdir() if location.local else "/tmp",
+        utils.random_name(),
+        context=context,
+        location=location,
+    )
     try:
         await path.write_text("StreamFlow")
         assert await path.exists()
@@ -106,7 +122,12 @@ async def test_file(context, connector, location):
 @pytest.mark.asyncio
 async def test_glob(context, connector, location):
     """Test glob resolution."""
-    path = StreamFlowPath(utils.random_name(), context=context, location=location)
+    path = StreamFlowPath(
+        tempfile.gettempdir() if location.local else "/tmp",
+        utils.random_name(),
+        context=context,
+        location=location,
+    )
     await path.mkdir(mode=0o777)
     try:
         # ./
@@ -149,7 +170,12 @@ async def test_mkdir_failure(context):
     location = await get_location(context, deployment_config.type)
 
     # Create a file and try to create a directory with the same name
-    path = StreamFlowPath(utils.random_name(), context=context, location=location)
+    path = StreamFlowPath(
+        tempfile.gettempdir() if location.local else "/tmp",
+        utils.random_name(),
+        context=context,
+        location=location,
+    )
     mode = 0o777
     await path.write_text("StreamFlow")
     with pytest.raises(WorkflowExecutionException) as err:
@@ -161,15 +187,25 @@ async def test_mkdir_failure(context):
 @pytest.mark.asyncio
 async def test_symlink(context, connector, location):
     """Test symlink creation, resolution and deletion."""
-    src = StreamFlowPath(utils.random_name(), context=context, location=location)
-    path = StreamFlowPath(utils.random_name(), context=context, location=location)
+    src = StreamFlowPath(
+        tempfile.gettempdir() if location.local else "/tmp",
+        utils.random_name(),
+        context=context,
+        location=location,
+    )
+    path = StreamFlowPath(
+        tempfile.gettempdir() if location.local else "/tmp",
+        utils.random_name(),
+        context=context,
+        location=location,
+    )
     try:
         # Test symlink to file
         await src.write_text("StreamFlow")
         await path.symlink_to(src)
         assert await path.exists()
         assert await path.is_symlink()
-        assert (await path.resolve()).name == str(src)
+        assert (await path.resolve()).name == str(src.name)
         await path.rmtree()
         assert not await path.exists()
         await src.rmtree()
@@ -178,7 +214,7 @@ async def test_symlink(context, connector, location):
         await path.symlink_to(src, target_is_directory=True)
         assert await path.exists()
         assert await path.is_symlink()
-        assert (await path.resolve()).name == str(src)
+        assert (await path.resolve()).name == str(src.name)
         await path.rmtree()
         assert not await path.exists()
     finally:

--- a/tests/test_remotepath.py
+++ b/tests/test_remotepath.py
@@ -205,7 +205,7 @@ async def test_symlink(context, connector, location):
         await path.symlink_to(src)
         assert await path.exists()
         assert await path.is_symlink()
-        assert (await path.resolve()).name == str(src.name)
+        assert (await path.resolve()).name == src.name
         await path.rmtree()
         assert not await path.exists()
         await src.rmtree()
@@ -214,7 +214,7 @@ async def test_symlink(context, connector, location):
         await path.symlink_to(src, target_is_directory=True)
         assert await path.exists()
         assert await path.is_symlink()
-        assert (await path.resolve()).name == str(src.name)
+        assert (await path.resolve()).name == src.name
         await path.rmtree()
         assert not await path.exists()
     finally:

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -341,8 +341,8 @@ def test_workdir_inheritance() -> None:
     assert binding_config.targets[2].deployment.workdir == workdir_deployment_1
     assert binding_config.targets[2].workdir == workdir_deployment_1
 
-    # The `wrapper_4` deployment does NOT has a `workdir` and wraps the `awesome` deployment
-    # Get default `workdir` because `handsome` deployment does NOT has a `workdir` either
+    # The `wrapper_4` deployment does NOT have a `workdir` and wraps the `awesome` deployment
+    # Get default `workdir` because `handsome` deployment does NOT have a `workdir` either
     assert binding_config.targets[3].deployment.name == "wrapper_4"
     assert binding_config.targets[3].deployment.workdir is None
     assert binding_config.targets[3].workdir == (


### PR DESCRIPTION
This commit merges the `test_file_to_file` and `test_file_to_directory` tests of the `test_transfer` into a single test using the `parametrize` decorator of `pytest`. Furthermore, the working directories of tests in `test_remotepath` were changed from the current working directory to the tmp directory.