### PR TITLE
Refactor `TokenProcessor` and `CommandOutputProcessor` classes

### DIFF
--- a/streamflow/core/processor.py
+++ b/streamflow/core/processor.py
@@ -14,7 +14,6 @@ from streamflow.core.exception import ProcessorTypeError
 from streamflow.core.persistence import DatabaseLoadingContext
 from streamflow.core.utils import eval_processors, get_tag, make_future
 from streamflow.core.workflow import CommandOutput, Job, Token, Workflow
-from streamflow.cwl.workflow import CWLWorkflow
 from streamflow.workflow.token import ListToken, ObjectToken
 
 
@@ -205,7 +204,7 @@ class MapTokenProcessor(TokenProcessor):
     def __init__(
         self,
         name: str,
-        workflow: CWLWorkflow,
+        workflow: Workflow,
         processor: TokenProcessor,
     ):
         super().__init__(name, workflow)
@@ -220,10 +219,7 @@ class MapTokenProcessor(TokenProcessor):
     ) -> Self:
         return cls(
             name=row["name"],
-            workflow=cast(
-                CWLWorkflow,
-                await loading_context.load_workflow(context, row["workflow"]),
-            ),
+            workflow=await loading_context.load_workflow(context, row["workflow"]),
             processor=await TokenProcessor.load(
                 context, row["processor"], loading_context
             ),
@@ -368,7 +364,7 @@ class ObjectTokenProcessor(TokenProcessor):
     def __init__(
         self,
         name: str,
-        workflow: CWLWorkflow,
+        workflow: Workflow,
         processors: MutableMapping[str, TokenProcessor],
     ):
         super().__init__(name, workflow)
@@ -383,10 +379,7 @@ class ObjectTokenProcessor(TokenProcessor):
     ) -> Self:
         return cls(
             name=row["name"],
-            workflow=cast(
-                CWLWorkflow,
-                await loading_context.load_workflow(context, row["workflow"]),
-            ),
+            workflow=await loading_context.load_workflow(context, row["workflow"]),
             processors={
                 k: v
                 for k, v in zip(
@@ -578,7 +571,7 @@ class UnionTokenProcessor(TokenProcessor):
     def __init__(
         self,
         name: str,
-        workflow: CWLWorkflow,
+        workflow: Workflow,
         processors: MutableSequence[TokenProcessor],
     ):
         super().__init__(name, workflow)
@@ -593,10 +586,7 @@ class UnionTokenProcessor(TokenProcessor):
     ) -> Self:
         return cls(
             name=row["name"],
-            workflow=cast(
-                CWLWorkflow,
-                await loading_context.load_workflow(context, row["workflow"]),
-            ),
+            workflow=await loading_context.load_workflow(context, row["workflow"]),
             processors=cast(
                 MutableSequence[TokenProcessor],
                 await asyncio.gather(

--- a/tests/test_cwl_persistence.py
+++ b/tests/test_cwl_persistence.py
@@ -34,7 +34,6 @@ from streamflow.cwl.hardware import CWLHardwareRequirement
 from streamflow.cwl.processor import (
     CWLCommandOutputProcessor,
     CWLFileToken,
-    CWLMapCommandOutputProcessor,
     CWLObjectCommandOutputProcessor,
     CWLTokenProcessor,
 )
@@ -150,7 +149,6 @@ def _create_cwl_token_processor(name: str, workflow: CWLWorkflow) -> CWLTokenPro
         name=name,
         workflow=workflow,
         token_type="enum",
-        check_type=False,
         enum_symbols=["path1", "path2"],
         expression_lib=["expr_lib1", "expr_lib2"],
         file_format="directory",
@@ -158,7 +156,6 @@ def _create_cwl_token_processor(name: str, workflow: CWLWorkflow) -> CWLTokenPro
         load_contents=True,
         load_listing=LoadListing.no_listing,
         only_propagate_secondary_files=False,
-        optional=True,
         secondary_files=[
             get_full_instantiation(cls_=SecondaryFile, pattern="file1", required=True)
         ],
@@ -299,7 +296,7 @@ async def test_cwl_expression_command(context: StreamFlowContext):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "output_type", ["no_output", "default", "primitive", "map", "object", "union"]
+    "output_type", ["no_output", "default", "primitive", "object", "union"]
 )
 async def test_cwl_execute_step(context: StreamFlowContext, output_type: str):
     """Test saving and loading CWLExecuteStep from database"""
@@ -328,16 +325,6 @@ async def test_cwl_execute_step(context: StreamFlowContext, output_type: str):
         elif output_type == "primitive":
             processor = _create_cwl_command_output_processor(
                 name=utils.random_name(), workflow=workflow
-            )
-        elif output_type == "map":
-            processor = get_full_instantiation(
-                cls_=CWLMapCommandOutputProcessor,
-                name=utils.random_name(),
-                workflow=workflow,
-                processor=_create_cwl_command_output_processor(
-                    name=utils.random_name(), workflow=workflow
-                ),
-                target=LocalTarget(workdir="/home"),
             )
         elif output_type == "object":
             processor = get_full_instantiation(

--- a/tests/test_cwl_provenance.py
+++ b/tests/test_cwl_provenance.py
@@ -297,6 +297,7 @@ async def test_cwl_token_transformer(context: StreamFlowContext):
             "processor": CWLTokenProcessor(
                 name=step_name,
                 workflow=cast(CWLWorkflow, workflow),
+                token_type="string",
             ),
         },
         token_list=token_list,
@@ -330,6 +331,7 @@ async def test_value_from_transformer(context: StreamFlowContext):
             "processor": CWLTokenProcessor(
                 name=in_port.name,
                 workflow=cast(CWLWorkflow, workflow),
+                token_type="long",
             ),
             "port_name": in_port.name,
             "full_js": True,
@@ -707,6 +709,7 @@ async def test_loop_value_from_transformer(context: StreamFlowContext):
         processor=CWLTokenProcessor(
             name=in_port.name,
             workflow=cast(CWLWorkflow, workflow),
+            token_type="long",
         ),
         port_name=port_name,
         full_js=True,


### PR DESCRIPTION
This commit normalizes the behaviour of the `TokenProcessor` and `CommandOutputProcessor` classes in terms of type handling. In addition, it further relazes the `CWLCommandOutput` behaviour to resolve the value of the `Future[CommandOutput]` object only when strictly necessary.

 In addition, this commit removes the unnecessary `CWLMapCommandOutputProcessor` class. The `CWLCommandOutputProcessor`  alone is sufficient to treat both single and list outputs, making the former class an useless complication within the codebase. However, the `MapCommandOutputProcessor` base class has been preserved to be used within workflow languages other than CWL, if necessary.