### PR TITLE
Handle location storage retrieval errors

### DIFF
--- a/streamflow/deployment/connector/container.py
+++ b/streamflow/deployment/connector/container.py
@@ -75,7 +75,7 @@ async def _get_storage_from_binds(
                         storage[mount_point].bind = binds[mount_point]
             except ValueError as e:
                 logger.warning(
-                    f"Skipping partition for deployment {location.deployment}: {e}"
+                    f"Skipping line {line} for deployment {location.deployment}: {e}"
                 )
             except Exception as e:
                 raise WorkflowExecutionException(

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -503,7 +503,7 @@ class SSHConnector(BaseConnector):
                                 )
                         except ValueError as e:
                             logger.warning(
-                                f"Skipping partition for deployment {self.deployment_name}: {e}"
+                                f"Skipping line {line} for deployment {self.deployment_name}: {e}"
                             )
                         except Exception as e:
                             raise WorkflowExecutionException(


### PR DESCRIPTION
This commit fixes the retrieval of location storage information. The code now handles output parsing failures, such as when an error message is returned because the user does not have permission to access information about a partition. Additionally, all exceptions are now caught and raised as `WorkflowExecutionException` objects to provide more detailed error information.