### PR TITLE
Capture `TimeoutError` when retrieving disk usage

### DIFF
--- a/streamflow/deployment/connector/local.py
+++ b/streamflow/deployment/connector/local.py
@@ -52,10 +52,10 @@ class LocalConnector(BaseConnector):
                         mount_point=disk.mountpoint,
                         size=shutil.disk_usage(disk.mountpoint).free / 2**20,
                     )
-                except PermissionError as pe:
+                except (PermissionError, TimeoutError) as e:
                     logger.warning(
                         f"Skipping Storage on partition {disk.device} on {disk.mountpoint} "
-                        f"for deployment {self.deployment_name}: {pe}"
+                        f"for deployment {self.deployment_name}: {e}"
                     )
         self._hardware: Hardware = Hardware(
             cores=float(psutil.cpu_count()),


### PR DESCRIPTION
Some network file systems may return a `TimeoutError` when trying to query their space through the `os.statvfs` method. This commit fixes the code to correctly handle this case.