### PR TITLE
Fixed `invalidate_location` method

### DIFF
--- a/streamflow/data/manager.py
+++ b/streamflow/data/manager.py
@@ -134,12 +134,19 @@ class _RemotePathMapper:
         node = self._filesystem
         for token in path.parts:
             node = node.children[token]
-        for node_child in node.children.values():
+        # Not invalidate the root
+        nodes = (
+            [node] + list(node.children.values())
+            if node not in self._filesystem.children.values()
+            else list(node.children.values())
+        )
+        for node_child in nodes:
             for data_loc in node_child.locations.setdefault(
                 location.deployment, {}
             ).get(location.name, []):
                 if data_loc.data_type != DataType.INVALID:
-                    self.invalidate_location(data_loc, data_loc.path)
+                    if node_child != node:
+                        self.invalidate_location(data_loc.location, data_loc.path)
                     data_loc.data_type = DataType.INVALID
 
     def put(

--- a/streamflow/data/manager.py
+++ b/streamflow/data/manager.py
@@ -134,20 +134,18 @@ class _RemotePathMapper:
         node = self._filesystem
         for token in path.parts:
             node = node.children[token]
-        # Not invalidate the root
-        nodes = (
-            [node] + list(node.children.values())
-            if node not in self._filesystem.children.values()
-            else list(node.children.values())
-        )
-        for node_child in nodes:
+        # Invalidate node
+        for data_loc in node.locations.setdefault(location.deployment, {}).get(
+            location.name, []
+        ):
+            data_loc.data_type = DataType.INVALID
+        # Propagate
+        for node_child in node.children.values():
             for data_loc in node_child.locations.setdefault(
                 location.deployment, {}
             ).get(location.name, []):
                 if data_loc.data_type != DataType.INVALID:
-                    if node_child != node:
-                        self.invalidate_location(data_loc.location, data_loc.path)
-                    data_loc.data_type = DataType.INVALID
+                    self.invalidate_location(data_loc.location, data_loc.path)
 
     def put(
         self, path: str, data_location: DataLocation, recursive: bool = False

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -201,7 +201,7 @@ async def test_invalidate_location(
 
     # Check data manager has invalidated the location
     path = StreamFlowPath(context=context, location=src_location)
-    num_valid_data_loc = 1 if depth == "from_root" else level // 2 - 1
+    num_valid_data_loc = 0 if depth == "from_root" else level // 2 - 1
     for i, part in enumerate(src_path.parts):
         path /= part
         data_locs = context.data_manager.get_data_locations(

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import os
 import tempfile
 
 import pytest
 import pytest_asyncio
 
 from streamflow.core import utils
+from streamflow.core.context import StreamFlowContext
 from streamflow.core.data import DataLocation, DataType
 from streamflow.core.deployment import Connector, ExecutionLocation
 from streamflow.data.remotepath import StreamFlowPath
@@ -149,15 +151,21 @@ async def test_data_locations(
 
 
 @pytest.mark.asyncio
-async def test_invalidate_location(context, src_connector, src_location):
+@pytest.mark.parametrize("depth", ["from_root", "half_path"])
+async def test_invalidate_location(
+    context: StreamFlowContext,
+    src_connector: Connector,
+    src_location: ExecutionLocation,
+    depth: str,
+):
     """Test the invalidation of a location"""
     src_path = StreamFlowPath(
         tempfile.gettempdir() if src_location.local else "/tmp",
-        utils.random_name(),
-        utils.random_name(),
+        *(utils.random_name() for _ in range(5)),
         context=context,
         location=src_location,
     )
+    level = len(src_path.parts)
     context.data_manager.register_path(
         location=src_location,
         path=str(src_path),
@@ -177,21 +185,26 @@ async def test_invalidate_location(context, src_connector, src_location):
         assert data_locs[0].deployment == src_connector.deployment_name
 
     # Invalidate location
-    root_data_loc = next(
+    data_loc = next(
         iter(
             context.data_manager.get_data_locations(
-                path.root, src_connector.deployment_name
+                (
+                    path.root
+                    if depth == "from_root"
+                    else str(os.path.join(*path.parts[: level // 2]))
+                ),
+                src_connector.deployment_name,
             )
         )
     )
-    context.data_manager.invalidate_location(root_data_loc.location, root_data_loc.path)
+    context.data_manager.invalidate_location(data_loc.location, data_loc.path)
 
     # Check data manager has invalidated the location
     path = StreamFlowPath(context=context, location=src_location)
-    for part in src_path.parts:
+    num_valid_data_loc = 1 if depth == "from_root" else level // 2 - 1
+    for i, part in enumerate(src_path.parts):
         path /= part
         data_locs = context.data_manager.get_data_locations(
             str(path), src_connector.deployment_name
         )
-        # The data location of the root is not invalidated
-        assert len(data_locs) == (1 if path == path.parent else 0)
+        assert len(data_locs) == (1 if i < num_valid_data_loc else 0)


### PR DESCRIPTION
This commit fixes the invalidation of a path on a location. Before this commit, the `invalidate_location` method of the `_RemotePathMapper` class invalidated the `DataLocation` of the children of the path on the location, but not the path itself. Now, the invalidation starts from the path provided as input, with the exception that the root path is never invalidated.