### PR TITLE
Add OpenPBS tests to the CI/CD pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add OpenPBS tests to the CI/CD pipeline ([#873](https://github.com/alpha-unito/streamflow/pull/873))
 - Add RISC-V runners from the RISE project ([#998](https://github.com/alpha-unito/streamflow/pull/998))
 - Enforce `CHANGELOG.md` updates in PRs ([#1066](https://github.com/alpha-unito/streamflow/pull/1066))
 - Add MPI application tutorial and docs agent skills ([#1042](https://github.com/alpha-unito/streamflow/pull/1042))

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test:
 	python -m pytest -rs ${PYTEST_EXTRA}
 
 testcov:
-	python -m pytest -rs --cov --junitxml=junit.xml -o junit_family=legacy --cov-report= ${PYTEST_EXTRA}
+	python -m pytest -s --cov --junitxml=junit.xml -o junit_family=legacy --cov-report= ${PYTEST_EXTRA}
 
 typing:
 	mypy streamflow tests

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test:
 	python -m pytest -rs ${PYTEST_EXTRA}
 
 testcov:
-	python -m pytest -rs --cov --junitxml=junit.xml -o junit_family=legacy --cov-report= ${PYTEST_EXTRA}
+	python -m pytest -s --cov --junitxml=junit.xml -o junit_family=legacy --cov-report= ${PYTEST_EXTRA}
 
 typing:
 	mypy streamflow tests docs/source/conf.py docs/tests

--- a/streamflow/data/remotepath.py
+++ b/streamflow/data/remotepath.py
@@ -915,13 +915,14 @@ async def download(
                         f"Downloading {url} failed with status {response.status}:\n{response.content}"
                     )
         connector = context.deployment_manager.get_connector(location.deployment)
-        await connector.run(
-            location=location,
-            command=[
-                f'if [ command -v curl ]; then curl -L -o "{filepath}" "{url}"; '
-                f'else wget -O "{filepath}" "{url}"; fi'
-            ],
+        command = [
+            f'if command -v curl; then curl -L -o "{filepath}" "{url}"; '
+            f'else wget -O "{filepath}" "{url}"; fi'
+        ]
+        result, status = await connector.run(
+            location=location, command=command, capture_output=True
         )
+        _check_status(command, location, result, status)
     return StreamFlowPath(filepath, context=context, location=location)
 
 

--- a/streamflow/data/remotepath.py
+++ b/streamflow/data/remotepath.py
@@ -946,13 +946,14 @@ async def download(
                         f"Downloading {url} failed with status {response.status}:\n{response.content}"
                     )
         connector = context.deployment_manager.get_connector(location.deployment)
-        await connector.run(
-            location=location,
-            command=[
-                f'if [ command -v curl ]; then curl -L -o "{filepath}" "{url}"; '
-                f'else wget -O "{filepath}" "{url}"; fi'
-            ],
+        command = [
+            f'if command -v curl; then curl -L -o "{filepath}" "{url}"; '
+            f'else wget -O "{filepath}" "{url}"; fi'
+        ]
+        result, status = await connector.run(
+            location=location, command=command, capture_output=True
         )
+        _check_status(command, location, result, status)
     return StreamFlowPath(filepath, context=context, location=location)
 
 

--- a/streamflow/deployment/connector/container.py
+++ b/streamflow/deployment/connector/container.py
@@ -1464,9 +1464,28 @@ class DockerComposeConnector(DockerBaseConnector):
                 capture_output=True,
             )
             if returncode != 0:
+                log_stdout, returncode = await self.connector.run(
+                    location=self._get_inner_location(),
+                    command=await self._get_base_command() + ["logs"],
+                    capture_output=True,
+                )
+                if returncode == 0:
+                    stdout += f"\n{log_stdout}"
                 raise WorkflowExecutionException(
                     f"FAILED Deployment of {self.deployment_name} environment [{returncode}]:\n\t{stdout}"
                 )
+            elif logger.isEnabledFor(logging.DEBUG):
+                stdout, returncode = await self.connector.run(
+                    location=self._get_inner_location(),
+                    command=await self._get_base_command() + ["logs"],
+                    capture_output=True,
+                )
+                if returncode == 0:
+                    logger.debug(f"Docker Compose {self.deployment_name} log while deploying:\n\t{stdout}")
+                else:
+                    raise WorkflowExecutionException(
+                        f"FAILED Deployment of {self.deployment_name} environment [{returncode}]:\n\t{stdout}"
+                    )
 
     async def get_available_locations(
         self, service: str | None = None
@@ -1481,7 +1500,7 @@ class DockerComposeConnector(DockerBaseConnector):
             (json_end := output.rfind("}")) != -1
         ):
             if json_start != 0 and logger.isEnabledFor(logging.DEBUG):
-                logger.debug(f"Docker Compose log: {output[:json_start].strip()}")
+                logger.debug(f"Docker Compose {self.deployment_name} log while inspecting: {output[:json_start].strip()}")
             locations = json.loads(output[json_start : json_end + 1])
         else:
             raise WorkflowExecutionException(

--- a/streamflow/deployment/connector/container.py
+++ b/streamflow/deployment/connector/container.py
@@ -1513,9 +1513,30 @@ class DockerComposeConnector(DockerBaseConnector):
                 capture_output=True,
             )
             if returncode != 0:
+                log_stdout, returncode = await self.connector.run(
+                    location=self._get_inner_location(),
+                    command=await self._get_base_command() + ["logs"],
+                    capture_output=True,
+                )
+                if returncode == 0:
+                    stdout += f"\n{log_stdout}"
                 raise WorkflowExecutionException(
                     f"FAILED Deployment of {self.deployment_name} environment [{returncode}]:\n\t{stdout}"
                 )
+            elif logger.isEnabledFor(logging.DEBUG):
+                stdout, returncode = await self.connector.run(
+                    location=self._get_inner_location(),
+                    command=await self._get_base_command() + ["logs"],
+                    capture_output=True,
+                )
+                if returncode == 0:
+                    logger.debug(
+                        f"Docker Compose {self.deployment_name} log while deploying:\n\t{stdout}"
+                    )
+                else:
+                    raise WorkflowExecutionException(
+                        f"FAILED Deployment of {self.deployment_name} environment [{returncode}]:\n\t{stdout}"
+                    )
 
     async def get_available_locations(
         self, service: str | None = None
@@ -1530,7 +1551,10 @@ class DockerComposeConnector(DockerBaseConnector):
             (json_end := output.rfind("}")) != -1
         ):
             if json_start != 0 and logger.isEnabledFor(logging.DEBUG):
-                logger.debug(f"Docker Compose log: {output[:json_start].strip()}")
+                logger.debug(
+                    f"Docker Compose {self.deployment_name} log "
+                    f"while inspecting: {output[:json_start].strip()}"
+                )
             content = output[json_start : json_end + 1]
             try:
                 locations = json.loads(content)

--- a/streamflow/deployment/connector/queue_manager.py
+++ b/streamflow/deployment/connector/queue_manager.py
@@ -964,7 +964,7 @@ class PBSConnector(QueueManagerConnector):
             "-Fjson",
         ]
         if logger.isEnabledFor(logging.DEBUG):
-            logger.debug(f"Running command {command}")
+            logger.debug(f"Running command {' '.join(command)}")
         stdout, _ = await super().run(
             location=location,
             command=command,
@@ -995,7 +995,7 @@ class PBSConnector(QueueManagerConnector):
         stderr: int | str = asyncio.subprocess.STDOUT,
         timeout: int | None = None,
     ) -> str:
-        batch_command = ["sh", "-c"]
+        batch_command = []
         if workdir is not None:
             batch_command.extend(["cd", workdir, "&&"])
         resources = (

--- a/streamflow/deployment/connector/queue_manager.py
+++ b/streamflow/deployment/connector/queue_manager.py
@@ -966,7 +966,7 @@ class PBSConnector(QueueManagerConnector):
             "-Fjson",
         ]
         if logger.isEnabledFor(logging.DEBUG):
-            logger.debug(f"Running command {command}")
+            logger.debug(f"Running command {' '.join(command)}")
         stdout, _ = await super().run(
             location=location,
             command=command,
@@ -997,7 +997,7 @@ class PBSConnector(QueueManagerConnector):
         stderr: int | str = asyncio.subprocess.STDOUT,
         timeout: int | None = None,
     ) -> str:
-        batch_command = ["sh", "-c"]
+        batch_command = []
         if workdir is not None:
             batch_command.extend(["cd", workdir, "&&"])
         resources = (

--- a/streamflow/log_handler.py
+++ b/streamflow/log_handler.py
@@ -126,5 +126,5 @@ formatter = logging.Formatter(
 )
 defaultStreamHandler.setFormatter(formatter)
 logger.addHandler(defaultStreamHandler)
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
 logger.propagate = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,7 +126,14 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
 
 
 def all_deployment_types() -> list[str]:
-    deployments_ = ["local", "docker", "docker-compose", "docker-wrapper", "slurm"]
+    deployments_ = [
+        "local",
+        "docker",
+        "docker-compose",
+        "docker-wrapper",
+        "openpbs",
+        "slurm",
+    ]
     if platform.system() == "Linux":
         deployments_.extend(["kubernetes", "singularity", "ssh"])
     return deployments_

--- a/tests/data/deployment/openpbs/docker-compose.yml
+++ b/tests/data/deployment/openpbs/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  server:
+    image: alphaunito/openpbs-server:23.06.06
+    environment:
+      PBS_EXECUTION_HOST_NAME_PREFIX: ${COMPOSE_PROJECT_NAME}-execution
+      PBS_EXECUTION_NODES: 2
+    hostname: openpbs-server
+    networks:
+      - pbsnet
+    volumes:
+      - home:/home/hpcuser
+      - munge:/etc/munge
+      - pgsql:/usr/local/pgsql/data
+  execution:
+    image: alphaunito/openpbs-execution:23.06.06
+    deploy:
+      mode: replicated
+      replicas: 2
+    environment:
+      PBS_SERVER_HOST_NAME: openpbs-server
+    networks:
+      - pbsnet
+    volumes:
+      - home:/home/hpcuser
+      - munge:/etc/munge
+networks:
+  pbsnet:
+volumes:
+  home:
+  munge:
+  pgsql:

--- a/tests/data/deployment/slurm/docker-compose.yml
+++ b/tests/data/deployment/slurm/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   slurmctld:
-    image: alphaunito/slurmctld:21.08.5
+    image: alphaunito/slurmctld:23.11.4
     environment:
       SLURMD_HOSTNAME_PREFIX: ${COMPOSE_PROJECT_NAME}-slurmd
       SLURMD_NODES: 2
@@ -13,7 +13,7 @@ services:
       - munge:/etc/munge
       - mysql:/var/lib/mysql
   slurmd:
-    image: alphaunito/slurmd:21.08.5
+    image: alphaunito/slurmd:23.11.4
     deploy:
       mode: replicated
       replicas: 2

--- a/tests/utils/deployment.py
+++ b/tests/utils/deployment.py
@@ -79,6 +79,8 @@ def get_deployment(deployment_t: str) -> str:
             return "__LOCAL__"
         case "local-fs-volatile":
             return "local-fs-volatile"
+        case "openpbs":
+            return "docker-openpbs"
         case "parameterizable_hardware":
             return "custom-hardware"
         case "singularity":
@@ -115,6 +117,16 @@ async def get_deployment_config(
                     "test-fs-volatile",
                 ),
             )
+        case "docker":
+            return get_docker_deployment_config()
+        case "docker-compose":
+            return get_docker_compose_deployment_config()
+        case "docker-wrapper":
+            return await get_docker_wrapper_deployment_config(_context)
+        case "kubernetes":
+            return get_kubernetes_deployment_config()
+        case "openpbs":
+            return await get_openpbs_deployment_config(_context)
         case "parameterizable-hardware":
             return get_parameterizable_hardware_deployment_config()
         case "singularity":
@@ -231,6 +243,36 @@ async def get_location(
     return next(iter(locations.values())).location
 
 
+async def get_openpbs_deployment_config(_context: StreamFlowContext):
+    docker_compose_config = DeploymentConfig(
+        name="docker-compose-openpbs",
+        type="docker-compose",
+        config={
+            "files": [
+                str(get_data_path("deployment", "openpbs", "docker-compose.yml"))
+            ],
+            "projectName": random_name(),
+        },
+        external=False,
+    )
+    await _context.deployment_manager.deploy(docker_compose_config)
+    return DeploymentConfig(
+        name="docker-openpbs",
+        type="pbs",
+        config={
+            "services": {
+                "test": {
+                    "destination": "workq",
+                    "resources": {"nodes": "2:ppn=1"},
+                }
+            }
+        },
+        external=False,
+        lazy=False,
+        wraps=WrapsConfig(deployment="docker-compose-openpbs", service="server"),
+    )
+
+
 def get_parameterizable_hardware_deployment_config() -> DeploymentConfig:
     workdir = os.path.join(
         os.path.realpath(tempfile.gettempdir()), "streamflow-test", random_name()
@@ -263,7 +305,7 @@ def get_service(_context: StreamFlowContext, deployment_t: str) -> str | None:
             return "alpine"
         case "kubernetes":
             return "sf-test"
-        case "slurm":
+        case "slurm" | "openpbs":
             return "test"
         case _:
             raise Exception(f"{deployment_t} deployment type not supported")

--- a/tests/utils/deployment.py
+++ b/tests/utils/deployment.py
@@ -263,7 +263,7 @@ async def get_openpbs_deployment_config(_context: StreamFlowContext):
             "services": {
                 "test": {
                     "destination": "workq",
-                    "resources": {"nodes": "2:ppn=1"},
+                    "resources": {"nodes": "1"},
                 }
             }
         },

--- a/tests/utils/deployment.py
+++ b/tests/utils/deployment.py
@@ -251,7 +251,7 @@ async def get_openpbs_deployment_config(_context: StreamFlowContext):
             "files": [
                 str(get_data_path("deployment", "openpbs", "docker-compose.yml"))
             ],
-            "projectName": random_name(),
+            "projectName": random_name().split("-")[0],
         },
         external=False,
     )

--- a/tests/utils/deployment.py
+++ b/tests/utils/deployment.py
@@ -79,6 +79,8 @@ def get_deployment(deployment_t: str) -> str:
             return "__LOCAL__"
         case "local-fs-volatile":
             return "local-fs-volatile"
+        case "openpbs":
+            return "docker-openpbs"
         case "parameterizable_hardware":
             return "custom-hardware"
         case "singularity":
@@ -115,6 +117,16 @@ async def get_deployment_config(
                     "test-fs-volatile",
                 ),
             )
+        case "docker":
+            return get_docker_deployment_config()
+        case "docker-compose":
+            return get_docker_compose_deployment_config()
+        case "docker-wrapper":
+            return await get_docker_wrapper_deployment_config(_context)
+        case "kubernetes":
+            return get_kubernetes_deployment_config()
+        case "openpbs":
+            return await get_openpbs_deployment_config(_context)
         case "parameterizable-hardware":
             return get_parameterizable_hardware_deployment_config()
         case "singularity":
@@ -241,6 +253,36 @@ async def get_location(
     return next(iter(locations.values())).location
 
 
+async def get_openpbs_deployment_config(_context: StreamFlowContext):
+    docker_compose_config = DeploymentConfig(
+        name="docker-compose-openpbs",
+        type="docker-compose",
+        config={
+            "files": [
+                str(get_data_path("deployment", "openpbs", "docker-compose.yml"))
+            ],
+            "projectName": random_name().split("-")[0],
+        },
+        external=False,
+    )
+    await _context.deployment_manager.deploy(docker_compose_config)
+    return DeploymentConfig(
+        name="docker-openpbs",
+        type="pbs",
+        config={
+            "services": {
+                "test": {
+                    "destination": "workq",
+                    "resources": {"nodes": "1"},
+                }
+            }
+        },
+        external=False,
+        lazy=False,
+        wraps=WrapsConfig(deployment="docker-compose-openpbs", service="server"),
+    )
+
+
 def get_parameterizable_hardware_deployment_config(
     name: str = "custom-hardware",
 ) -> DeploymentConfig:
@@ -275,7 +317,7 @@ def get_service(_context: StreamFlowContext, deployment_t: str) -> str | None:
             return "alpine"
         case "kubernetes":
             return "sf-test"
-        case "slurm":
+        case "slurm" | "openpbs":
             return "test"
         case _:
             raise Exception(f"{deployment_t} deployment type not supported")

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ asyncio_default_fixture_loop_scope = session
 asyncio_default_test_loop_scope = session
 asyncio_mode = strict
 testpaths = tests
+log_cli = True
 
 [testenv]
 allowlist_externals = make


### PR DESCRIPTION
This commit adds a Docker-based OpenPBS cluster to the set of target architectures for CI tests, ensuring that the `PBSConnector` is properly tested.