### PR TITLE
Added `ROLLBACK` status

### DIFF
--- a/streamflow/core/utils.py
+++ b/streamflow/core/utils.py
@@ -10,6 +10,7 @@ import posixpath
 import shlex
 import uuid
 from collections.abc import Iterable, MutableMapping, MutableSequence
+from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any
 
 from streamflow.core.exception import WorkflowExecutionException
@@ -48,6 +49,17 @@ class NamesStack:
             if name in scope:
                 return True
         return False
+
+
+def compare_tags(tag1: str, tag2: str) -> int:
+    list1 = tag1.split(".")
+    list2 = tag2.split(".")
+    if (res := (len(list1) - len(list2))) != 0:
+        return res
+    for elem1, elem2 in zip(list1, list2):
+        if (res := (int(elem1) - int(elem2))) != 0:
+            return res
+    return 0
 
 
 def contains_persistent_id(id_: int, entities: Iterable[PersistableEntity]) -> bool:
@@ -111,6 +123,14 @@ def create_command(
         stderr=stderr,
     )
     return command
+
+
+def get_job_step_name(job_name: str) -> str:
+    return PurePosixPath(job_name).parent.name
+
+
+def get_job_tag(job_name: str) -> str:
+    return PurePosixPath(job_name).name
 
 
 def dict_product(**kwargs) -> MutableMapping[Any, Any]:

--- a/streamflow/core/workflow.py
+++ b/streamflow/core/workflow.py
@@ -213,6 +213,7 @@ class Status(IntEnum):
     COMPLETED = 4
     FAILED = 5
     CANCELLED = 6
+    ROLLBACK = 7
 
 
 class Step(PersistableEntity, ABC):


### PR DESCRIPTION
This commit adds the `ROLLBACK` status and improves the `DefaultScheduler` to manage this new status. This feature is helpful for introducing recovery mechanisms when a job fails.

The `DefaultScheduler` gives higher priority to scheduling older jobs of the same step when they are in `ROLLBACK`. Moreover, when a job notifies the `ROLLBACK` status, its `JobAllocation` instance is reset.