### PR TITLE
Improved `is_available` method of the `FileToken` class

### DIFF
--- a/streamflow/core/workflow.py
+++ b/streamflow/core/workflow.py
@@ -424,7 +424,7 @@ class Token(PersistableEntity):
         loading_context.add_token(persistent_id, token)
         return token
 
-    async def is_available(self, context: StreamFlowContext):
+    async def is_available(self, context: StreamFlowContext) -> bool:
         if isinstance(self.value, Token):
             return await self.value.is_available(context)
         else:

--- a/streamflow/cwl/token.py
+++ b/streamflow/cwl/token.py
@@ -39,16 +39,6 @@ async def _get_file_token_weight(context: StreamFlowContext, value: Any):
     return weight
 
 
-async def _is_file_token_available(context: StreamFlowContext, value: Any) -> bool:
-    if path := utils.get_path_from_token(value):
-        data_locations = context.data_manager.get_data_locations(
-            path=path, data_type=DataType.PRIMARY
-        )
-        return len(data_locations) != 0
-    else:
-        return True
-
-
 class CWLFileToken(FileToken):
     __slots__ = ()
 
@@ -73,9 +63,3 @@ class CWLFileToken(FileToken):
             return await self.value.get_weight(context)
         else:
             return await _get_file_token_weight(context, self.value)
-
-    async def is_available(self, context: StreamFlowContext):
-        if isinstance(self.value, Token):
-            return await self.value.is_available(context)
-        else:
-            return await _is_file_token_available(context, self.value)


### PR DESCRIPTION
This commit improves the `is_available` method of the `FileToken` class. Before this commit, no checks were made regarding the file's existence on the location.

If a path of the `FileToken` is not registered or is invalid in the `DataManager`, the method will return `false`. Otherwise, the existence of the path will be checked at its location. If the path does not exist, it will be invalidated in the `DataManager`, and the method will return `false`.

Note: The `FileToken` can have multiple paths. The default implementation assumes that if one path does not exist, the `FileToken` is not available (if a subclass needs different behavior, it should override the method).
