### PR TITLE
Add support for CWL v1.3

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         on: [ "ubuntu-24.04" ]
         python: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
-        version: [ "v1.0", "v1.1", "v1.2" ]
+        version: [ "v1.0", "v1.1", "v1.2", "v1.3" ]
         docker: [ "docker" ]
         include:
           - commit: "1c1f122f780075d910fdfdea7e15e46eef3c078d"
@@ -40,23 +40,26 @@ jobs:
           - commit: "76bdf9b55e2378432e0e6380ccedebb4a94ce483"
             exclude: "docker_entrypoint,modify_file_content"
             version: "v1.2"
+          - commit: "41c679d507ebd3b94e3085c666fb739bc0bbf9a8"
+            exclude: "docker_entrypoint,modify_file_content"
+            version: "v1.3"
           - docker: "singularity"
-            commit: "76bdf9b55e2378432e0e6380ccedebb4a94ce483"
+            commit: "41c679d507ebd3b94e3085c666fb739bc0bbf9a8"
             exclude: "docker_entrypoint,modify_file_content,iwd-container-entryname1"
             on: "ubuntu-24.04"
             python: "3.13"
-            version: "v1.2"
+            version: "v1.3"
           - docker: "kubernetes"
-            commit: "76bdf9b55e2378432e0e6380ccedebb4a94ce483"
+            commit: "41c679d507ebd3b94e3085c666fb739bc0bbf9a8"
             exclude: "docker_entrypoint,modify_file_content"
             on: "ubuntu-24.04"
             python: "3.13"
-            version: "v1.2"
+            version: "v1.3"
           - on: "macos-13"
             python: "3.13"
-            commit: "76bdf9b55e2378432e0e6380ccedebb4a94ce483"
+            commit: "41c679d507ebd3b94e3085c666fb739bc0bbf9a8"
             exclude: "docker_entrypoint,modify_file_content"
-            version: "v1.2"
+            version: "v1.3"
     runs-on: ${{ matrix.on }}
     steps:
       - uses: actions/checkout@v5

--- a/cwl-conformance-test.sh
+++ b/cwl-conformance-test.sh
@@ -12,7 +12,7 @@ venv() {
 }
 
 # Version of the standard to test against
-# Current options: v1.0, v1.1, v1.2
+# Current options: v1.0, v1.1, v1.2, and v1.3
 VERSION=${VERSION:-"v1.2"}
 
 # Which commit of the standard's repo to use
@@ -53,6 +53,10 @@ venv cwl-conformance-venv
 pip install -U setuptools wheel pip
 pip install -r "${SCRIPT_DIRECTORY}/requirements.txt"
 pip install -r "${SCRIPT_DIRECTORY}/test-requirements.txt"
+if [[ "${VERSION}" = "v1.3" ]] ; then
+  pip uninstall -y cwl-utils
+  pip install git+https://github.com/common-workflow-language/cwl-utils.git@refs/pull/370/head
+fi
 
 # Set conformance test filename
 if [[ "${VERSION}" = "v1.0" ]] ; then


### PR DESCRIPTION
This commit adds preliminary support for CWL v1.3 and enables the CI/CD to run the CWL v1.3 conformance test suite. Note that support for CWL v1.3 is still experimental and the standard itself has not been released, yet. Therefore, users are discouraged to implement CWL v1.3 workflows in production at the moment.