### PR TITLE
Fixed `CWLCommand` persistence

### DIFF
--- a/streamflow/cwl/command.py
+++ b/streamflow/cwl/command.py
@@ -617,6 +617,7 @@ class CWLCommand(TokenizedCommand):
         processors: MutableSequence[CommandTokenProcessor] | None = None,
         absolute_initial_workdir_allowed: bool = False,
         base_command: MutableSequence[str] | None = None,
+        environment: MutableMapping[str, str] | None = None,
         expression_lib: MutableSequence[str] | None = None,
         failure_codes: MutableSequence[int] | None = None,
         full_js: bool = False,
@@ -632,7 +633,7 @@ class CWLCommand(TokenizedCommand):
         super().__init__(step=step, processors=processors)
         self.absolute_initial_workdir_allowed: bool = absolute_initial_workdir_allowed
         self.base_command: MutableSequence[str] = base_command or []
-        self.environment: MutableMapping[str, str] = {}
+        self.environment: MutableMapping[str, str] = environment or {}
         self.expression_lib: MutableSequence[str] = expression_lib or []
         self.failure_codes: MutableSequence[int] | None = failure_codes
         self.full_js: bool = full_js
@@ -708,6 +709,7 @@ class CWLCommand(TokenizedCommand):
             processors=await cls._load_command_token_processors(
                 context=context, row=row, loading_context=loading_context
             ),
+            environment=row["environment"],
             expression_lib=row["expression_lib"],
             failure_codes=row["failure_codes"],
             full_js=row["full_js"],

--- a/tests/test_cwl_persistence.py
+++ b/tests/test_cwl_persistence.py
@@ -78,6 +78,7 @@ def _create_cwl_command(
         processors=processors,
         base_command=["command", "tool"],
         expression_lib=["Requirement"],
+        environment={"ARCH": "$(inputs.arch)", "PYTHONPATH": "$(inputs.pythonpath)"},
         failure_codes=[0, 0],
         full_js=True,
         initial_work_dir="/home",


### PR DESCRIPTION
This commit addresses the persistence issue with the `CWLCommand` class. 
Before this commit, the `environment` attribute was not loaded in the new class instance.