### PR TITLE
Added a check for the chosen deployment in the tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,7 @@ def pytest_generate_tests(metafunc):
         )
     if "communication_pattern" in metafunc.fixturenames:
         fst_remote = next(
-            d for d in metafunc.config.getoption("deploys") if d != "local"
+            (d for d in metafunc.config.getoption("deploys") if d != "local"), None
         )
         test_local = "local" in metafunc.config.getoption("deploys")
         comm_pattern = [
@@ -107,15 +107,23 @@ def pytest_generate_tests(metafunc):
             *((d, d) for d in metafunc.config.getoption("deploys") if d != "local"),
             # Remote to Remote testing the data receiving
             *(
-                (fst_remote, d)
-                for d in metafunc.config.getoption("deploys")
-                if d != fst_remote and d != "local"
+                (
+                    (fst_remote, d)
+                    for d in metafunc.config.getoption("deploys")
+                    if d != fst_remote and d != "local"
+                )
+                if fst_remote
+                else ()
             ),
             # Remote to Remote testing the data sending
             *(
-                (d, fst_remote)
-                for d in metafunc.config.getoption("deploys")
-                if d != fst_remote and d != "local"
+                (
+                    (d, fst_remote)
+                    for d in metafunc.config.getoption("deploys")
+                    if d != fst_remote and d != "local"
+                )
+                if fst_remote
+                else ()
             ),
         ]
         metafunc.parametrize(

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -137,12 +137,15 @@ async def test_future_connector_multiple_request_fail(
 
 @pytest.mark.asyncio
 async def test_ssh_connector_channel_open_error(
-    caplog, context: StreamFlowContext
+    caplog, chosen_deployment_types, context: StreamFlowContext
 ) -> None:
     """
     Test SSHConnector on a channel open error which close the ssh connection.
     The SSHConnector retry mechanism will retry on a new ssh connection
     """
+    if "ssh" not in chosen_deployment_types:
+        pytest.skip("Deployment ssh did non activated")
+
     caplog.set_level(logging.WARNING)
     caplog_handler = caplog.handler
     logger.addHandler(caplog_handler)
@@ -160,8 +163,12 @@ async def test_ssh_connector_channel_open_error(
 
 
 @pytest.mark.asyncio
-async def test_ssh_connector_multiple_request_fail(context: StreamFlowContext) -> None:
+async def test_ssh_connector_multiple_request_fail(
+    chosen_deployment_types, context: StreamFlowContext
+) -> None:
     """Test SSHConnector with multiple requests but the deployment fails"""
+    if "ssh" not in chosen_deployment_types:
+        pytest.skip("Deployment ssh did non activated")
     deployment_config = await get_ssh_deployment_config(context)
     # changed username to get an exception for the test
     deployment_config.config["nodes"][0]["username"] = "test"

--- a/tests/test_remotepath.py
+++ b/tests/test_remotepath.py
@@ -165,8 +165,10 @@ async def test_glob(context, connector, location):
 
 
 @pytest.mark.asyncio
-async def test_mkdir_failure(context):
+async def test_mkdir_failure(chosen_deployment_types, context):
     """Test on `mkdir` function failure"""
+    if "docker" not in chosen_deployment_types:
+        pytest.skip("Deployment docker did non activated")
     deployment_config = get_docker_deployment_config()
     location = await get_location(context, deployment_config.type)
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -89,8 +89,12 @@ def service(context, deployment) -> str | None:
 
 
 @pytest.mark.asyncio
-async def test_bind_volumes(context: StreamFlowContext):
+async def test_bind_volumes(chosen_deployment_types, context: StreamFlowContext):
     """Test the binding of volumes in stacked locations"""
+    if "docker" not in chosen_deployment_types:
+        pytest.skip("Deployment docker did non activated")
+    if "local" not in chosen_deployment_types:
+        pytest.skip("Deployment local did non activated")
     local_deployment = get_local_deployment_config()
     local_connector = context.deployment_manager.get_connector(local_deployment.name)
     local_location = next(
@@ -146,8 +150,12 @@ async def test_bind_volumes(context: StreamFlowContext):
 
 
 @pytest.mark.asyncio
-async def test_binding_filter(context: StreamFlowContext):
+async def test_binding_filter(chosen_deployment_types, context: StreamFlowContext):
     """Test Binding Filter using a job with two targets both free. With the CustomBindingFilter the scheduling will choose the second target"""
+    if "docker" not in chosen_deployment_types:
+        pytest.skip("Deployment docker did non activated")
+    if "local" not in chosen_deployment_types:
+        pytest.skip("Deployment local did non activated")
     job = Job(
         name=random_job_name(),
         workflow_id=0,
@@ -264,8 +272,12 @@ def test_hardware():
 
 
 @pytest.mark.asyncio
-async def test_multi_env(context: StreamFlowContext):
+async def test_multi_env(chosen_deployment_types, context: StreamFlowContext):
     """Test scheduling two jobs on two different environments."""
+    if "docker" not in chosen_deployment_types:
+        pytest.skip("Deployment docker did non activated")
+    if "local" not in chosen_deployment_types:
+        pytest.skip("Deployment local did non activated")
     hardware_requirement, target = _prepare_connector(context)
     docker_config = get_docker_deployment_config()
     docker_target = Target(
@@ -310,8 +322,14 @@ async def test_multi_env(context: StreamFlowContext):
 
 
 @pytest.mark.asyncio
-async def test_multi_targets_one_job(context: StreamFlowContext):
+async def test_multi_targets_one_job(
+    chosen_deployment_types, context: StreamFlowContext
+):
     """Test scheduling one jobs with two targets: Local and Docker Image. The job will be scheduled in the first"""
+    if "docker" not in chosen_deployment_types:
+        pytest.skip("Deployment docker did non activated")
+    if "local" not in chosen_deployment_types:
+        pytest.skip("Deployment local did non activated")
     hardware_requirement, target = _prepare_connector(context)
     # Create fake job with two targets and schedule it
     job = Job(
@@ -358,11 +376,17 @@ async def test_multi_targets_one_job(context: StreamFlowContext):
 
 
 @pytest.mark.asyncio
-async def test_multi_targets_two_jobs(context: StreamFlowContext):
+async def test_multi_targets_two_jobs(
+    chosen_deployment_types, context: StreamFlowContext
+):
     """
     Test scheduling two jobs with two same targets: Local and Docker Image.
     The first job will be scheduled in the local target and the second job in the docker target because the local resources will be full.
     """
+    if "docker" not in chosen_deployment_types:
+        pytest.skip("Deployment docker did non activated")
+    if "local" not in chosen_deployment_types:
+        pytest.skip("Deployment local did non activated")
     hardware_requirement, target = _prepare_connector(context)
     # Create fake jobs with two same targets and schedule them
     jobs = [

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -72,9 +72,12 @@ def _get_workflow_config(streamflow_config) -> WorkflowConfig:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("config", ["File", "Directory:literal", "Directory:concrete"])
-async def test_inject_remote_input(context: StreamFlowContext, config: str) -> None:
+async def test_inject_remote_input(
+    chosen_deployment_types, context: StreamFlowContext, config: str
+) -> None:
     """Test injection of remote input data through the port targets in the StreamFlow file"""
-
+    if "docker" not in chosen_deployment_types:
+        pytest.skip("Deployment docker did non activated")
     # Create remote file
     docker_config = get_docker_deployment_config()
     location = await get_location(context, docker_config.type)


### PR DESCRIPTION
This commit improves the test for local development purposes, specifically when not all deployments are used (e.g., by specifying a subset of deployments with the `--deploys` flag). Before this commit, some tests would fail if certain deployments were not selected, as they required the deployment to run. Now, the tests are skipped for missing deployments. However, in the CI, all deployments are tested.