### PR TITLE
Remove `disable-content-trust` in DockerConnector

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -162,7 +162,7 @@ jobs:
           python -m pip install .
       - name: "Build documentation and check for consistency"
         env:
-          CHECKSUM: "47721124c7689e9138ec656aecb30367fe9571fc088748e8b802df4aba5ba465"
+          CHECKSUM: "c2b7f3b50bb5ec79e95645b67526af3c6c0b1b37111a1453626c2d98020b86a0"
         run: |
           cd docs
           HASH="$(make checksum | tail -n1)"

--- a/streamflow/cwl/requirement/docker/docker.py
+++ b/streamflow/cwl/requirement/docker/docker.py
@@ -39,7 +39,6 @@ class DockerCWLDockerTranslator(CWLDockerTranslator):
         deviceReadIops: MutableSequence[str] | None = None,
         deviceWriteBps: MutableSequence[str] | None = None,
         deviceWriteIops: MutableSequence[str] | None = None,
-        disableContentTrust: bool = True,
         dns: MutableSequence[str] | None = None,
         dnsOptions: MutableSequence[str] | None = None,
         dnsSearch: MutableSequence[str] | None = None,
@@ -131,7 +130,6 @@ class DockerCWLDockerTranslator(CWLDockerTranslator):
         self.deviceReadIops: MutableSequence[str] | None = deviceReadIops
         self.deviceWriteBps: MutableSequence[str] | None = deviceWriteBps
         self.deviceWriteIops: MutableSequence[str] | None = deviceWriteIops
-        self.disableContentTrust: bool = disableContentTrust
         self.dns: MutableSequence[str] | None = dns
         self.dnsOptions: MutableSequence[str] | None = dnsOptions
         self.dnsSearch: MutableSequence[str] | None = dnsSearch
@@ -255,7 +253,6 @@ class DockerCWLDockerTranslator(CWLDockerTranslator):
                     "deviceReadIops": self.deviceReadIops,
                     "deviceWriteBps": self.deviceWriteBps,
                     "deviceWriteIops": self.deviceWriteIops,
-                    "disableContentTrust": self.disableContentTrust,
                     "dns": self.dns,
                     "dnsOptions": self.dnsOptions,
                     "dnsSearch": self.dnsSearch,

--- a/streamflow/deployment/connector/container.py
+++ b/streamflow/deployment/connector/container.py
@@ -846,8 +846,13 @@ class DockerBaseConnector(ContainerConnector, ABC):
             },
         )
         # Create instance
+        addresses = [
+            v["IPAddress"]
+            for v in container["NetworkSettings"]["Networks"].values()
+            if v["IPAddress"]
+        ]
         self._instances[name] = ContainerInstance(
-            address=container["NetworkSettings"]["IPAddress"],
+            address=addresses[0] if addresses else "",
             cores=cores,
             memory=memory,
             current_user=host_user == container_user,
@@ -888,7 +893,6 @@ class DockerConnector(DockerBaseConnector):
         deviceReadIops: MutableSequence[str] | None = None,
         deviceWriteBps: MutableSequence[str] | None = None,
         deviceWriteIops: MutableSequence[str] | None = None,
-        disableContentTrust: bool = True,
         dns: MutableSequence[str] | None = None,
         dnsOptions: MutableSequence[str] | None = None,
         dnsSearch: MutableSequence[str] | None = None,
@@ -988,7 +992,6 @@ class DockerConnector(DockerBaseConnector):
         self.deviceReadIops: MutableSequence[str] | None = deviceReadIops
         self.deviceWriteBps: MutableSequence[str] | None = deviceWriteBps
         self.deviceWriteIops: MutableSequence[str] | None = deviceWriteIops
-        self.disableContentTrust: bool = disableContentTrust
         self.dns: MutableSequence[str] | None = dns
         self.dnsOptions: MutableSequence[str] | None = dnsOptions
         self.dnsSearch: MutableSequence[str] | None = dnsSearch
@@ -1111,7 +1114,6 @@ class DockerConnector(DockerBaseConnector):
                 get_option("device-read-iops", self.deviceReadIops),
                 get_option("device-write-bps", self.deviceWriteBps),
                 get_option("device-write-iops", self.deviceWriteIops),
-                f"--disable-content-trust={'true' if self.disableContentTrust else 'false'}",
                 get_option("dns", self.dns),
                 get_option("dns-option", self.dnsOptions),
                 get_option("dns-search", self.dnsSearch),

--- a/streamflow/deployment/connector/schemas/base/docker.json
+++ b/streamflow/deployment/connector/schemas/base/docker.json
@@ -174,12 +174,6 @@
       "title": "Devices write IOPS",
       "description": "Limit write rate (IO per second) from a device"
     },
-    "disableContentTrust": {
-      "type": "boolean",
-      "title": "Disable content trust",
-      "description": "Skip image verification",
-      "default": true
-    },
     "dns": {
       "type": "array",
       "items": {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -181,11 +181,11 @@ def test_schema_generation():
     """Check that the `streamflow schema` command generates a correct JSON Schema."""
     assert (
         hashlib.sha256(SfSchema().dump("v1.0", False).encode()).hexdigest()
-        == "de0e5736eaa46a70b4d9b28e2faa7b235b2d965886fa1b8bfe80428d131ee31b"
+        == "1905364613920875ae79e3d93647477d5e5872fd79bfb5bf08576ccdaf72ea4c"
     )
     assert (
         hashlib.sha256(SfSchema().dump("v1.0", True).encode()).hexdigest()
-        == "5aef0ec1925e490075e126d0bc38ed987391cbf10b401bea3ca3a1f4ccb0c0fd"
+        == "6afb9fec0c4f90bdb59800f6e6b85f4cde80408acf58759078bd6fb790d57413"
     )
 
 


### PR DESCRIPTION
This commit removes support for the deprecated `disable-content-trust` flag in Docker.
See https://www.docker.com/blog/retiring-docker-content-trust/