### PR TITLE
Make `Scheduler` helper methods raise exceptions

### DIFF
--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -491,7 +491,7 @@ class DefaultScheduler(Scheduler):
     async def notify_status(self, job_name: str, status: Status) -> None:
         if (
             connector := self.get_connector(job_name)
-        ) and connector.deployment_name in self.wait_queues:
+        ).deployment_name in self.wait_queues:
             async with self.wait_queues[connector.deployment_name]:
                 if job_allocation := self.job_allocations.get(job_name):
                     if status != (previous_status := job_allocation.status):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -532,7 +532,11 @@ async def test_single_env_few_resources(context: StreamFlowContext):
         for t in task_completed:
             assert t.result() is None
         assert context.scheduler.get_allocation(jobs[0].name).status == Status.FIREABLE
-        assert context.scheduler.get_allocation(jobs[1].name) is None
+        with pytest.raises(
+            WorkflowExecutionException,
+            match=f"Could not retrieve allocation for job {jobs[1].name}",
+        ):
+            context.scheduler.get_allocation(jobs[1].name)
 
         # First job changes status to RUNNING and continue to keep all resources
         # Testing that second job is not scheduled (timeout parameter necessary)
@@ -541,7 +545,11 @@ async def test_single_env_few_resources(context: StreamFlowContext):
 
         assert len(task_pending) == 1
         assert context.scheduler.get_allocation(jobs[0].name).status == Status.RUNNING
-        assert context.scheduler.get_allocation(jobs[1].name) is None
+        with pytest.raises(
+            WorkflowExecutionException,
+            match=f"Could not retrieve allocation for job {jobs[1].name}",
+        ):
+            context.scheduler.get_allocation(jobs[1].name)
 
         # First job completes and the second job can be scheduled (timeout parameter useful if a deadlock occurs)
         await context.scheduler.notify_status(jobs[0].name, Status.COMPLETED)


### PR DESCRIPTION
StreamFlow never checks if the optional return value is `None` when calling the `Scheduler`'s helper methods (i.e., `get_allocation`, `get_hardware`, `get_connector`, and `get_locations`). Therefore, this commit embeds this chekc inside the methods themselves by raising a `WorkflowExecutionException` whenever a method is called on an invalid `Job` object.