### PR TITLE
Check if bindings exist in the workflow

### DIFF
--- a/streamflow/config/config.py
+++ b/streamflow/config/config.py
@@ -1,64 +1,21 @@
 from __future__ import annotations
 
 import logging
-import posixpath
 from collections.abc import MutableMapping, MutableSequence
 from pathlib import PurePosixPath
 from typing import Any
 
 from streamflow.core.config import Config
 from streamflow.core.exception import WorkflowDefinitionException
-from streamflow.core.workflow import Workflow
 from streamflow.log_handler import logger
-from streamflow.workflow.step import InputInjectorStep
-
-
-def _check_bindings(
-    current_node: MutableMapping[str, Any], workflow: Workflow, path: str
-) -> None:
-    if logger.isEnabledFor(logging.WARNING):
-        if "step" in current_node and not current_node.get("inherited_target", False):
-            if not any(step.startswith(path) for step in workflow.steps.keys()):
-                # The `step` bind check if there is a step named /parent/step_name
-                #   (it includes also sub-workflow bindings)
-                logger.warning(
-                    f"Binding {path}, defined in the StreamFlow file, does not match any steps in the workflow"
-                )
-        if "port" in current_node:
-            if not (
-                (
-                    # The port is an input port of the workflow
-                    posixpath.dirname(path) == posixpath.sep
-                    and any(
-                        posixpath.basename(path) in s.input_ports
-                        for s in workflow.steps.values()
-                        if isinstance(s, InputInjectorStep)
-                    )
-                )
-                or (
-                    # The port is an output port of a step
-                    posixpath.dirname(path) in workflow.steps
-                    and posixpath.basename(path)
-                    in workflow.steps[posixpath.dirname(path)].output_ports
-                )
-            ):
-                logger.warning(
-                    f"Binding {path}, defined in the StreamFlow file, does not match any ports in the workflow"
-                )
-        for key, node in current_node["children"].items():
-            _check_bindings(node, workflow, posixpath.join(path, key))
-
-
-def check_bindings(workflow_config: WorkflowConfig, workflow: Workflow) -> None:
-    if len(node := workflow_config.filesystem["children"]) == 1:
-        _check_bindings(node[posixpath.sep], workflow, posixpath.sep)
 
 
 def set_targets(current_node, target):
     for node in current_node["children"].values():
+        if "port" in node:
+            continue
         if "step" not in node:
             node["step"] = target
-            node["inherited_target"] = True
         set_targets(node, node["step"])
 
 
@@ -114,6 +71,8 @@ class WorkflowConfig(Config):
                         f"The deployment `{deployment['name']}` leads to a circular reference: "
                         f"Recursive deployment definitions are not allowed."
                     )
+                else:
+                    deployments.add(deployment["name"])
 
     def _process_binding(self, binding: MutableMapping[str, Any]):
         targets = (

--- a/streamflow/core/recovery.py
+++ b/streamflow/core/recovery.py
@@ -10,10 +10,9 @@ from streamflow.core.context import SchemaEntity
 from streamflow.workflow.token import JobToken
 
 if TYPE_CHECKING:
-    from streamflow.core.command import CommandOutput
     from streamflow.core.context import StreamFlowContext
     from streamflow.core.data import DataLocation
-    from streamflow.core.workflow import Job, Step, Token, Workflow
+    from streamflow.core.workflow import CommandOutput, Job, Step, Token, Workflow
 
 
 class CheckpointManager(SchemaEntity):

--- a/streamflow/cwl/command.py
+++ b/streamflow/cwl/command.py
@@ -16,17 +16,6 @@ from typing import IO, Any, cast
 from ruamel.yaml import RoundTripRepresenter
 from ruamel.yaml.scalarfloat import ScalarFloat
 
-from streamflow.core.command import (
-    Command,
-    CommandOptions,
-    CommandToken,
-    CommandTokenProcessor,
-    ListCommandToken,
-    MapCommandTokenProcessor,
-    ObjectCommandToken,
-    ObjectCommandTokenProcessor,
-    TokenizedCommand,
-)
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.data import DataLocation
 from streamflow.core.deployment import Connector
@@ -36,7 +25,17 @@ from streamflow.core.exception import (
 )
 from streamflow.core.persistence import DatabaseLoadingContext
 from streamflow.core.utils import flatten_list, get_tag
-from streamflow.core.workflow import Job, Status, Step, Token, Workflow
+from streamflow.core.workflow import (
+    Command,
+    CommandOptions,
+    CommandToken,
+    CommandTokenProcessor,
+    Job,
+    Status,
+    Step,
+    Token,
+    Workflow,
+)
 from streamflow.cwl import utils
 from streamflow.cwl.processor import (
     CWLCommandOutput,
@@ -50,6 +49,13 @@ from streamflow.cwl.workflow import CWLWorkflow
 from streamflow.data.remotepath import StreamFlowPath
 from streamflow.deployment.utils import get_path_processor
 from streamflow.log_handler import logger
+from streamflow.workflow.command import (
+    ListCommandToken,
+    MapCommandTokenProcessor,
+    ObjectCommandToken,
+    ObjectCommandTokenProcessor,
+    TokenizedCommand,
+)
 from streamflow.workflow.step import ExecuteStep
 from streamflow.workflow.utils import get_token_value
 

--- a/streamflow/cwl/processor.py
+++ b/streamflow/cwl/processor.py
@@ -9,7 +9,6 @@ from typing import Any, cast
 import cwl_utils.file_formats
 from schema_salad.exceptions import ValidationException
 
-from streamflow.core.command import CommandOutput, CommandOutputProcessor
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.deployment import Connector, LocalTarget, Target
 from streamflow.core.exception import (
@@ -18,7 +17,14 @@ from streamflow.core.exception import (
 )
 from streamflow.core.persistence import DatabaseLoadingContext
 from streamflow.core.utils import flatten_list, get_tag
-from streamflow.core.workflow import Job, Status, Token, TokenProcessor
+from streamflow.core.workflow import (
+    CommandOutput,
+    CommandOutputProcessor,
+    Job,
+    Status,
+    Token,
+    TokenProcessor,
+)
 from streamflow.cwl import utils
 from streamflow.cwl.token import CWLFileToken
 from streamflow.cwl.utils import LoadListing, SecondaryFile

--- a/streamflow/cwl/step.py
+++ b/streamflow/cwl/step.py
@@ -8,7 +8,6 @@ from abc import ABC
 from collections.abc import MutableMapping, MutableSequence
 from typing import Any, cast
 
-from streamflow.core.command import Command, CommandOutput, CommandOutputProcessor
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.data import DataLocation, DataType
 from streamflow.core.deployment import Connector, ExecutionLocation
@@ -18,7 +17,14 @@ from streamflow.core.exception import (
 )
 from streamflow.core.persistence import DatabaseLoadingContext
 from streamflow.core.utils import get_entity_ids, get_tag, random_name
-from streamflow.core.workflow import Job, Port, Token
+from streamflow.core.workflow import (
+    Command,
+    CommandOutput,
+    CommandOutputProcessor,
+    Job,
+    Port,
+    Token,
+)
 from streamflow.cwl import utils
 from streamflow.cwl.token import CWLFileToken
 from streamflow.cwl.utils import (

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -13,7 +13,7 @@ import cwl_utils.parser
 import cwl_utils.parser.utils
 from schema_salad.exceptions import ValidationException
 
-from streamflow.config.config import WorkflowConfig
+from streamflow.config.config import WorkflowConfig, check_bindings
 from streamflow.core.command import (
     CommandOutputProcessor,
     CommandTokenProcessor,
@@ -2787,6 +2787,7 @@ class CWLTranslator:
         )
         # Inject initial inputs
         self._inject_inputs(workflow)
+        check_bindings(self.workflow_config, workflow)
         # Extract requirements
         for hint in self.cwl_definition.hints or []:
             if not isinstance(hint, MutableMapping):

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -13,12 +13,7 @@ import cwl_utils.parser
 import cwl_utils.parser.utils
 from schema_salad.exceptions import ValidationException
 
-from streamflow.config.config import WorkflowConfig, check_bindings
-from streamflow.core.command import (
-    CommandOutputProcessor,
-    CommandTokenProcessor,
-    UnionCommandTokenProcessor,
-)
+from streamflow.config.config import WorkflowConfig
 from streamflow.core.config import BindingConfig
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.deployment import (
@@ -28,7 +23,15 @@ from streamflow.core.deployment import (
     Target,
 )
 from streamflow.core.exception import WorkflowDefinitionException
-from streamflow.core.workflow import Port, Step, Token, TokenProcessor, Workflow
+from streamflow.core.workflow import (
+    CommandOutputProcessor,
+    CommandTokenProcessor,
+    Port,
+    Step,
+    Token,
+    TokenProcessor,
+    Workflow,
+)
 from streamflow.cwl import utils
 from streamflow.cwl.combinator import ListMergeCombinator
 from streamflow.cwl.command import (
@@ -97,6 +100,7 @@ from streamflow.workflow.combinator import (
     LoopCombinator,
     LoopTerminationCombinator,
 )
+from streamflow.workflow.command import UnionCommandTokenProcessor
 from streamflow.workflow.step import (
     Combinator,
     CombinatorStep,
@@ -108,6 +112,7 @@ from streamflow.workflow.step import (
     Transformer,
 )
 from streamflow.workflow.token import TerminationToken
+from streamflow.workflow.utils import check_bindings
 
 
 def _copy_context(context: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
@@ -1531,6 +1536,8 @@ class CWLTranslator:
         # Connect input and output ports to the injector step
         injector_step.add_input_port(port_name, input_port)
         injector_step.add_output_port(port_name, port)
+        # Add the input port of the InputInjectorStep to the workflow input ports
+        workflow.input_ports[port_name] = input_port.name
 
     def _inject_inputs(self, workflow: Workflow):
         output_directory = None

--- a/streamflow/recovery/failure_manager.py
+++ b/streamflow/recovery/failure_manager.py
@@ -5,11 +5,10 @@ import logging
 from collections.abc import MutableMapping
 from importlib.resources import files
 
-from streamflow.core.command import CommandOutput
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.exception import FailureHandlingException, WorkflowException
 from streamflow.core.recovery import FailureManager, RetryRequest, TokenAvailability
-from streamflow.core.workflow import Job, Status, Step, Token
+from streamflow.core.workflow import CommandOutput, Job, Status, Step, Token
 from streamflow.log_handler import logger
 from streamflow.recovery.policy.recovery import RollbackRecoveryPolicy
 from streamflow.workflow.token import JobToken

--- a/streamflow/workflow/command.py
+++ b/streamflow/workflow/command.py
@@ -1,205 +1,23 @@
 from __future__ import annotations
 
 import asyncio
-from abc import ABC, abstractmethod
+from abc import ABC
 from collections.abc import MutableMapping, MutableSequence
 from typing import Any, cast
 
-from streamflow.core import utils
 from streamflow.core.context import StreamFlowContext
-from streamflow.core.deployment import Connector, ExecutionLocation, Target
 from streamflow.core.exception import WorkflowDefinitionException
 from streamflow.core.persistence import DatabaseLoadingContext
-from streamflow.core.utils import get_class_from_name, get_class_fullname
-from streamflow.core.workflow import Job, Status, Step, Token, Workflow
+from streamflow.core.workflow import (
+    Command,
+    CommandOptions,
+    CommandToken,
+    CommandTokenProcessor,
+    Step,
+    Token,
+)
 from streamflow.workflow.token import ListToken, ObjectToken
 from streamflow.workflow.utils import get_token_value
-
-
-class Command(ABC):
-    def __init__(self, step: Step):
-        super().__init__()
-        self.step: Step = step
-
-    @abstractmethod
-    async def execute(self, job: Job) -> CommandOutput: ...
-
-    @classmethod
-    async def load(
-        cls,
-        context: StreamFlowContext,
-        row: MutableMapping[str, Any],
-        loading_context: DatabaseLoadingContext,
-        step: Step,
-    ) -> Command:
-        type_ = cast(type[Command], utils.get_class_from_name(row["type"]))
-        return await type_._load(context, row["params"], loading_context, step)
-
-    async def save(self, context: StreamFlowContext):
-        return {
-            "type": utils.get_class_fullname(type(self)),
-            "params": await self._save_additional_params(context),
-        }
-
-    @classmethod
-    async def _load(
-        cls,
-        context: StreamFlowContext,
-        row: MutableMapping[str, Any],
-        loading_context: DatabaseLoadingContext,
-        step: Step,
-    ):
-        return cls(step=step)
-
-    async def _save_additional_params(
-        self, context: StreamFlowContext
-    ) -> MutableMapping[str, Any]:
-        return {}
-
-
-class CommandOptions(ABC):
-    pass
-
-
-class CommandOutput:
-    __slots__ = ("value", "status")
-
-    def __init__(self, value: Any, status: Status):
-        self.value: Any = value
-        self.status: Status = status
-
-    def update(self, value: Any):
-        return CommandOutput(value=value, status=self.status)
-
-
-class CommandOutputProcessor(ABC):
-    def __init__(self, name: str, workflow: Workflow, target: Target | None = None):
-        self.name: str = name
-        self.workflow: Workflow = workflow
-        self.target: Target | None = target
-
-    def _get_connector(self, connector: Connector | None, job: Job) -> Connector:
-        return connector or self.workflow.context.scheduler.get_connector(job.name)
-
-    async def _get_locations(
-        self, connector: Connector | None, job: Job
-    ) -> MutableSequence[ExecutionLocation]:
-        if self.target:
-            available_locations = await connector.get_available_locations(
-                service=self.target.service
-            )
-            return [loc.location for loc in available_locations.values()]
-        else:
-            return self.workflow.context.scheduler.get_locations(job.name)
-
-    @classmethod
-    async def _load(
-        cls,
-        context: StreamFlowContext,
-        row: MutableMapping[str, Any],
-        loading_context: DatabaseLoadingContext,
-    ) -> CommandOutputProcessor:
-        return cls(
-            name=row["name"],
-            workflow=await loading_context.load_workflow(context, row["workflow"]),
-            target=(
-                (await loading_context.load_target(context, row["workflow"]))
-                if row["target"]
-                else None
-            ),
-        )
-
-    async def _save_additional_params(
-        self, context: StreamFlowContext
-    ) -> MutableMapping[str, Any]:
-        if self.target:
-            await self.target.save(context)
-        return {
-            "name": self.name,
-            "workflow": self.workflow.persistent_id,
-            "target": self.target.persistent_id if self.target else None,
-        }
-
-    @classmethod
-    async def load(
-        cls,
-        context: StreamFlowContext,
-        row: MutableMapping[str, Any],
-        loading_context: DatabaseLoadingContext,
-    ) -> CommandOutputProcessor:
-        type_ = cast(
-            type[CommandOutputProcessor], utils.get_class_from_name(row["type"])
-        )
-        return await type_._load(context, row["params"], loading_context)
-
-    @abstractmethod
-    async def process(
-        self,
-        job: Job,
-        command_output: CommandOutput,
-        connector: Connector | None = None,
-    ) -> Token | None: ...
-
-    async def save(self, context: StreamFlowContext):
-        return {
-            "type": utils.get_class_fullname(type(self)),
-            "params": await self._save_additional_params(context),
-        }
-
-
-class CommandToken:
-    __slots__ = ("name", "position", "value")
-
-    def __init__(self, name: str | None, position: int | None, value: Any):
-        self.name: str | None = name
-        self.position: int | None = position
-        self.value: Any = value
-
-
-class CommandTokenProcessor(ABC):
-    def __init__(self, name: str):
-        self.name: str = name
-
-    @classmethod
-    async def _load(
-        cls,
-        context: StreamFlowContext,
-        row: MutableMapping[str, Any],
-        loading_context: DatabaseLoadingContext,
-    ):
-        return cls(name=row["name"])
-
-    async def _save_additional_params(
-        self, context: StreamFlowContext
-    ) -> MutableMapping[str, Any]:
-        return {"name": self.name}
-
-    @abstractmethod
-    def bind(
-        self,
-        token: Token | None,
-        position: int | None,
-        options: CommandOptions,
-    ) -> CommandToken: ...
-
-    @abstractmethod
-    def check_type(self, token: Token) -> bool: ...
-
-    @classmethod
-    async def load(
-        cls,
-        context: StreamFlowContext,
-        row: MutableMapping[str, Any],
-        loading_context: DatabaseLoadingContext,
-    ) -> CommandTokenProcessor:
-        type_ = cast(type[CommandTokenProcessor], get_class_from_name(row["type"]))
-        return await type_._load(context, row["params"], loading_context)
-
-    async def save(self, context: StreamFlowContext):
-        return {
-            "type": get_class_fullname(type(self)),
-            "params": await self._save_additional_params(context),
-        }
 
 
 class ListCommandToken(CommandToken):
@@ -369,6 +187,62 @@ class ObjectCommandTokenProcessor(CommandTokenProcessor):
             return False
 
 
+class TokenizedCommand(Command, ABC):
+    def __init__(
+        self,
+        step: Step,
+        processors: MutableSequence[CommandTokenProcessor] | None = None,
+    ):
+        super().__init__(step)
+        self.processors: MutableSequence[CommandTokenProcessor] = processors or []
+
+    @classmethod
+    async def _load_command_token_processors(
+        cls,
+        context: StreamFlowContext,
+        row: MutableMapping[str, Any],
+        loading_context: DatabaseLoadingContext,
+    ) -> MutableSequence[CommandTokenProcessor]:
+        return cast(
+            MutableSequence[CommandTokenProcessor],
+            await asyncio.gather(
+                *(
+                    asyncio.create_task(
+                        CommandTokenProcessor.load(context, processor, loading_context)
+                    )
+                    for processor in row["processors"]
+                )
+            ),
+        )
+
+    @classmethod
+    async def _load(
+        cls,
+        context: StreamFlowContext,
+        row: MutableMapping[str, Any],
+        loading_context: DatabaseLoadingContext,
+        step: Step,
+    ):
+        return cls(
+            step=step,
+            processors=await cls._load_command_token_processors(
+                context=context, row=row, loading_context=loading_context
+            ),
+        )
+
+    async def _save_additional_params(
+        self, context: StreamFlowContext
+    ) -> MutableMapping[str, Any]:
+        return cast(dict[str, Any], await super()._save_additional_params(context)) | {
+            "processors": await asyncio.gather(
+                *(
+                    asyncio.create_task(processor.save(context))
+                    for processor in self.processors
+                )
+            )
+        }
+
+
 class UnionCommandTokenProcessor(CommandTokenProcessor):
     def __init__(self, name: str, processors: MutableSequence[CommandTokenProcessor]):
         super().__init__(name)
@@ -430,59 +304,3 @@ class UnionCommandTokenProcessor(CommandTokenProcessor):
 
     def check_type(self, token: Token) -> bool:
         return self._get_processor(token) is not None
-
-
-class TokenizedCommand(Command):
-    def __init__(
-        self,
-        step: Step,
-        processors: MutableSequence[CommandTokenProcessor] | None = None,
-    ):
-        super().__init__(step)
-        self.processors: MutableSequence[CommandTokenProcessor] = processors or []
-
-    @classmethod
-    async def _load_command_token_processors(
-        cls,
-        context: StreamFlowContext,
-        row: MutableMapping[str, Any],
-        loading_context: DatabaseLoadingContext,
-    ) -> MutableSequence[CommandTokenProcessor]:
-        return cast(
-            MutableSequence[CommandTokenProcessor],
-            await asyncio.gather(
-                *(
-                    asyncio.create_task(
-                        CommandTokenProcessor.load(context, processor, loading_context)
-                    )
-                    for processor in row["processors"]
-                )
-            ),
-        )
-
-    @classmethod
-    async def _load(
-        cls,
-        context: StreamFlowContext,
-        row: MutableMapping[str, Any],
-        loading_context: DatabaseLoadingContext,
-        step: Step,
-    ):
-        return cls(
-            step=step,
-            processors=await cls._load_command_token_processors(
-                context=context, row=row, loading_context=loading_context
-            ),
-        )
-
-    async def _save_additional_params(
-        self, context: StreamFlowContext
-    ) -> MutableMapping[str, Any]:
-        return cast(dict[str, Any], await super()._save_additional_params(context)) | {
-            "processors": await asyncio.gather(
-                *(
-                    asyncio.create_task(processor.save(context))
-                    for processor in self.processors
-                )
-            )
-        }

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -11,7 +11,6 @@ from types import ModuleType
 from typing import Any, cast
 
 from streamflow.core import utils
-from streamflow.core.command import Command, CommandOutput, CommandOutputProcessor
 from streamflow.core.config import BindingConfig
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.data import DataType
@@ -30,7 +29,17 @@ from streamflow.core.exception import (
 from streamflow.core.persistence import DatabaseLoadingContext
 from streamflow.core.scheduling import HardwareRequirement
 from streamflow.core.utils import get_entity_ids
-from streamflow.core.workflow import Job, Port, Status, Step, Token, Workflow
+from streamflow.core.workflow import (
+    Command,
+    CommandOutput,
+    CommandOutputProcessor,
+    Job,
+    Port,
+    Status,
+    Step,
+    Token,
+    Workflow,
+)
 from streamflow.data.remotepath import StreamFlowPath
 from streamflow.deployment.utils import get_path_processor
 from streamflow.log_handler import logger

--- a/streamflow/workflow/utils.py
+++ b/streamflow/workflow/utils.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, MutableSequence
+import logging
+import posixpath
+from collections.abc import Iterable, MutableMapping, MutableSequence
 from typing import Any
 
+from streamflow.config.config import WorkflowConfig
 from streamflow.core.exception import WorkflowExecutionException
-from streamflow.core.workflow import Token
+from streamflow.core.workflow import Token, Workflow
+from streamflow.log_handler import logger
 from streamflow.workflow.token import (
     IterationTerminationToken,
     JobToken,
@@ -12,6 +16,46 @@ from streamflow.workflow.token import (
     ObjectToken,
     TerminationToken,
 )
+
+
+def _check_bindings(
+    current_node: MutableMapping[str, Any], workflow: Workflow, path: str
+) -> None:
+    if "step" in current_node:
+        if not any(step.startswith(path) for step in workflow.steps.keys()):
+            # The `step` bind check if there is a step named /parent/step_name
+            #   (it includes also sub-workflow bindings)
+            logger.warning(
+                f"Binding {path}, defined in the StreamFlow file, does not match any steps in the workflow"
+            )
+            return
+    if "port" in current_node:
+        if not (
+            (
+                # The port is an input port of the workflow
+                posixpath.dirname(path) == posixpath.sep
+                and posixpath.basename(path) in workflow.input_ports.keys()
+            )
+            or (
+                # The port is an output port of a step
+                posixpath.dirname(path) in workflow.steps
+                and posixpath.basename(path)
+                in workflow.steps[posixpath.dirname(path)].output_ports
+            )
+        ):
+            logger.warning(
+                f"Binding {path}, defined in the StreamFlow file, does not match any ports in the workflow"
+            )
+    for key, node in current_node["children"].items():
+        _check_bindings(node, workflow, posixpath.join(path, key))
+
+
+def check_bindings(workflow_config: WorkflowConfig, workflow: Workflow) -> None:
+    if (
+        logger.isEnabledFor(logging.WARNING)
+        and len(node := workflow_config.filesystem["children"]) == 1
+    ):
+        _check_bindings(node[posixpath.sep], workflow, posixpath.sep)
 
 
 def check_iteration_termination(inputs: Token | Iterable[Token]) -> bool:

--- a/tests/test_cwl_persistence.py
+++ b/tests/test_cwl_persistence.py
@@ -9,11 +9,10 @@ from rdflib import Graph
 from ruamel.yaml.scalarstring import DoubleQuotedScalarString, LiteralScalarString
 
 from streamflow.core import utils
-from streamflow.core.command import CommandTokenProcessor, UnionCommandTokenProcessor
 from streamflow.core.config import BindingConfig
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.deployment import FilterConfig, LocalTarget
-from streamflow.core.workflow import Step
+from streamflow.core.workflow import CommandTokenProcessor, Step
 from streamflow.cwl.combinator import ListMergeCombinator
 from streamflow.cwl.command import (
     CWLCommand,
@@ -55,6 +54,7 @@ from streamflow.cwl.transformer import (
 )
 from streamflow.cwl.utils import LoadListing, SecondaryFile
 from streamflow.cwl.workflow import CWLWorkflow
+from streamflow.workflow.command import UnionCommandTokenProcessor
 from streamflow.workflow.port import ConnectorPort, JobPort
 from streamflow.workflow.step import CombinatorStep, ExecuteStep
 from tests.conftest import save_load_and_test

--- a/tests/utils/workflow.py
+++ b/tests/utils/workflow.py
@@ -8,7 +8,6 @@ from collections.abc import MutableMapping, MutableSequence
 from typing import TYPE_CHECKING, Any, cast
 
 from streamflow.core import utils
-from streamflow.core.command import Command, CommandOutput, CommandOutputProcessor
 from streamflow.core.config import BindingConfig
 from streamflow.core.data import DataLocation, DataType
 from streamflow.core.deployment import (
@@ -22,7 +21,17 @@ from streamflow.core.persistence import DatabaseLoadingContext
 from streamflow.core.recovery import RetryRequest
 from streamflow.core.scheduling import HardwareRequirement
 from streamflow.core.utils import flatten_list, get_job_tag, get_tag
-from streamflow.core.workflow import Job, Port, Status, Step, Token, Workflow
+from streamflow.core.workflow import (
+    Command,
+    CommandOutput,
+    CommandOutputProcessor,
+    Job,
+    Port,
+    Status,
+    Step,
+    Token,
+    Workflow,
+)
 from streamflow.cwl.hardware import CWLHardwareRequirement
 from streamflow.cwl.step import CWLScheduleStep
 from streamflow.cwl.utils import get_token_class, search_in_parent_locations


### PR DESCRIPTION
This commit adds a check to warn the user if there are bindings (steps or ports) in the StreamFlow config file that do not have a corresponding entity in the workflow. This commit also refactors the `Command` classes in the `streamflow.core` to remove circular dependencies. Finally, this commit improves the check for circular deployment wrappers introduced in #705 by keeping track of the already visited deployments.
