### PR TITLE
Adjust Python cache in GitHub CI/CD

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -155,6 +155,7 @@ jobs:
           cache: pip
           cache-dependency-path: |
             docs/requirements.txt
+            requirements.txt
       - name: "Install Python Dependencies"
         run: |
           python -m pip install -r docs/requirements.txt
@@ -219,8 +220,9 @@ jobs:
           python-version: "3.14"
           cache: pip
           cache-dependency-path: |
+            bandit-requirements.txt
+            lint-requirements.txt
             requirements.txt
-            test-requirements.txt
             tox.ini
       - name: "Install Python Dependencies and StreamFlow"
         run: |
@@ -247,7 +249,9 @@ jobs:
           python-version: ${{ matrix.python }}
           cache: pip
           cache-dependency-path: |
+            report-requirements.txt
             requirements.txt
+            test-requirements.txt
             tox.ini
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
This commit adds missing files to the `cache-dependency-path` property of the `setup-python` GitHub Action to speed up install process in subsequent runs.