### PR TITLE
Update versions in CI/CD pipeline

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -72,25 +72,25 @@ jobs:
             test-requirements.txt
       - uses: actions/setup-node@v5
         with:
-          node-version: "20"
+          node-version: "24"
       - name: "Install Docker (MacOS X)"
-        uses: douglascamata/setup-docker-macos-action@v1-alpha.16
+        uses: douglascamata/setup-docker-macos-action@v1
         with:
-          colima-additional-options: '--mount /private/var/folders:w --mount-type virtiofs'
+          colima-additional-options: '--mount /private/var/folders:w'
         if: ${{ startsWith(matrix.on, 'macos-') }}
       - uses: docker/setup-qemu-action@v3
         if: ${{ startsWith(matrix.on, 'ubuntu-') }}
       - name: "Install Apptainer"
         uses: eWaterCycle/setup-apptainer@v2
         with:
-          apptainer-version: 1.3.6
+          apptainer-version: 1.4.2
         if: ${{ matrix.docker == 'singularity' }}
       - name: "Install KinD"
         uses: helm/kind-action@v1.12.0
         with:
           config: .github/kind/config.yaml
-          kubectl_version: v1.30.3
-          version: v0.21.0
+          kubectl_version: v1.34.1
+          version: v0.30.0
         if: ${{ matrix.docker == 'kubernetes' }}
       - name: "Configure Calico on KinD"
         run: |
@@ -132,7 +132,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           build-args: |
-            HELM_VERSION=v3.17.0
+            HELM_VERSION=v3.19.0
           load: true
           tags: alphaunito/streamflow:latest
       - name: "Run test with Docker"
@@ -251,25 +251,25 @@ jobs:
             tox.ini
       - uses: actions/setup-node@v5
         with:
-          node-version: "20"
+          node-version: "24"
       - name: "Install Docker (MacOs X)"
-        uses: douglascamata/setup-docker-macos-action@v1-alpha.16
+        uses: douglascamata/setup-docker-macos-action@v1
         with:
-          colima-additional-options: '--mount /private/var/folders:w --mount-type virtiofs'
+          colima-additional-options: '--mount /private/var/folders:w'
         if: ${{ startsWith(matrix.on, 'macos-') }}
       - uses: docker/setup-qemu-action@v3
         if: ${{ startsWith(matrix.on, 'ubuntu-') }}
       - name: "Install Apptainer"
         uses: eWaterCycle/setup-apptainer@v2
         with:
-          apptainer-version: 1.3.6
+          apptainer-version: 1.4.2
         if: ${{ startsWith(matrix.on, 'ubuntu-') }}
       - name: "Install KinD"
         uses: helm/kind-action@v1.12.0
         with:
           config: .github/kind/config.yaml
-          kubectl_version: v1.30.3
-          version: v0.21.0
+          kubectl_version: v1.34.1
+          version: v0.30.0
         if: ${{ startsWith(matrix.on, 'ubuntu-') }}
       - name: "Configure Calico on KinD"
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           build-args: |
-            HELM_VERSION=v3.17.0
+            HELM_VERSION=v3.19.0
           push: true
           tags: |
             alphaunito/streamflow:${{ env.STREAMFLOW_VERSION }}


### PR DESCRIPTION
This commit modernizes the CI/CD pipeline by updating versions of Node.js, Kubernetes, and Apptainer. In addition, this commit ports the `douglascamata/setup-docker-macos-action` GitHub Action to version v1.