### PR TITLE
Make `CommandOutputProcessor` handle `Future` objs

### DIFF
--- a/streamflow/cwl/step.py
+++ b/streamflow/cwl/step.py
@@ -455,7 +455,7 @@ class CWLExecuteStep(ExecuteStep):
         job: Job,
         output_name: str,
         output_port: Port,
-        command_output: CommandOutput,
+        command_output: asyncio.Future[CommandOutput],
         connector: Connector | None = None,
     ) -> None:
         if (

--- a/tests/utils/workflow.py
+++ b/tests/utils/workflow.py
@@ -406,11 +406,11 @@ class EvalCommandOutputProcessor(DefaultCommandOutputProcessor):
     async def process(
         self,
         job: Job,
-        command_output: CommandOutput,
+        command_output: asyncio.Future[CommandOutput],
         connector: Connector | None = None,
     ) -> Token | None:
         context = self.workflow.context
-        value = command_output.value
+        value = (await command_output).value
         if self.value_type == "file":
             locations = context.scheduler.get_locations(job.name)
             await _register_path(


### PR DESCRIPTION
This commit modifies the signature of the `process` method from the `CommandOutputProcessor` class to take a `Future[CommandOutput]` argument. In this way, StreamFlow can keep executing its internal logic asynchronously until it really needs to know the output of a command execution.