### PR TITLE
Remove Lima version from MacOS CI

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -77,7 +77,6 @@ jobs:
         uses: douglascamata/setup-docker-macos-action@v1
         with:
           colima-additional-options: '--mount /private/var/folders:w'
-          lima: v1.2.2
         if: ${{ startsWith(matrix.on, 'macos-') }}
       - uses: docker/setup-qemu-action@v3
         if: ${{ startsWith(matrix.on, 'ubuntu-') }}
@@ -257,7 +256,6 @@ jobs:
         uses: douglascamata/setup-docker-macos-action@v1
         with:
           colima-additional-options: '--mount /private/var/folders:w'
-          lima: v1.2.2
         if: ${{ startsWith(matrix.on, 'macos-') }}
       - uses: docker/setup-qemu-action@v3
         if: ${{ startsWith(matrix.on, 'ubuntu-') }}


### PR DESCRIPTION
Now that the MacOS CI action has been fixed to work with Lima v2.0 and above, there is no need to fix Lima version in the CI spec.