### PR TITLE
Check if glob contains wildcards

### DIFF
--- a/streamflow/core/utils.py
+++ b/streamflow/core/utils.py
@@ -308,6 +308,48 @@ def get_tag(tokens: Iterable[Token]) -> str:
     return output_tag
 
 
+def is_glob(
+    path: str,
+) -> bool:
+    """
+    Check if the argument string is a glob with wildcards.
+
+    :param path: the string to be checked
+    :return: `True` if the string contains any wildcards, `False` otherwise
+    """
+    DEFAULT = 0
+    BRACKET_FIRST = 1
+    BRACKET = 2
+    BACKSLASH = 3
+
+    i = 0
+    stack = [DEFAULT]
+    wildcards = ["*", "?"]
+    while i < len(path):
+        state = stack[-1]
+        c = path[i]
+
+        if state == DEFAULT:
+            if c in wildcards:
+                return True
+            elif c == "[":
+                stack.append(BRACKET_FIRST)
+            elif c == "\\":
+                stack.append(BACKSLASH)
+        elif state == BRACKET_FIRST:
+            stack.pop()
+            stack.append(BRACKET)
+        elif state == BRACKET:
+            if c == "]":
+                return True
+            elif c == "\\":
+                stack.append(BACKSLASH)
+        elif state == BACKSLASH:
+            stack.pop()
+        i += 1
+    return False
+
+
 def make_future(obj: T) -> asyncio.Future[T]:
     future = asyncio.Future()
     future.set_result(obj)

--- a/streamflow/cwl/utils.py
+++ b/streamflow/cwl/utils.py
@@ -540,7 +540,7 @@ async def expand_glob(
     outdir = StreamFlowPath(
         output_directory, context=workflow.context, location=location
     )
-    paths = sorted([p async for p in outdir.glob(path)])
+    paths = sorted(await outdir.glob(path))
     effective_paths = await asyncio.gather(
         *(asyncio.create_task(p.resolve()) for p in paths)
     )

--- a/tests/test_cwl_execution.py
+++ b/tests/test_cwl_execution.py
@@ -187,7 +187,7 @@ async def test_initial_workdir(
         outdir = StreamFlowPath(
             job.output_directory, context=context, location=execution_location
         )
-        files_found = [str(f) async for f in outdir.glob("*")]
+        files_found = [str(f) async for f in outdir.iglob("*")]
         for out_file, init_path in zip(token.value.split(" "), initial_paths):
             # Check whether the file has been copied to the job output directory
             files_found.remove(out_file)

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -240,7 +240,7 @@ async def test_inject_remote_input(context: StreamFlowContext, config: str) -> N
 
     if file_type == "Directory":
         remote_files = sorted(
-            [p async for p in remote_path.glob("*")],
+            await remote_path.glob("*"),
             key=lambda x: os.path.basename(x),
         )
         assert len(remote_files) == 1
@@ -251,7 +251,7 @@ async def test_inject_remote_input(context: StreamFlowContext, config: str) -> N
         assert len(wf_files) == 1
     else:
         remote_files = sorted(
-            [p async for p in remote_path.parent.glob("*")],
+            await remote_path.parent.glob("*"),
             key=lambda x: os.path.basename(x),
         )
         assert len(remote_files) == 2


### PR DESCRIPTION
This commit add an explicit check to see if a `glob` CWL option actually contains a wildcard (and needs to be resolved against the filesystem on the destination location) or if it is just a plain string (and only needs to check for existence in the target location).