### PR TITLE
Fixed cleanup in unit tests

### DIFF
--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -71,14 +71,14 @@ async def test_data_locations(
         context=context,
         location=dst_location,
     )
-
-    # Create working directories in src and dst locations
-    await src_path.parent.mkdir(mode=0o777, exist_ok=True)
-    await dst_path.mkdir(mode=0o777, parents=True)
-
     try:
+        # Create working directories in src and dst locations
+        await src_path.parent.mkdir(mode=0o777, exist_ok=True)
+        await dst_path.mkdir(mode=0o777, parents=True)
+
         await src_path.write_text("StreamFlow")
         src_path = await src_path.resolve()
+        assert src_path is not None
         context.data_manager.register_path(
             location=src_location,
             path=str(src_path),
@@ -144,8 +144,10 @@ async def test_data_locations(
                     == 1
                 )
     finally:
-        await src_path.rmtree()
-        await dst_path.rmtree()
+        if src_path is not None:
+            await src_path.rmtree()
+        if dst_path is not None:
+            await dst_path.rmtree()
 
 
 @pytest.mark.asyncio

--- a/tests/test_remotepath.py
+++ b/tests/test_remotepath.py
@@ -76,14 +76,15 @@ async def test_download(context, connector, location):
         parent_dir / "LICENSE",
         parent_dir / "streamflow-0.1.6.zip",
     ]
-    path = None
     for i, url in enumerate(urls):
+        path = None
         try:
             path = await remotepath.download(context, location, url, str(parent_dir))
             assert path == paths[i]
             assert await path.exists()
         finally:
-            await path.rmtree()
+            if path is not None:
+                await path.rmtree()
 
 
 @pytest.mark.asyncio
@@ -128,8 +129,8 @@ async def test_glob(context, connector, location):
         context=context,
         location=location,
     )
-    await path.mkdir(mode=0o777)
     try:
+        await path.mkdir(mode=0o777)
         # ./
         #   file1.txt
         #   file2.csv

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -131,7 +131,7 @@ async def test_directory_to_directory(
                     lvl=f"{i}-0",
                 )
         src_path = await src_path.resolve()
-
+        assert src_path is not None
         # Transfer from `src_path` on `src_location` to `dst_path` directory on `dst_location`
         dst_path = StreamFlowPath(
             tempfile.gettempdir() if dst_location.local else "/tmp",
@@ -190,9 +190,9 @@ async def test_file_to_entity(
         context=context,
         location=dst_location,
     )
-    if dst_t == "directory":
-        await dst_path.mkdir(mode=0o777, exist_ok=True)
     try:
+        if dst_t == "directory":
+            await dst_path.mkdir(mode=0o777, exist_ok=True)
         await src_path.write_text("StreamFlow")
         src_path = await src_path.resolve()
         assert src_path is not None
@@ -213,8 +213,10 @@ async def test_file_to_entity(
         assert await dst_file.exists()
         assert await src_path.checksum() == await dst_file.checksum()
     finally:
-        await src_path.rmtree()
-        await dst_path.rmtree()
+        if src_path is not None:
+            await src_path.rmtree()
+        if dst_path is not None:
+            await dst_path.rmtree()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This commit adds a check in the `finally` block of some integration tests to verify that the variables containing file paths have been initialized before using them to clean up the filesystem.