### PR TITLE
Remove support for nested `Token` objects

### DIFF
--- a/streamflow/core/workflow.py
+++ b/streamflow/core/workflow.py
@@ -587,19 +587,10 @@ class Token(PersistableEntity):
         return cls(tag=row["tag"], value=value, recoverable=row["recoverable"])
 
     async def _save_value(self, context: StreamFlowContext):
-        if isinstance(self.value, Token) and not self.value.persistent_id:
-            await self.value.save(context)
-        return (
-            {"token": self.value.persistent_id}
-            if isinstance(self.value, Token)
-            else self.value
-        )
+        return self.value
 
     async def get_weight(self, context: StreamFlowContext) -> int:
-        if isinstance(self.value, Token):
-            return await self.value.get_weight(context)
-        else:
-            return sys.getsizeof(self.value)
+        return sys.getsizeof(self.value)
 
     @classmethod
     async def load(
@@ -615,10 +606,7 @@ class Token(PersistableEntity):
         return token
 
     async def is_available(self, context: StreamFlowContext) -> bool:
-        if isinstance(self.value, Token):
-            return self.recoverable and await self.value.is_available(context)
-        else:
-            return self.recoverable
+        return self.recoverable
 
     def retag(self, tag: str, recoverable: bool = False) -> Token:
         return self.__class__(tag=tag, value=self.value, recoverable=recoverable)

--- a/streamflow/cwl/processor.py
+++ b/streamflow/cwl/processor.py
@@ -321,9 +321,6 @@ class CWLTokenProcessor(TokenProcessor):
         }
 
     async def process(self, inputs: MutableMapping[str, Token], token: Token) -> Token:
-        # If value is token, propagate the process call
-        if isinstance(token.value, Token):
-            return token.update(await self.process(inputs, token.value))
         # Process file token
         if utils.get_token_class(token.value) in ["File", "Directory"]:
             token = token.update(await self._process_file_token(inputs, token.value))
@@ -778,9 +775,6 @@ class CWLMapTokenProcessor(TokenProcessor):
         }
 
     async def process(self, inputs: MutableMapping[str, Token], token: Token) -> Token:
-        # If value is token, propagate the process call
-        if isinstance(token.value, Token):
-            return token.update(await self.process(inputs, token.value))
         # Check if value is None
         if token.value is None:
             if self.optional:
@@ -945,9 +939,6 @@ class CWLObjectTokenProcessor(TokenProcessor):
         }
 
     async def process(self, inputs: MutableMapping[str, Token], token: Token) -> Token:
-        # If value is token, propagate the process call
-        if isinstance(token.value, Token):
-            return token.update(await self.process(inputs, token.value))
         # Check if value is None
         if token.value is None:
             if self.optional:
@@ -1230,9 +1221,6 @@ class CWLUnionTokenProcessor(TokenProcessor):
         )
 
     async def process(self, inputs: MutableMapping[str, Token], token: Token) -> Token:
-        # If value is token, propagate the process call
-        if isinstance(token.value, Token):
-            return token.update(await self.process(inputs, token.value))
         # Select the correct processor for the evaluation
         processor = self.get_processor(token.value)
         # Propagate evaluation to the selected processor

--- a/streamflow/cwl/step.py
+++ b/streamflow/cwl/step.py
@@ -193,6 +193,10 @@ async def build_token(
                     )
                 ),
             )
+    elif isinstance(token_value, Token):
+        return token_value.retag(
+            tag=get_tag(job.inputs.values()), recoverable=token_value.recoverable
+        )
     else:
         return Token(tag=get_tag(job.inputs.values()), value=token_value)
 
@@ -554,13 +558,11 @@ class CWLLoopOutputAllStep(LoopOutputStep):
 
 class CWLLoopOutputLastStep(LoopOutputStep):
     async def _process_output(self, tag: str) -> Token:
-        return Token(
-            tag=tag,
-            value=sorted(
-                self.token_map.get(tag, [Token(value=None)]),
-                key=lambda t: int(t.tag.split(".")[-1]),
-            )[-1],
-        )
+        token = sorted(
+            self.token_map.get(tag, [Token(value=None)]),
+            key=lambda t: int(t.tag.split(".")[-1]),
+        )[-1]
+        return token.retag(tag=tag, recoverable=token.recoverable)
 
 
 class CWLScheduleStep(ScheduleStep):

--- a/streamflow/cwl/token.py
+++ b/streamflow/cwl/token.py
@@ -4,7 +4,6 @@ from typing import Any
 
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.data import DataType
-from streamflow.core.workflow import Token
 from streamflow.cwl import utils
 from streamflow.data.remotepath import StreamFlowPath
 from streamflow.workflow.token import FileToken
@@ -59,7 +58,4 @@ class CWLFileToken(FileToken):
         return paths
 
     async def get_weight(self, context):
-        if isinstance(self.value, Token):
-            return await self.value.get_weight(context)
-        else:
-            return await _get_file_token_weight(context, self.value)
+        return await _get_file_token_weight(context, self.value)

--- a/streamflow/cwl/transformer.py
+++ b/streamflow/cwl/transformer.py
@@ -29,8 +29,6 @@ class AllNonNullTransformer(OneToOneTransformer):
             return token.update(
                 [t for t in token.value if get_token_value(t) is not None]
             )
-        elif isinstance(token.value, Token):
-            return token.update(self._transform(name, token.value))
         else:
             raise WorkflowExecutionException(f"Invalid value for token {name}")
 
@@ -276,8 +274,6 @@ class FirstNonNullTransformer(OneToOneTransformer):
                 if get_token_value(t) is not None:
                     return t.update(t.value)
             raise WorkflowExecutionException(f"All sources are null in token {name}")
-        elif isinstance(token.value, Token):
-            return token.update(self._transform(name, token.value))
         else:
             raise WorkflowExecutionException(f"Invalid value for token {name}")
 
@@ -302,8 +298,6 @@ class ListToElementTransformer(OneToOneTransformer):
                 return token.value[0].update(token.value[0].value)
             else:
                 return token.update(token.value)
-        elif isinstance(token.value, Token):
-            return token.update(self._transform(token.value))
         else:
             raise WorkflowDefinitionException(
                 f"Invalid token value: Token required, but received {type(token.value)}"
@@ -331,8 +325,6 @@ class OnlyNonNullTransformer(OneToOneTransformer):
                     f"All sources are null in token {name}"
                 )
             return ret.update(ret.value) if isinstance(ret, Token) else ret
-        elif isinstance(token.value, Token):
-            return token.update(self._transform(name, token.value))
         else:
             raise WorkflowExecutionException(f"Invalid value for token {name}")
 

--- a/streamflow/workflow/step.py
+++ b/streamflow/workflow/step.py
@@ -1646,9 +1646,7 @@ class ScatterStep(BaseStep):
         }
 
     async def _scatter(self, token: Token) -> Token:
-        if isinstance(token.value, Token):
-            await self._scatter(token.value)
-        elif isinstance(token, ListToken):
+        if isinstance(token, ListToken):
             output_port = self.get_output_port()
             for i, t in enumerate(token.value):
                 output_port.put(

--- a/streamflow/workflow/utils.py
+++ b/streamflow/workflow/utils.py
@@ -84,8 +84,6 @@ def get_token_value(token: Token) -> Any:
         return [get_token_value(t) for t in token.value]
     elif isinstance(token, ObjectToken):
         return {k: get_token_value(v) for k, v in token.value.items()}
-    elif isinstance(token.value, Token):
-        return get_token_value(token.value)
     else:
         return token.value
 

--- a/tests/utils/workflow.py
+++ b/tests/utils/workflow.py
@@ -81,8 +81,6 @@ async def _invalidate_token(context: StreamFlowContext, job: Job, token: Token) 
     elif isinstance(token, ObjectToken):
         for t in token.value.value():
             await _invalidate_token(context, job, t)
-    elif isinstance(token.value, Token):
-        await _invalidate_token(context, job, token.value)
 
 
 async def _register_path(


### PR DESCRIPTION
A `Token` object whose `value` is another `Token` needs special treatment in several StreamFlow functions. However, this feature seems not necessary anymore, as no nested `Token` appear to be created in the current codebase.

This commit removes support for nested `Token` objects from the codebase, simplifying logic and increasing maintainability.