### PR TITLE
Fixed issue on multiple `exampleOfWork` on `RunCrate` provenance

### DIFF
--- a/streamflow/provenance/run_crate.py
+++ b/streamflow/provenance/run_crate.py
@@ -563,7 +563,7 @@ class RunCrateProvenanceManager(ProvenanceManager, ABC):
                     self.create_action_map[wf_id].get(parent["@id"], {}).items()
                 ):
                     if step_name.startswith(action_name):
-                        for create_action in create_actions[tag]:
+                        for create_action in create_actions.get(tag, []):
                             if is_input and param["@id"] in [
                                 inp["@id"] for inp in parent.get("input", [])
                             ]:


### PR DESCRIPTION
This PR fixed an issue with archive creation in `RunCrate` provenance. Before this commit, if an input had multiple file sources, they attempted to update the `actions` field. However, only the execution step had multiple actions.