### PR TITLE
Fixed token processing in the `CWLObjectTokenProcessor`

### DIFF
--- a/streamflow/cwl/processor.py
+++ b/streamflow/cwl/processor.py
@@ -961,17 +961,12 @@ class CWLObjectTokenProcessor(TokenProcessor):
             dict(
                 zip(
                     token.value,
-                    [
-                        t.value
-                        for t in await asyncio.gather(
-                            *(
-                                asyncio.create_task(
-                                    self.processors[k].process(inputs, token.update(v))
-                                )
-                                for k, v in token.value.items()
-                            )
+                    await asyncio.gather(
+                        *(
+                            asyncio.create_task(self.processors[k].process(inputs, v))
+                            for k, v in token.value.items()
                         )
-                    ],
+                    ),
                 )
             )
         )


### PR DESCRIPTION
This commit simplifies the token processing logic in `CWLObjectTokenProcessor`. 
In StreamFlow, the `ObjectToken` has a dictionary with keys that are strings and values that are other tokens. 
Each key in the dictionary was associated with an inner processor within the `CWLObjectTokenProcessor`.

Before this commit, the value of the token was encapsulated inside an `ObjectToken` and passed to inner processors. 
Now,  the token values are passed directly, streamlining the process and improving its correctness.