### PR TITLE
Refactored the no-cyclic check for stacked deployment definitions

### DIFF
--- a/streamflow/deployment/utils.py
+++ b/streamflow/deployment/utils.py
@@ -24,7 +24,9 @@ if TYPE_CHECKING:
     from streamflow.core.deployment import Connector
 
 
-def _get_workdir(deployment, workflow_config) -> None:
+def _get_workdir(
+    deployment: MutableMapping[str, Any], workflow_config: WorkflowConfig
+) -> str:
     while (workdir := deployment.get("workdir")) is None and (
         wraps := deployment.get("wraps")
     ) is not None:


### PR DESCRIPTION
This commit adds a check to detect if the StreamFlow config file contains a cyclic definition of the stacked deployments. Before this commit, the cyclic definition was handled by the `DefaultDeploymentManager` at workflow execution time when the locations were deployed. Now, the check is done at translation time.