### PR TITLE
Removed comparison operators from `Hardware` class

### DIFF
--- a/streamflow/core/scheduling.py
+++ b/streamflow/core/scheduling.py
@@ -176,30 +176,28 @@ class Hardware:
     def __le__(self, other: Any) -> bool:
         if not isinstance(other, Hardware):
             raise NotImplementedError
-        if self.cores <= other.cores or self.memory <= other.memory:
-            return True
-        else:
-            _check_storages(self, other)
+        if self.cores <= other.cores and self.memory <= other.memory:
+            _check_storages(other, self)
             other_norm = other._normalize_storage()
-            return any(
+            return all(
                 self_disk <= other_norm[self_disk.mount_point]
                 for self_disk in self._normalize_storage().values()
-                if self_disk.mount_point in other_norm
             )
+        else:
+            return False
 
     def __lt__(self, other: Any) -> bool:
         if not isinstance(other, Hardware):
             raise NotImplementedError
-        if self.cores < other.cores or self.memory < other.memory:
-            return True
-        else:
-            _check_storages(self, other)
+        if self.cores < other.cores and self.memory < other.memory:
+            _check_storages(other, self)
             other_norm = other._normalize_storage()
-            return any(
+            return all(
                 self_disk < other_norm[self_disk.mount_point]
                 for self_disk in self._normalize_storage().values()
-                if self_disk.mount_point in other_norm
             )
+        else:
+            return False
 
 
 class HardwareRequirement(ABC):

--- a/streamflow/core/scheduling.py
+++ b/streamflow/core/scheduling.py
@@ -140,8 +140,8 @@ class Hardware:
             ),
         )
 
-    def can_host(self, other: Any) -> bool:
-        """The hardware is enough to host the other hardware"""
+    def satisfies(self, other: Any) -> bool:
+        """Check if this hardware has enough resources to satisfy the requirement."""
         if not isinstance(other, Hardware):
             raise NotImplementedError
         if self.cores >= other.cores and self.memory >= other.memory:

--- a/streamflow/core/scheduling.py
+++ b/streamflow/core/scheduling.py
@@ -176,28 +176,30 @@ class Hardware:
     def __le__(self, other: Any) -> bool:
         if not isinstance(other, Hardware):
             raise NotImplementedError
-        if self.cores <= other.cores and self.memory <= other.memory:
-            _check_storages(other, self)
+        if self.cores <= other.cores or self.memory <= other.memory:
+            return True
+        else:
+            _check_storages(self, other)
             other_norm = other._normalize_storage()
-            return all(
+            return any(
                 self_disk <= other_norm[self_disk.mount_point]
                 for self_disk in self._normalize_storage().values()
+                if self_disk.mount_point in other_norm
             )
-        else:
-            return False
 
     def __lt__(self, other: Any) -> bool:
         if not isinstance(other, Hardware):
             raise NotImplementedError
-        if self.cores < other.cores and self.memory < other.memory:
-            _check_storages(other, self)
+        if self.cores < other.cores or self.memory < other.memory:
+            return True
+        else:
+            _check_storages(self, other)
             other_norm = other._normalize_storage()
-            return all(
+            return any(
                 self_disk < other_norm[self_disk.mount_point]
                 for self_disk in self._normalize_storage().values()
+                if self_disk.mount_point in other_norm
             )
-        else:
-            return False
 
 
 class HardwareRequirement(ABC):

--- a/streamflow/core/scheduling.py
+++ b/streamflow/core/scheduling.py
@@ -26,13 +26,6 @@ if TYPE_CHECKING:
     from streamflow.core.workflow import Job, Status
 
 
-def _check_storages(hardware_a: Hardware, hardware_b: Hardware) -> None:
-    if set(hardware_b.get_mount_points()) - set(hardware_a.get_mount_points()):
-        raise WorkflowExecutionException(
-            f"Invalid `Hardware` comparison: {hardware_a} should contain all the storage included in {hardware_b}."
-        )
-
-
 def _reduce_storages(
     storages: Iterable[Storage], operator: Callable[[Storage, Any], Storage]
 ) -> MutableMapping[str, Storage]:
@@ -147,54 +140,20 @@ class Hardware:
             ),
         )
 
-    def __ge__(self, other: Any) -> bool:
+    def can_host(self, other: Any) -> bool:
+        """The hardware is enough to host the other hardware"""
         if not isinstance(other, Hardware):
             raise NotImplementedError
         if self.cores >= other.cores and self.memory >= other.memory:
-            _check_storages(self, other)
-            self_norm = self._normalize_storage()
+            if set((other_norm := other._normalize_storage()).keys()) - set(
+                (self_norm := self._normalize_storage()).keys()
+            ):
+                raise WorkflowExecutionException(
+                    f"Invalid `Hardware` comparison: {self} should contain all the storage included in {other}."
+                )
             return all(
-                self_norm[other_disk.mount_point] >= other_disk
-                for other_disk in other._normalize_storage().values()
-            )
-        else:
-            return False
-
-    def __gt__(self, other: Any) -> bool:
-        if not isinstance(other, Hardware):
-            raise NotImplementedError
-        if self.cores > other.cores and self.memory > other.memory:
-            _check_storages(self, other)
-            self_norm = self._normalize_storage()
-            return all(
-                self_norm[other_disk.mount_point] > other_disk
-                for other_disk in other._normalize_storage().values()
-            )
-        else:
-            return False
-
-    def __le__(self, other: Any) -> bool:
-        if not isinstance(other, Hardware):
-            raise NotImplementedError
-        if self.cores <= other.cores and self.memory <= other.memory:
-            _check_storages(other, self)
-            other_norm = other._normalize_storage()
-            return all(
-                self_disk <= other_norm[self_disk.mount_point]
-                for self_disk in self._normalize_storage().values()
-            )
-        else:
-            return False
-
-    def __lt__(self, other: Any) -> bool:
-        if not isinstance(other, Hardware):
-            raise NotImplementedError
-        if self.cores < other.cores and self.memory < other.memory:
-            _check_storages(other, self)
-            other_norm = other._normalize_storage()
-            return all(
-                self_disk < other_norm[self_disk.mount_point]
-                for self_disk in self._normalize_storage().values()
+                self_norm[other_disk.mount_point].size >= other_disk.size
+                for other_disk in other_norm.values()
             )
         else:
             return False
@@ -488,39 +447,3 @@ class Storage:
             paths=self.paths | other.paths,
             bind=self.bind,
         )
-
-    def __ge__(self, other: Any) -> bool:
-        if not isinstance(other, Storage):
-            raise NotImplementedError
-        if self.mount_point != other.mount_point:
-            raise KeyError(
-                f"Cannot compare two storages with different mount points: {self.mount_point} and {other.mount_point}"
-            )
-        return self.size >= other.size
-
-    def __gt__(self, other: Any) -> bool:
-        if not isinstance(other, Storage):
-            raise NotImplementedError
-        if self.mount_point != other.mount_point:
-            raise KeyError(
-                f"Cannot compare two storages with different mount points: {self.mount_point} and {other.mount_point}"
-            )
-        return self.size > other.size
-
-    def __le__(self, other: Any) -> bool:
-        if not isinstance(other, Storage):
-            raise NotImplementedError
-        if self.mount_point != other.mount_point:
-            raise KeyError(
-                f"Cannot compare two storages with different mount points: {self.mount_point} and {other.mount_point}"
-            )
-        return self.size <= other.size
-
-    def __lt__(self, other: Any) -> bool:
-        if not isinstance(other, Storage):
-            raise NotImplementedError
-        if self.mount_point != other.mount_point:
-            raise KeyError(
-                f"Cannot compare two storages with different mount points: {self.mount_point} and {other.mount_point}"
-            )
-        return self.size < other.size

--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -272,7 +272,7 @@ class DefaultScheduler(Scheduler):
                     (
                         location.hardware
                         - self.hardware_locations.get(location.name, Hardware())
-                    ).can_host(hardware_requirement)
+                    ).satisfies(hardware_requirement)
                 ):
                     return False
             # Otherwise, simply compute the number of allocated slots

--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -268,10 +268,13 @@ class DefaultScheduler(Scheduler):
             # If at least one location provides hardware capabilities
             if location.hardware is not None:
                 # Compute the used amount of locations
-                if (
-                    location.hardware
-                    - self.hardware_locations.get(location.name, Hardware())
-                ) < hardware_requirement:
+                if not (
+                    (
+                        location.hardware
+                        - self.hardware_locations.get(location.name, Hardware())
+                    )
+                    >= hardware_requirement
+                ):
                     return False
             # Otherwise, simply compute the number of allocated slots
             else:

--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -272,8 +272,7 @@ class DefaultScheduler(Scheduler):
                     (
                         location.hardware
                         - self.hardware_locations.get(location.name, Hardware())
-                    )
-                    >= hardware_requirement
+                    ).can_host(hardware_requirement)
                 ):
                     return False
             # Otherwise, simply compute the number of allocated slots

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -24,7 +24,6 @@ from streamflow.core.exception import (
     FailureHandlingException,
     WorkflowDefinitionException,
     WorkflowException,
-    WorkflowExecutionException,
 )
 from streamflow.core.persistence import DatabaseLoadingContext
 from streamflow.core.scheduling import HardwareRequirement
@@ -106,10 +105,6 @@ class BaseStep(Step, ABC):
                 ),
             )
         }
-        if len(tags := {t.tag for t in inputs.values()}) != 1:
-            raise WorkflowExecutionException(
-                f"Step {self.name} has input tokens with different tags {tags}"
-            )
         if logger.isEnabledFor(logging.DEBUG):
             if check_termination(inputs.values()):
                 logger.debug(

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -50,9 +50,9 @@ def _prepare_connector(context: StreamFlowContext, num_jobs: int = 1):
         context.deployment_manager.get_connector("custom-hardware"),
     )
     conn.set_hardware(
-        Hardware(
+        hardware=Hardware(
             cores=hardware_requirement.cores * num_jobs,
-            memory=hardware_requirement.memory * num_jobs,
+            memory=hardware_requirement.memory * num_jobs * 3,
             storage={
                 os.sep: Storage(
                     os.sep,
@@ -186,145 +186,8 @@ async def test_binding_filter(context: StreamFlowContext):
     await _notify_status_and_test(context, job, Status.COMPLETED)
 
 
-def test_hardware1():
-
-    location_hardware = Hardware(
-        cores=8.0,
-        memory=30073.26953125,
-        storage={
-            "/sys/firmware/efi/efivars": Storage(
-                mount_point="/sys/firmware/efi/efivars",
-                size=0.22668075561523438,
-                bind=None,
-                paths=set(),
-            ),
-            "/": Storage(
-                mount_point="/",
-                size=34625.1953125,
-                bind=None,
-                paths={"/tmp/streamflow"},
-            ),
-            "/proc/sys/fs/binfmt_misc": Storage(
-                mount_point="/ proc / sys / fs / binfmt_misc",
-                size=0.0,
-                bind=None,
-                paths=set(),
-            ),
-            "/software": Storage(
-                mount_point="/ software", size=9641972.0, bind=None, paths=set()
-            ),
-            "/snap/bare/5": Storage(
-                mount_point="/ snap / bare / 5", size=0.0, bind=None, paths=set()
-            ),
-            "/snap/core22/1748": Storage(
-                mount_point="/ snap / core22 / 1748", size=0.0, bind=None, paths=set()
-            ),
-            "/snap/gnome-42-2204/202": Storage(
-                mount_point="/ snap / gnome - 42 - 2204 / 202",
-                size=0.0,
-                bind=None,
-                paths=set(),
-            ),
-            "/snap/gtk-common-themes/1535": Storage(
-                mount_point="/ snap / gtk - common - themes / 1535",
-                size=0.0,
-                bind=None,
-                paths=set(),
-            ),
-            "/snap/snapd/23545": Storage(
-                mount_point="/ snap / snapd / 23545", size=0.0, bind=None, paths=set()
-            ),
-            "/boot": Storage(
-                mount_point="/ boot", size=638.39453125, bind=None, paths=set()
-            ),
-        },
-    )
-
-    used_hardware = Hardware(
-        cores=8.0,
-        memory=1024.0,
-        storage={
-            "/": Storage(
-                mount_point="/", size=8192.0, bind=None, paths={"/tmp/streamflow"}
-            )
-        },
-    )
-
-    expected_diff = Hardware(
-        cores=0.0,
-        memory=29049.26953125,
-        storage={
-            "/sys/firmware/efi/efivars": Storage(
-                mount_point="/sys/firmware/efi/efivars",
-                size=0.22668075561523438,
-                bind=None,
-                paths=set(),
-            ),
-            "/": Storage(mount_point="/", size=26433.1953125, bind=None, paths=set()),
-            "/proc/sys/fs/binfmt_misc": Storage(
-                mount_point="/ proc / sys / fs / binfmt_misc",
-                size=0.0,
-                bind=None,
-                paths=set(),
-            ),
-            "/software": Storage(
-                mount_point="/ software", size=9641972.0, bind=None, paths=set()
-            ),
-            "/snap/bare/5": Storage(
-                mount_point="/ snap / bare / 5", size=0.0, bind=None, paths=set()
-            ),
-            "/snap/core22/1748": Storage(
-                mount_point="/ snap / core22 / 1748", size=0.0, bind=None, paths=set()
-            ),
-            "/snap/gnome-42-2204/202": Storage(
-                mount_point="/ snap / gnome - 42 - 2204 / 202",
-                size=0.0,
-                bind=None,
-                paths=set(),
-            ),
-            "/snap/gtk-common-themes/1535": Storage(
-                mount_point="/ snap / gtk - common - themes / 1535",
-                size=0.0,
-                bind=None,
-                paths=set(),
-            ),
-            "/snap/snapd/23545": Storage(
-                mount_point="/ snap / snapd / 23545", size=0.0, bind=None, paths=set()
-            ),
-            "/boot": Storage(
-                mount_point="/ boot", size=638.39453125, bind=None, paths=set()
-            ),
-        },
-    )
-
-    diff = location_hardware - used_hardware
-    assert diff.cores == expected_diff.cores
-    assert diff.memory == expected_diff.memory
-    for s1, s2 in zip(diff.storage.values(), expected_diff.storage.values()):
-        assert s1.mount_point == s2.mount_point
-        assert s1.paths == s2.paths
-        assert s1.bind == s2.bind
-        assert s1.size == s2.size
-
-    hardware_requirement = Hardware(
-        cores=2,
-        memory=256,
-        storage={
-            "__outdir__": Storage(
-                mount_point="/", size=1024, bind=None, paths={"/tmp/streamflow"}
-            ),
-            "__tmpdir__": Storage(
-                mount_point="/", size=1024, bind=None, paths={"/tmp/streamflow"}
-            ),
-        },
-    )
-    assert diff < hardware_requirement
-
-
 def test_hardware():
     """Test Hardware arithmetic and comparison operations"""
-    # TODO: create dedicated tests for each operation arithmetic and comparison
-    #  for each comparison op the tests must cover all the cases: less/equal/more in cores, memory and storage
     main_hardware = Hardware(
         cores=float(2**4),
         memory=float(2**10),
@@ -370,20 +233,18 @@ def test_hardware():
     assert main_hardware <= secondary_hardware
     assert secondary_hardware >= main_hardware
 
-    bigger_main_hw = Hardware(
-        cores=main_hardware.cores + 1,
-        memory=main_hardware.memory + 1,
-        storage={
-            "placeholder_5": Storage(os.path.join(os.sep, "tmp", "streamflow"), size=10)
-        },
-    )
-    with pytest.raises(WorkflowExecutionException) as err:
-        _ = bigger_main_hw <= main_hardware
-    assert (
-        str(err.value) == f"Invalid `Hardware` comparison: {bigger_main_hw} should "
-        f"contain all the storage included in {main_hardware}."
-    )
+    # Hardware must have the same `mount_point` to execute comparison operations.
+    # The "bigger" hardware must have at least all the mount_point values of the "smaller" one;
+    # otherwise, an error must be raised.
+    # If this check is not performed, for example, if the two hardware have different
+    # `mount_point` values at scheduling time, the scheduling process may enter an infinite loop.
     main_hardware.storage.pop("placeholder_3")
+    with pytest.raises(WorkflowExecutionException) as err:
+        _ = secondary_hardware <= main_hardware
+    assert (
+        str(err.value) == f"Invalid `Hardware` comparison: {main_hardware} should "
+        f"contain all the storage included in {secondary_hardware}."
+    )
     with pytest.raises(WorkflowExecutionException) as err:
         _ = main_hardware >= secondary_hardware
     assert (
@@ -587,26 +448,39 @@ async def test_single_env_enough_resources(context: StreamFlowContext):
     ]
 
     binding_config = BindingConfig(targets=[target])
-    task_pending = [
-        asyncio.create_task(
-            context.scheduler.schedule(job, binding_config, hardware_requirement)
+    try:
+        task_pending = [
+            asyncio.create_task(
+                context.scheduler.schedule(job, binding_config, hardware_requirement)
+            )
+            for job in jobs
+        ]
+        assert len(task_pending) == num_jobs
+
+        # Available resources to schedule all the jobs (timeout parameter useful if a deadlock occurs)
+        task_completed, task_pending = await asyncio.wait(
+            task_pending, return_when=asyncio.ALL_COMPLETED, timeout=60
         )
-        for job in jobs
-    ]
-    assert len(task_pending) == num_jobs
+        assert len(task_pending) == 0
+        # Test errors were raised
+        for t in task_completed:
+            assert t.result() is None
+        for j in jobs:
+            assert context.scheduler.get_allocation(j.name).status == Status.FIREABLE
 
-    # Available resources to schedule all the jobs (timeout parameter useful if a deadlock occurs)
-    _, task_pending = await asyncio.wait(
-        task_pending, return_when=asyncio.ALL_COMPLETED, timeout=60
-    )
-    assert len(task_pending) == 0
-    for j in jobs:
-        assert context.scheduler.get_allocation(j.name).status == Status.FIREABLE
-
-    # Jobs change status to RUNNING
-    await _notify_status_and_test(context, jobs, Status.RUNNING)
-    # Jobs change status to COMPLETED
-    await _notify_status_and_test(context, jobs, Status.COMPLETED)
+        # Jobs change status to RUNNING
+        await _notify_status_and_test(context, jobs, Status.RUNNING)
+        # Jobs change status to COMPLETED
+        await _notify_status_and_test(context, jobs, Status.COMPLETED)
+    finally:
+        await asyncio.gather(
+            *(
+                asyncio.create_task(
+                    context.scheduler.notify_status(j.name, Status.COMPLETED)
+                )
+                for j in jobs
+            )
+        )
 
 
 @pytest.mark.asyncio
@@ -627,40 +501,53 @@ async def test_single_env_few_resources(context: StreamFlowContext):
     ]
 
     binding_config = BindingConfig(targets=[target])
-    task_pending = [
-        asyncio.create_task(
-            context.scheduler.schedule(job, binding_config, hardware_requirement)
+    try:
+        task_pending = [
+            asyncio.create_task(
+                context.scheduler.schedule(job, binding_config, hardware_requirement)
+            )
+            for job in jobs
+        ]
+        assert len(task_pending) == 2
+
+        # Available resources to schedule only one job (timeout parameter useful if a deadlock occurs)
+        task_completed, task_pending = await asyncio.wait(
+            task_pending, return_when=asyncio.FIRST_COMPLETED, timeout=60
         )
-        for job in jobs
-    ]
-    assert len(task_pending) == 2
+        assert len(task_pending) == 1
+        # Test errors were raised
+        for t in task_completed:
+            assert t.result() is None
+        assert context.scheduler.get_allocation(jobs[0].name).status == Status.FIREABLE
+        assert context.scheduler.get_allocation(jobs[1].name) is None
 
-    # Available resources to schedule only one job (timeout parameter useful if a deadlock occurs)
-    _, task_pending = await asyncio.wait(
-        task_pending, return_when=asyncio.FIRST_COMPLETED, timeout=60
-    )
-    assert len(task_pending) == 1
-    assert context.scheduler.get_allocation(jobs[0].name).status == Status.FIREABLE
-    assert context.scheduler.get_allocation(jobs[1].name) is None
+        # First job changes status to RUNNING and continue to keep all resources
+        # Testing that second job is not scheduled (timeout parameter necessary)
+        await context.scheduler.notify_status(jobs[0].name, Status.RUNNING)
+        _, task_pending = await asyncio.wait(task_pending, timeout=2)
 
-    # First job changes status to RUNNING and continue to keep all resources
-    # Testing that second job is not scheduled (timeout parameter necessary)
-    await context.scheduler.notify_status(jobs[0].name, Status.RUNNING)
-    _, task_pending = await asyncio.wait(task_pending, timeout=2)
+        assert len(task_pending) == 1
+        assert context.scheduler.get_allocation(jobs[0].name).status == Status.RUNNING
+        assert context.scheduler.get_allocation(jobs[1].name) is None
 
-    assert len(task_pending) == 1
-    assert context.scheduler.get_allocation(jobs[0].name).status == Status.RUNNING
-    assert context.scheduler.get_allocation(jobs[1].name) is None
+        # First job completes and the second job can be scheduled (timeout parameter useful if a deadlock occurs)
+        await context.scheduler.notify_status(jobs[0].name, Status.COMPLETED)
+        _, task_pending = await asyncio.wait(
+            task_pending, return_when=asyncio.ALL_COMPLETED, timeout=60
+        )
+        assert len(task_pending) == 0
+        assert context.scheduler.get_allocation(jobs[0].name).status == Status.COMPLETED
+        assert context.scheduler.get_allocation(jobs[1].name).status == Status.FIREABLE
 
-    # First job completes and the second job can be scheduled (timeout parameter useful if a deadlock occurs)
-    await context.scheduler.notify_status(jobs[0].name, Status.COMPLETED)
-    _, task_pending = await asyncio.wait(
-        task_pending, return_when=asyncio.ALL_COMPLETED, timeout=60
-    )
-    assert len(task_pending) == 0
-    assert context.scheduler.get_allocation(jobs[0].name).status == Status.COMPLETED
-    assert context.scheduler.get_allocation(jobs[1].name).status == Status.FIREABLE
-
-    # Second job completed
-    await _notify_status_and_test(context, jobs[1], Status.RUNNING)
-    await _notify_status_and_test(context, jobs[1], Status.COMPLETED)
+        # Second job completed
+        await _notify_status_and_test(context, jobs[1], Status.RUNNING)
+        await _notify_status_and_test(context, jobs[1], Status.COMPLETED)
+    finally:
+        await asyncio.gather(
+            *(
+                asyncio.create_task(
+                    context.scheduler.notify_status(j.name, Status.COMPLETED)
+                )
+                for j in jobs
+            )
+        )

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -142,7 +142,7 @@ async def test_bind_volumes(context: StreamFlowContext):
     ).mount_point == await utils.get_mount_point(
         context, local_location, local_deployment.workdir
     )
-    assert local_location.hardware.can_host(container_hardware)
+    assert local_location.hardware.satisfies(container_hardware)
 
 
 @pytest.mark.asyncio
@@ -240,8 +240,8 @@ def test_hardware():
         main_hardware.storage["placeholder_3"].mount_point
     )
     # The `secondary_hardware` has more cores and disk space in the `/tmp` storage than `main_hardware`
-    assert secondary_hardware.can_host(main_hardware)
-    assert not main_hardware.can_host(secondary_hardware)
+    assert secondary_hardware.satisfies(main_hardware)
+    assert not main_hardware.satisfies(secondary_hardware)
 
     # Testing difference operation
     secondary_hardware -= extra_hardware
@@ -252,11 +252,11 @@ def test_hardware():
         secondary_hardware.get_storage(testing_mount_point).size
         == main_hardware.get_storage(testing_mount_point).size
     )
-    assert main_hardware.can_host(secondary_hardware)
+    assert main_hardware.satisfies(secondary_hardware)
     # Testing the validity of the storage comparison
     main_hardware.storage.pop("placeholder_3")
     with pytest.raises(WorkflowExecutionException) as err:
-        _ = main_hardware.can_host(secondary_hardware)
+        _ = main_hardware.satisfies(secondary_hardware)
     assert (
         str(err.value) == f"Invalid `Hardware` comparison: {main_hardware} should "
         f"contain all the storage included in {secondary_hardware}."


### PR DESCRIPTION
This commit prevents the overfilling of `Hardware` resources by fixing an erroneous hardware comparison. In addition, this commit removes the overloaded comparison operators in the `Hardware` class, as they could lead to ambiguous results. In lieu of this, this commit introduces a `satisfies` method to check whether an `Hardware` instance has enough resources to satisfy a requirement.

This commit also improves `Hardware` tests. The `test_single_env_few_resources` unit test of the `test_scheduler.py` file has been improved to have a more realistic case (i.e., the location does not have exactly the needed resources). Additionally, a `finally` block has been added to free the resources in case of a failed test. Finally, an assertion is made to check the job status when attempting to be scheduled to ensure that no errors are raised. The `asyncio.wait` did not raise the exception until the task result was checked.