### PR TITLE
Add a check to verify object instantiation in persistence tests

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -158,7 +158,7 @@ jobs:
           python -m pip install .
       - name: "Build documentation and check for consistency"
         env:
-          CHECKSUM: "f7c92b8f54ee12821a4e7d9bd49ca6e05bb343b48034c97abd07d39c3193e466"
+          CHECKSUM: "c46318a9221772bb6c442b1ada9d375c30fc4e2a2e91a20f287f0a4ed1a71bd9"
         run: |
           cd docs
           HASH="$(make checksum | tail -n1)"

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -158,7 +158,7 @@ jobs:
           python -m pip install .
       - name: "Build documentation and check for consistency"
         env:
-          CHECKSUM: "063fde5ed9244856f1545f7dbaf75378fd8444afd06c10f168ff896ba1e854f8"
+          CHECKSUM: "c43d92c19552aef86ccc418c52038c9d941ecbd86f3f23231e67ed161ee9d7ab"
         run: |
           cd docs
           HASH="$(make checksum | tail -n1)"

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -158,7 +158,7 @@ jobs:
           python -m pip install .
       - name: "Build documentation and check for consistency"
         env:
-          CHECKSUM: "feb4ec30d8f294a0a31f7d475e0caa9240b763ac969718956814abce1f7c85ec"
+          CHECKSUM: "063fde5ed9244856f1545f7dbaf75378fd8444afd06c10f168ff896ba1e854f8"
         run: |
           cd docs
           HASH="$(make checksum | tail -n1)"

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -158,7 +158,7 @@ jobs:
           python -m pip install .
       - name: "Build documentation and check for consistency"
         env:
-          CHECKSUM: "c43d92c19552aef86ccc418c52038c9d941ecbd86f3f23231e67ed161ee9d7ab"
+          CHECKSUM: "f7c92b8f54ee12821a4e7d9bd49ca6e05bb343b48034c97abd07d39c3193e466"
         run: |
           cd docs
           HASH="$(make checksum | tail -n1)"

--- a/docs/source/ext/database.rst
+++ b/docs/source/ext/database.rst
@@ -143,6 +143,11 @@ The ``Database`` interface, defined in the ``streamflow.core.persistence`` modul
     ) -> MutableSequence[MutableMapping[str, Any]]:
         ...
 
+    async def get_filter(
+        self, filter_id: int
+    ) -> MutableMapping[str, Any]:
+        ...
+
     async def get_input_ports(
         self, step_id: int
     ) -> MutableSequence[MutableMapping[str, Any]]:
@@ -230,6 +235,11 @@ The ``Database`` interface, defined in the ``streamflow.core.persistence`` modul
 
     async def update_execution(
         self, execution_id: int, updates: MutableMapping[str, Any]
+    ) -> int:
+        ...
+
+    async def update_filter(
+        self, filter_id: int, updates: MutableMapping[str, Any]
     ) -> int:
         ...
 

--- a/docs/source/ext/database.rst
+++ b/docs/source/ext/database.rst
@@ -46,7 +46,9 @@ The ``Database`` interface, defined in the ``streamflow.core.persistence`` modul
         config: str,
         external: bool,
         lazy: bool,
+        scheduling_policy: str,
         workdir: str | None,
+        wraps: MutableMapping[str, Any] | None,
     ) -> int:
         ...
 

--- a/docs/source/ext/database.rst
+++ b/docs/source/ext/database.rst
@@ -43,7 +43,7 @@ The ``Database`` interface, defined in the ``streamflow.core.persistence`` modul
         self,
         name: str,
         type: str,
-        config: str,
+        config: MutableMapping[str, Any],
         external: bool,
         lazy: bool,
         scheduling_policy: MutableMapping[str, Any],
@@ -54,6 +54,14 @@ The ``Database`` interface, defined in the ``streamflow.core.persistence`` modul
 
     async def add_execution(
         self, step_id: int, tag: str, cmd: str
+    ) -> int:
+        ...
+
+    async def add_filter(
+        self,
+        name: str,
+        type: str,
+        config: MutableMapping[str, Any],
     ) -> int:
         ...
 

--- a/docs/source/ext/database.rst
+++ b/docs/source/ext/database.rst
@@ -46,7 +46,7 @@ The ``Database`` interface, defined in the ``streamflow.core.persistence`` modul
         config: str,
         external: bool,
         lazy: bool,
-        scheduling_policy: str,
+        scheduling_policy: MutableMapping[str, Any],
         workdir: str | None,
         wraps: MutableMapping[str, Any] | None,
     ) -> int:

--- a/streamflow/core/config.py
+++ b/streamflow/core/config.py
@@ -31,7 +31,7 @@ class Config:
         row: MutableMapping[str, Any],
         loading_context: DatabaseLoadingContext,
     ):
-        return Config(name=row["name"], type=row["type"], config=row["config"])
+        return cls(name=row["name"], type=row["type"], config=row["config"])
 
     async def save(self, context: StreamFlowContext):
         return {"name": self.name, "type": self.type, "config": self.config}

--- a/streamflow/core/config.py
+++ b/streamflow/core/config.py
@@ -31,12 +31,10 @@ class Config:
         row: MutableMapping[str, Any],
         loading_context: DatabaseLoadingContext,
     ):
-        return Config(
-            name=row["name"], type=row["type"], config=json.loads(row["config"])
-        )
+        return Config(name=row["name"], type=row["type"], config=row["config"])
 
     async def save(self, context: StreamFlowContext):
-        return {"name": self.name, "type": self.type, "config": json.dumps(self.config)}
+        return {"name": self.name, "type": self.type, "config": self.config}
 
 
 class BindingConfig:

--- a/streamflow/core/config.py
+++ b/streamflow/core/config.py
@@ -24,6 +24,20 @@ class Config:
         self.type: str = type
         self.config: MutableMapping[str, Any] = config or {}
 
+    @classmethod
+    async def load(
+        cls,
+        context: StreamFlowContext,
+        row: MutableMapping[str, Any],
+        loading_context: DatabaseLoadingContext,
+    ):
+        return Config(
+            name=row["name"], type=row["type"], config=json.loads(row["config"])
+        )
+
+    async def save(self, context: StreamFlowContext):
+        return {"name": self.name, "type": self.type, "config": json.dumps(self.config)}
+
 
 class BindingConfig:
     __slots__ = ("targets", "filters")

--- a/streamflow/core/deployment.py
+++ b/streamflow/core/deployment.py
@@ -225,7 +225,7 @@ class DeploymentConfig(PersistableEntity):
                     row=json.loads(row["wraps"]),
                     loading_context=loading_context,
                 )
-                if row["wraps"] != "null"
+                if row["wraps"] is not None
                 else None
             ),
         )

--- a/streamflow/core/deployment.py
+++ b/streamflow/core/deployment.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import os
 import posixpath
 import tempfile
@@ -210,19 +209,19 @@ class DeploymentConfig(PersistableEntity):
         obj = cls(
             name=row["name"],
             type=row["type"],
-            config=json.loads(row["config"]),
+            config=row["config"],
             external=row["external"],
             lazy=row["lazy"],
             scheduling_policy=await Config.load(
                 context=context,
-                row=json.loads(row["scheduling_policy"]),
+                row=row["scheduling_policy"],
                 loading_context=loading_context,
             ),
             workdir=row["workdir"],
             wraps=(
                 await WrapsConfig.load(
                     context=context,
-                    row=json.loads(row["wraps"]),
+                    row=row["wraps"],
                     loading_context=loading_context,
                 )
                 if row["wraps"] is not None
@@ -238,7 +237,7 @@ class DeploymentConfig(PersistableEntity):
                 self.persistent_id = await context.database.add_deployment(
                     name=self.name,
                     type=self.type,
-                    config=json.dumps(self.config),
+                    config=self.config,
                     external=self.external,
                     lazy=self.lazy,
                     scheduling_policy=await self.scheduling_policy.save(context),
@@ -372,7 +371,7 @@ class FilterConfig(PersistableEntity):
         obj = cls(
             name=row["name"],
             type=row["type"],
-            config=json.loads(row["config"]),
+            config=row["config"],
         )
         loading_context.add_filter(persistent_id, obj)
         return obj
@@ -383,7 +382,7 @@ class FilterConfig(PersistableEntity):
                 self.persistent_id = await context.database.add_filter(
                     name=self.name,
                     type=self.type,
-                    config=json.dumps(self.config),
+                    config=self.config,
                 )
 
 

--- a/streamflow/core/persistence.py
+++ b/streamflow/core/persistence.py
@@ -112,7 +112,7 @@ class Database(SchemaEntity):
         self,
         name: str,
         type: str,
-        config: str,
+        config: MutableMapping[str, Any],
         external: bool,
         lazy: bool,
         scheduling_policy: MutableMapping[str, Any],
@@ -128,7 +128,7 @@ class Database(SchemaEntity):
         self,
         name: str,
         type: str,
-        config: str,
+        config: MutableMapping[str, Any],
     ) -> int: ...
 
     @abstractmethod

--- a/streamflow/core/persistence.py
+++ b/streamflow/core/persistence.py
@@ -115,6 +115,7 @@ class Database(SchemaEntity):
         config: str,
         external: bool,
         lazy: bool,
+        scheduling_policy: str,
         workdir: str | None,
         wraps: MutableMapping[str, Any] | None,
     ) -> int: ...

--- a/streamflow/core/persistence.py
+++ b/streamflow/core/persistence.py
@@ -115,7 +115,7 @@ class Database(SchemaEntity):
         config: str,
         external: bool,
         lazy: bool,
-        scheduling_policy: str,
+        scheduling_policy: MutableMapping[str, Any],
         workdir: str | None,
         wraps: MutableMapping[str, Any] | None,
     ) -> int: ...

--- a/streamflow/core/workflow.py
+++ b/streamflow/core/workflow.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import sys
 import uuid
 from abc import ABC, abstractmethod
@@ -582,12 +581,12 @@ class Token(PersistableEntity):
         row: MutableMapping[str, Any],
         loading_context: DatabaseLoadingContext,
     ) -> Token:
-        value = json.loads(row["value"])
+        value = row["value"]
         if isinstance(value, MutableMapping) and "token" in value:
             value = await loading_context.load_token(context, value["token"])
         return cls(tag=row["tag"], value=value, recoverable=row["recoverable"])
 
-    async def _save_value(self, context: StreamFlowContext) -> MutableMapping[str, Any]:
+    async def _save_value(self, context: StreamFlowContext):
         if isinstance(self.value, Token) and not self.value.persistent_id:
             await self.value.save(context)
         return (
@@ -633,7 +632,7 @@ class Token(PersistableEntity):
                         recoverable=self.recoverable,
                         tag=self.tag,
                         type=type(self),
-                        value=json.dumps(await self._save_value(context)),
+                        value=await self._save_value(context),
                     )
                 except TypeError as e:
                     raise WorkflowExecutionException from e

--- a/streamflow/cwl/command.py
+++ b/streamflow/cwl/command.py
@@ -1228,6 +1228,7 @@ class CWLExpressionCommand(Command):
             initial_work_dir=row["initial_work_dir"],
             inplace_update=row["inplace_update"],
             expression=row["expression"],
+            time_limit=row["time_limit"],
         )
 
 

--- a/streamflow/cwl/step.py
+++ b/streamflow/cwl/step.py
@@ -606,6 +606,7 @@ class CWLTransferStep(TransferStep):
             job_port=cast(
                 JobPort, await loading_context.load_port(context, params["job_port"])
             ),
+            prefix_path=params["prefix_path"],
             writable=params["writable"],
         )
         return step
@@ -614,7 +615,8 @@ class CWLTransferStep(TransferStep):
         self, context: StreamFlowContext
     ) -> MutableMapping[str, Any]:
         return cast(dict[str, Any], await super()._save_additional_params(context)) | {
-            "writable": self.writable
+            "prefix_path": self.prefix_path,
+            "writable": self.writable,
         }
 
     async def _transfer_value(self, job: Job, token_value: Any) -> Any:

--- a/streamflow/cwl/step.py
+++ b/streamflow/cwl/step.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import urllib.parse
 from abc import ABC
@@ -284,7 +283,7 @@ class CWLConditionalStep(CWLBaseConditionalStep):
         row: MutableMapping[str, Any],
         loading_context: DatabaseLoadingContext,
     ) -> CWLConditionalStep:
-        params = json.loads(row["params"])
+        params = row["params"]
         step = cls(
             name=row["name"],
             workflow=cast(
@@ -367,15 +366,14 @@ class CWLEmptyScatterConditionalStep(CWLBaseConditionalStep):
         context: StreamFlowContext,
         row: MutableMapping[str, Any],
         loading_context: DatabaseLoadingContext,
-    ):
-        params = json.loads(row["params"])
+    ) -> CWLEmptyScatterConditionalStep:
         return cls(
             name=row["name"],
             workflow=cast(
                 CWLWorkflow,
                 await loading_context.load_workflow(context, row["workflow"]),
             ),
-            scatter_method=params["scatter_method"],
+            scatter_method=row["params"]["scatter_method"],
         )
 
     async def _on_true(self, inputs: MutableMapping[str, Token]):
@@ -493,7 +491,7 @@ class CWLExecuteStep(ExecuteStep):
         row: MutableMapping[str, Any],
         loading_context: DatabaseLoadingContext,
     ) -> CWLExecuteStep:
-        params = json.loads(row["params"])
+        params = row["params"]
         step = cls(
             name=row["name"],
             workflow=cast(
@@ -596,7 +594,7 @@ class CWLTransferStep(TransferStep):
         row: MutableMapping[str, Any],
         loading_context: DatabaseLoadingContext,
     ) -> CWLTransferStep:
-        params = json.loads(row["params"])
+        params = row["params"]
         step = cls(
             name=row["name"],
             workflow=cast(

--- a/streamflow/cwl/transformer.py
+++ b/streamflow/cwl/transformer.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import functools
-import json
 from collections.abc import MutableMapping, MutableSequence
 from typing import Any, cast
 
@@ -74,7 +73,7 @@ class CloneTransformer(ManyToOneTransformer):
                 await loading_context.load_workflow(context, row["workflow"]),
             ),
             replicas_port=await loading_context.load_port(
-                context, json.loads(row["params"])["replicas_port"]
+                context, row["params"]["replicas_port"]
             ),
         )
 
@@ -142,8 +141,8 @@ class CWLTokenTransformer(ManyToOneTransformer):
         context: StreamFlowContext,
         row: MutableMapping[str, Any],
         loading_context: DatabaseLoadingContext,
-    ):
-        params = json.loads(row["params"])
+    ) -> CWLTokenTransformer:
+        params = row["params"]
         return cls(
             name=row["name"],
             workflow=cast(
@@ -186,8 +185,7 @@ class DefaultTransformer(ManyToOneTransformer):
         context: StreamFlowContext,
         row: MutableMapping[str, Any],
         loading_context: DatabaseLoadingContext,
-    ):
-        params = json.loads(row["params"])
+    ) -> DefaultTransformer:
         return cls(
             name=row["name"],
             workflow=cast(
@@ -195,7 +193,7 @@ class DefaultTransformer(ManyToOneTransformer):
                 await loading_context.load_workflow(context, row["workflow"]),
             ),
             default_port=await loading_context.load_port(
-                context, params["default_port"]
+                context, row["params"]["default_port"]
             ),
         )
 
@@ -368,8 +366,8 @@ class ValueFromTransformer(ManyToOneTransformer):
         context: StreamFlowContext,
         row: MutableMapping[str, Any],
         loading_context: DatabaseLoadingContext,
-    ):
-        params = json.loads(row["params"])
+    ) -> ValueFromTransformer:
+        params = row["params"]
         job_port = cast(
             JobPort, await loading_context.load_port(context, params["job_port"])
         )

--- a/streamflow/cwl/workflow.py
+++ b/streamflow/cwl/workflow.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from collections.abc import MutableMapping, MutableSet
 from typing import TYPE_CHECKING, Any, cast
 
@@ -48,7 +47,7 @@ class CWLWorkflow(Workflow):
         row: MutableMapping[str, Any],
         loading_context: DatabaseLoadingContext,
     ) -> CWLWorkflow:
-        params = json.loads(row["params"])
+        params = row["params"]
         return cls(
             context=context,
             config=params["config"],

--- a/streamflow/persistence/schemas/sqlite.sql
+++ b/streamflow/persistence/schemas/sqlite.sql
@@ -85,14 +85,15 @@ CREATE TABLE IF NOT EXISTS provenance
 
 CREATE TABLE IF NOT EXISTS deployment
 (
-    id       INTEGER PRIMARY KEY,
-    name     TEXT,
-    type     TEXT,
-    config   TEXT,
-    external INTEGER,
-    lazy     INTEGER,
-    workdir  TEXT,
-    wraps    TEXT
+    id                  INTEGER PRIMARY KEY,
+    name                TEXT,
+    type                TEXT,
+    config              TEXT,
+    external            INTEGER,
+    lazy                INTEGER,
+    scheduling_policy   TEXT,
+    workdir             TEXT,
+    wraps               TEXT
 );
 
 

--- a/streamflow/persistence/sqlite.py
+++ b/streamflow/persistence/sqlite.py
@@ -107,19 +107,21 @@ class SqliteDatabase(CachedDatabase):
         config: str,
         external: bool,
         lazy: bool,
+        scheduling_policy: MutableMapping[str, Any],
         workdir: str | None,
         wraps: MutableMapping[str, Any] | None,
     ) -> int:
         async with self.connection as db:
             async with db.execute(
-                "INSERT INTO deployment(name, type, config, external, lazy, workdir, wraps) "
-                "VALUES (:name, :type, :config, :external, :lazy, :workdir, :wraps)",
+                "INSERT INTO deployment(name, type, config, external, lazy, scheduling_policy, workdir, wraps) "
+                "VALUES (:name, :type, :config, :external, :lazy, :scheduling_policy, :workdir, :wraps)",
                 {
                     "name": name,
                     "type": type,
                     "config": config,
                     "external": external,
                     "lazy": lazy,
+                    "scheduling_policy": json.dumps(scheduling_policy),
                     "workdir": workdir,
                     "wraps": json.dumps(wraps),
                 },

--- a/streamflow/persistence/sqlite.py
+++ b/streamflow/persistence/sqlite.py
@@ -260,7 +260,7 @@ class SqliteDatabase(CachedDatabase):
                     "port": port,
                     "type": utils.get_class_fullname(type),
                     "tag": tag,
-                    "value": value,
+                    "value": json.dumps(value),
                 },
             ) as cursor:
                 token_id = cursor.lastrowid
@@ -469,7 +469,7 @@ class SqliteDatabase(CachedDatabase):
                 "WHERE id =:id",
                 {"id": token_id},
             ) as cursor:
-                return await cursor.fetchone()
+                return _load_keys(dict(await cursor.fetchone()), keys=["value"])
 
     async def get_workflow(self, workflow_id: int) -> MutableMapping[str, Any]:
         async with self.connection as db:

--- a/streamflow/persistence/sqlite.py
+++ b/streamflow/persistence/sqlite.py
@@ -123,7 +123,7 @@ class SqliteDatabase(CachedDatabase):
                     "lazy": lazy,
                     "scheduling_policy": json.dumps(scheduling_policy),
                     "workdir": workdir,
-                    "wraps": json.dumps(wraps),
+                    "wraps": json.dumps(wraps) if wraps else None,
                 },
             ) as cursor:
                 return cursor.lastrowid

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import posixpath
 from abc import ABC, abstractmethod
@@ -299,12 +298,11 @@ class CombinatorStep(BaseStep):
         row: MutableMapping[str, Any],
         loading_context: DatabaseLoadingContext,
     ) -> CombinatorStep:
-        params = json.loads(row["params"])
         return cls(
             name=row["name"],
             workflow=await loading_context.load_workflow(context, row["workflow"]),
             combinator=await Combinator.load(
-                context, params["combinator"], loading_context
+                context, row["params"]["combinator"], loading_context
             ),
         )
 
@@ -466,7 +464,7 @@ class DeployStep(BaseStep):
         row: MutableMapping[str, Any],
         loading_context: DatabaseLoadingContext,
     ) -> DeployStep:
-        params = json.loads(row["params"])
+        params = row["params"]
         return cls(
             name=row["name"],
             workflow=await loading_context.load_workflow(context, row["workflow"]),
@@ -615,7 +613,7 @@ class ExecuteStep(BaseStep):
         row: MutableMapping[str, Any],
         loading_context: DatabaseLoadingContext,
     ) -> ExecuteStep:
-        params = json.loads(row["params"])
+        params = row["params"]
         step = cls(
             name=row["name"],
             workflow=await loading_context.load_workflow(context, row["workflow"]),
@@ -909,7 +907,7 @@ class GatherStep(BaseStep):
         row: MutableMapping[str, Any],
         loading_context: DatabaseLoadingContext,
     ) -> GatherStep:
-        params = json.loads(row["params"])
+        params = row["params"]
         return cls(
             name=row["name"],
             workflow=await loading_context.load_workflow(context, row["workflow"]),
@@ -1042,12 +1040,12 @@ class InputInjectorStep(BaseStep, ABC):
         row: MutableMapping[str, Any],
         loading_context: DatabaseLoadingContext,
     ) -> InputInjectorStep:
-        params = json.loads(row["params"])
         return cls(
             name=row["name"],
             workflow=await loading_context.load_workflow(context, row["workflow"]),
             job_port=cast(
-                JobPort, await loading_context.load_port(context, params["job_port"])
+                JobPort,
+                await loading_context.load_port(context, row["params"]["job_port"]),
             ),
         )
 
@@ -1339,7 +1337,7 @@ class ScheduleStep(BaseStep):
         row: MutableMapping[str, Any],
         loading_context: DatabaseLoadingContext,
     ) -> ScheduleStep:
-        params = json.loads(row["params"])
+        params = row["params"]
         if hardware_requirement := params.get("hardware_requirement"):
             hardware_requirement = await HardwareRequirement.load(
                 context, hardware_requirement, loading_context
@@ -1611,11 +1609,12 @@ class ScatterStep(BaseStep):
         row: MutableMapping[str, Any],
         loading_context: DatabaseLoadingContext,
     ) -> ScatterStep:
-        params = json.loads(row["params"])
         return cls(
             name=row["name"],
             workflow=await loading_context.load_workflow(context, row["workflow"]),
-            size_port=await loading_context.load_port(context, params["size_port"]),
+            size_port=await loading_context.load_port(
+                context, row["params"]["size_port"]
+            ),
         )
 
     async def _save_additional_params(
@@ -1709,12 +1708,12 @@ class TransferStep(BaseStep, ABC):
         row: MutableMapping[str, Any],
         loading_context: DatabaseLoadingContext,
     ) -> TransferStep:
-        params = json.loads(row["params"])
         return cls(
             name=row["name"],
             workflow=await loading_context.load_workflow(context, row["workflow"]),
             job_port=cast(
-                JobPort, await loading_context.load_port(context, params["job_port"])
+                JobPort,
+                await loading_context.load_port(context, row["params"]["job_port"]),
             ),
         )
 

--- a/streamflow/workflow/token.py
+++ b/streamflow/workflow/token.py
@@ -125,6 +125,7 @@ class JobToken(Token):
         return cls(
             tag=row["tag"],
             value=await Job.load(context, params["job"], loading_context),
+            recoverable=row["recoverable"],
         )
 
 
@@ -147,6 +148,7 @@ class ListToken(Token):
                     for t in value
                 )
             ),
+            recoverable=row["recoverable"],
         )
 
     async def _save_value(self, context: StreamFlowContext):
@@ -195,6 +197,7 @@ class ObjectToken(Token):
                     ),
                 )
             },
+            recoverable=row["recoverable"],
         )
 
     async def _save_value(self, context: StreamFlowContext):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,14 +223,15 @@ def are_equals(elem1, elem2, obj_compared=None):
     # Save the different values on the same attribute in the two dicts in a list:
     #   - if we find objects in the list, they must be checked recursively on their attributes
     #   - if we find elems of primitive types, their values are actually different
-    differences = [
-        (dict1[attr], dict2[attr])
+    differences = {
+        attr: (dict1[attr], dict2[attr])
         for attr in dict1.keys()
         if dict1[attr] != dict2[attr]
-    ]
-    for value1, value2 in differences:
+    }
+    for key, (value1, value2) in differences.items():
         # Check recursively the elements
         if not are_equals(value1, value2, obj_compared):
+            print(f"Attribute {key} has different values")
             return False
     return True
 

--- a/tests/test_cwl_persistence.py
+++ b/tests/test_cwl_persistence.py
@@ -63,28 +63,33 @@ from streamflow.workflow.command import UnionCommandTokenProcessor
 from streamflow.workflow.port import ConnectorPort, JobPort
 from streamflow.workflow.step import CombinatorStep, ExecuteStep
 from tests.conftest import save_load_and_test
+from tests.utils.utils import get_full_instantiation
 from tests.utils.workflow import CWL_VERSION, create_workflow
 
 
 def _create_cwl_command(
-    step: Step, processors: MutableSequence[CommandTokenProcessor]
+    step: Step, processors: MutableSequence[CommandTokenProcessor] | None = None
 ) -> CWLCommand:
-    return CWLCommand(
-        step=step,
-        absolute_initial_workdir_allowed=True,
-        base_command=["command", "tool"],
-        processors=processors,
-        expression_lib=["Requirement"],
-        failure_codes=[0, 0],
-        full_js=True,
-        initial_work_dir="/home",
-        inplace_update=True,
-        is_shell_command=True,
-        success_codes=[1],
-        step_stderr="stderr",
-        step_stdin="stdin",
-        step_stdout="stdout",
-        time_limit=1000,
+    processors = processors or []
+    return get_full_instantiation(
+        CWLCommand,
+        {
+            "step": step,
+            "absolute_initial_workdir_allowed": True,
+            "processors": processors,
+            "base_command": ["command", "tool"],
+            "expression_lib": ["Requirement"],
+            "failure_codes": [0, 0],
+            "full_js": True,
+            "initial_work_dir": "/home",
+            "inplace_update": True,
+            "is_shell_command": True,
+            "success_codes": [1],
+            "step_stderr": "a",
+            "step_stdin": "b",
+            "step_stdout": "c",
+            "time_limit": 1000,
+        },
     )
 
 
@@ -192,7 +197,7 @@ async def test_cwl_command(context: StreamFlowContext):
     step = workflow.create_step(
         cls=ExecuteStep, name=utils.random_name(), job_port=job_port
     )
-    step.command = _create_cwl_command(step, [])
+    step.command = _create_cwl_command(step)
     await save_load_and_test(step, context)
 
 

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -3,10 +3,16 @@ import posixpath
 import pytest
 
 from streamflow.core import utils
-from streamflow.core.config import BindingConfig
+from streamflow.core.config import BindingConfig, Config
 from streamflow.core.context import StreamFlowContext
-from streamflow.core.deployment import FilterConfig, LocalTarget, Target
-from streamflow.core.workflow import Job, Token, Workflow
+from streamflow.core.deployment import (
+    DeploymentConfig,
+    FilterConfig,
+    LocalTarget,
+    Target,
+    WrapsConfig,
+)
+from streamflow.core.workflow import Job, Status, Token, Workflow
 from streamflow.workflow.combinator import (
     CartesianProductCombinator,
     DotProductCombinator,
@@ -32,13 +38,19 @@ from streamflow.workflow.token import (
 )
 from tests.conftest import save_load_and_test
 from tests.utils.deployment import get_docker_deployment_config
+from tests.utils.utils import get_full_instantiation
 from tests.utils.workflow import create_workflow
 
 
 @pytest.mark.asyncio
 async def test_workflow(context: StreamFlowContext):
     """Test saving and loading Workflow from database"""
-    workflow = Workflow(context=context, name=utils.random_name(), config={})
+    workflow = get_full_instantiation(
+        cls_=Workflow,
+        context=context,
+        name=utils.random_name(),
+        config={"key": "value"},
+    )
     await save_load_and_test(workflow, context)
 
 
@@ -77,8 +89,11 @@ async def test_combinator_step(context: StreamFlowContext):
     step = workflow.create_step(
         cls=CombinatorStep,
         name=utils.random_name() + "-combinator",
-        combinator=CartesianProductCombinator(
-            name=utils.random_name(), workflow=workflow, depth=1
+        combinator=get_full_instantiation(
+            cls_=CartesianProductCombinator,
+            name=utils.random_name(),
+            workflow=workflow,
+            depth=2,
         ),
     )
     await save_load_and_test(step, context)
@@ -93,8 +108,11 @@ async def test_loop_combinator_step(context: StreamFlowContext):
     step = workflow.create_step(
         cls=LoopCombinatorStep,
         name=utils.random_name() + "-loop-combinator",
-        combinator=CartesianProductCombinator(
-            name=utils.random_name(), workflow=workflow, depth=1
+        combinator=get_full_instantiation(
+            cls_=CartesianProductCombinator,
+            name=utils.random_name(),
+            workflow=workflow,
+            depth=2,
         ),
     )
     await save_load_and_test(step, context)
@@ -123,13 +141,20 @@ async def test_schedule_step(context: StreamFlowContext):
     workflow, _ = await create_workflow(context, 0)
     binding_config = BindingConfig(
         targets=[
-            LocalTarget(workdir=utils.random_name()),
-            Target(
+            get_full_instantiation(cls_=LocalTarget, workdir=utils.random_name()),
+            get_full_instantiation(
+                cls_=Target,
                 deployment=get_docker_deployment_config(),
+                locations=2,
+                service="my_service",
                 workdir=utils.random_name(),
             ),
         ],
-        filters=[FilterConfig(config={}, name=utils.random_name(), type="shuffle")],
+        filters=[
+            get_full_instantiation(
+                cls_=FilterConfig, config={}, name=utils.random_name(), type="shuffle"
+            )
+        ],
     )
     connector_ports = {
         target.deployment.name: workflow.create_port(ConnectorPort)
@@ -195,7 +220,9 @@ async def test_dot_product_combinator(context: StreamFlowContext):
     step = workflow.create_step(
         cls=CombinatorStep,
         name=name + "-combinator",
-        combinator=DotProductCombinator(name=utils.random_name(), workflow=workflow),
+        combinator=get_full_instantiation(
+            cls_=DotProductCombinator, name=utils.random_name(), workflow=workflow
+        ),
     )
     await save_load_and_test(step, context)
 
@@ -210,7 +237,9 @@ async def test_loop_combinator(context: StreamFlowContext):
     step = workflow.create_step(
         cls=CombinatorStep,
         name=name + "-combinator",
-        combinator=LoopCombinator(name=utils.random_name(), workflow=workflow),
+        combinator=get_full_instantiation(
+            cls_=LoopCombinator, name=utils.random_name(), workflow=workflow
+        ),
     )
     await save_load_and_test(step, context)
 
@@ -222,8 +251,10 @@ async def test_loop_termination_combinator(context: StreamFlowContext):
     await workflow.save(context)
 
     name = utils.random_name()
-    combinator = LoopTerminationCombinator(
-        name=name + "-loop-termination-combinator", workflow=workflow
+    combinator = get_full_instantiation(
+        cls_=LoopTerminationCombinator,
+        name=name + "-loop-termination-combinator",
+        workflow=workflow,
     )
     combinator.add_output_item("test")
     combinator.add_output_item("another")
@@ -236,8 +267,10 @@ async def test_loop_termination_combinator(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_target(context: StreamFlowContext):
     """Test saving and loading Target from database"""
-    target = Target(
+    target = get_full_instantiation(
+        cls_=Target,
         deployment=get_docker_deployment_config(),
+        locations=2,
         service="test-persistence",
         workdir=utils.random_name(),
     )
@@ -247,16 +280,15 @@ async def test_target(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_local_target(context: StreamFlowContext):
     """Test saving and loading LocalTarget from database"""
-    target = LocalTarget(workdir=utils.random_name())
+    target = get_full_instantiation(cls_=LocalTarget, workdir=utils.random_name())
     await save_load_and_test(target, context)
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("recoverable", ["recoverable", "unrecoverable"])
-async def test_token(context: StreamFlowContext, recoverable: str):
+async def test_token(context: StreamFlowContext):
     """Test saving and loading Token from database"""
-    token = Token(
-        value=["test", "token"], tag="0.0", recoverable=recoverable == "recoverable"
+    token = get_full_instantiation(
+        cls_=Token, value=["test", "token"], tag="0.0", recoverable=True
     )
     await save_load_and_test(token, context)
 
@@ -264,7 +296,8 @@ async def test_token(context: StreamFlowContext, recoverable: str):
 @pytest.mark.asyncio
 async def test_job_token(context: StreamFlowContext):
     """Test saving and loading JobToken from database"""
-    token = JobToken(
+    token = get_full_instantiation(
+        cls_=JobToken,
         value=Job(
             workflow_id=0,
             name=utils.random_name(),
@@ -273,6 +306,8 @@ async def test_job_token(context: StreamFlowContext):
             output_directory=utils.random_name(),
             tmp_directory=utils.random_name(),
         ),
+        tag="0.0",
+        recoverable=True,
     )
     await save_load_and_test(token, context)
 
@@ -280,40 +315,62 @@ async def test_job_token(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_list_token(context: StreamFlowContext):
     """Test saving and loading ListToken from database"""
-    token = ListToken(value=[Token("list"), Token("test")])
+    token = get_full_instantiation(
+        cls_=ListToken,
+        value=[Token("list"), Token("test")],
+        tag="0.0",
+        recoverable=True,
+    )
     await save_load_and_test(token, context)
 
 
 @pytest.mark.asyncio
 async def test_object_token(context: StreamFlowContext):
     """Test saving and loading ObjectToken from database"""
-    token = ObjectToken(value={"test": Token("object")})
+    token = get_full_instantiation(
+        cls_=ObjectToken, value={"test": Token("object")}, tag="0.0", recoverable=True
+    )
     await save_load_and_test(token, context)
 
 
 @pytest.mark.asyncio
 async def test_termination_token(context: StreamFlowContext):
     """Test saving and loading TerminationToken from database"""
-    token = TerminationToken()
+    token = get_full_instantiation(cls_=TerminationToken, value=Status.FAILED)
     await save_load_and_test(token, context)
 
 
 @pytest.mark.asyncio
 async def test_iteration_termination_token(context: StreamFlowContext):
     """Test saving and loading IterationTerminationToken from database"""
-    token = IterationTerminationToken("1")
+    token = get_full_instantiation(cls_=IterationTerminationToken, tag="0.0")
     await save_load_and_test(token, context)
 
 
 @pytest.mark.asyncio
 async def test_filter_config(context: StreamFlowContext):
     """Test saving and loading filter configuration from database"""
-    config = FilterConfig(config={}, name=utils.random_name(), type="shuffle")
+    config = get_full_instantiation(
+        cls_=FilterConfig,
+        config={"key": ["1"]},
+        name=utils.random_name(),
+        type="shuffle",
+    )
     await save_load_and_test(config, context)
 
 
 @pytest.mark.asyncio
 async def test_deployment(context: StreamFlowContext):
     """Test saving and loading deployment configuration from database"""
-    config = get_docker_deployment_config()
+    config = get_full_instantiation(
+        cls_=DeploymentConfig,
+        name="test",
+        type="ssh",
+        config={"nodes": ["localhost"]},
+        external=True,
+        lazy=False,
+        scheduling_policy=Config(name="test", type="default", config={"key": 2}),
+        workdir="/tmp",
+        wraps=WrapsConfig(deployment="vm", service="test1"),
+    )
     await save_load_and_test(config, context)

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -170,7 +170,7 @@ async def test_deploy_step(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_schedule_step(context: StreamFlowContext):
     """Test saving and loading ScheduleStep from database"""
-    workflow, (job_port,) = await create_workflow(context, 1)
+    workflow, (job_port,) = await create_workflow(context, type_="default", num_port=1)
     binding_config = get_full_instantiation(
         BindingConfig,
         targets=[
@@ -215,7 +215,7 @@ async def test_schedule_step(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_execute_step(context: StreamFlowContext):
     """Test saving and loading ExecuteStep from database"""
-    workflow, (job_port,) = await create_workflow(context, 1)
+    workflow, (job_port,) = await create_workflow(context, type_="default", num_port=1)
     await workflow.save(context)
 
     step = get_full_instantiation(
@@ -231,7 +231,7 @@ async def test_execute_step(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_gather_step(context: StreamFlowContext):
     """Test saving and loading GatherStep from database"""
-    workflow, (port,) = await create_workflow(context, num_port=1)
+    workflow, (port,) = await create_workflow(context, type_="default", num_port=1)
     await workflow.save(context)
 
     step = get_full_instantiation(
@@ -248,7 +248,7 @@ async def test_gather_step(context: StreamFlowContext):
 @pytest.mark.asyncio
 async def test_scatter_step(context: StreamFlowContext):
     """Test saving and loading ScatterStep from database"""
-    workflow, (port,) = await create_workflow(context, num_port=1)
+    workflow, (port,) = await create_workflow(context, type_="default", num_port=1)
     await workflow.save(context)
 
     step = get_full_instantiation(

--- a/tests/utils/utils.py
+++ b/tests/utils/utils.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import inspect
 import logging
 from collections.abc import MutableMapping, MutableSequence
 from typing import Any
+
+import pytest
 
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.utils import contains_persistent_id
@@ -17,6 +20,39 @@ from streamflow.workflow.executor import StreamFlowExecutor
 from streamflow.workflow.step import Combinator
 from streamflow.workflow.token import TerminationToken
 from tests.conftest import are_equals
+
+
+def get_full_instantiation(cls_: type[Any], arguments: MutableMapping[str, Any]) -> Any:
+    """
+    Instantiates a class using the provided arguments, checking whether the resulting
+    instance has values that differ from the class's default values.
+
+    All class arguments are mandatory in this instantiation. Moreover, values for parameters that have
+    default values must be explicitly provided and must differ from those defaults.
+
+    :param cls_: The class to instantiate.
+    :param arguments: A mapping of argument names to values used for instantiation.
+    :returns: An instance of the class, created using the provided arguments.
+    """
+    sig = inspect.signature(cls_.__init__)
+
+    if new_args := {k for k in sig.parameters.keys() if k != "self"} - set(
+        arguments.keys()
+    ):
+        pytest.fail(f"Object instantiation failed due to missing arguments: {new_args}")
+    new_args = []
+    for name, param in sig.parameters.items():
+        if (
+            name != "self"
+            and param.default != inspect.Parameter.empty
+            and arguments[name] == param.default
+        ):
+            new_args.append(name)
+    if new_args:
+        pytest.fail(
+            f"Cannot create the object because default values were used for the following arguments: {new_args}"
+        )
+    return cls_(**arguments)
 
 
 def check_combinators(

--- a/tests/utils/utils.py
+++ b/tests/utils/utils.py
@@ -22,7 +22,7 @@ from streamflow.workflow.token import TerminationToken
 from tests.conftest import are_equals
 
 
-def get_full_instantiation(cls_: type[Any], arguments: MutableMapping[str, Any]) -> Any:
+def get_full_instantiation(cls_: type[Any], **arguments) -> Any:
     """
     Instantiates a class using the provided arguments, checking whether the resulting
     instance has values that differ from the class's default values.

--- a/tests/utils/workflow.py
+++ b/tests/utils/workflow.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import os
 import posixpath
 from collections.abc import MutableMapping, MutableSequence
@@ -417,7 +416,7 @@ class InjectorFailureCommand(Command):
         self, context: StreamFlowContext
     ) -> MutableMapping[str, Any]:
         return cast(dict[str, Any], await super()._save_additional_params(context)) | {
-            "inject_failure": json.dumps(self.inject_failure)
+            "inject_failure": self.inject_failure
         }
 
     @classmethod
@@ -428,7 +427,7 @@ class InjectorFailureCommand(Command):
         loading_context: DatabaseLoadingContext,
         step: Step,
     ) -> InjectorFailureCommand:
-        return cls(step=step, inject_failure=json.loads(row["inject_failure"]))
+        return cls(step=step, inject_failure=row["inject_failure"])
 
 
 class InjectorFailureTransferStep(TransferStep):
@@ -451,7 +450,7 @@ class InjectorFailureTransferStep(TransferStep):
         row: MutableMapping[str, Any],
         loading_context: DatabaseLoadingContext,
     ) -> InjectorFailureTransferStep:
-        params = json.loads(row["params"])
+        params = row["params"]
         return cls(
             name=row["name"],
             workflow=await loading_context.load_workflow(context, row["workflow"]),


### PR DESCRIPTION
This commit introduces a new function in the persistence tests to instantiate and verify the initialization of class parameters. The function ensures that all object attributes, including any new ones with default values, are properly initialized. This check is especially useful when adding new arguments to an object, as it prevents the persistence tests from passing without verifying new attributes.

Additionally, the commit refactors the logic of serializing and deserializing class attributes. Previously, this logic was spread across the codebase. Now, it has been centralized to reside solely within the methods of the `Database` class for better maintainability and consistency.