### PR TITLE
Changed default StreamFlow workdir

### DIFF
--- a/streamflow/core/deployment.py
+++ b/streamflow/core/deployment.py
@@ -268,9 +268,13 @@ class Target(PersistableEntity):
             workdir
             or self.deployment.workdir
             or (
-                os.path.join(os.path.realpath(tempfile.gettempdir()), "streamflow")
+                os.path.join(
+                    os.path.realpath(tempfile.gettempdir()),
+                    utils.get_local_username(),
+                    "streamflow",
+                )
                 if deployment.type == "local"
-                else posixpath.join("/tmp", "streamflow")  # nosec
+                else posixpath.join("/tmp", "${USER}", "streamflow")
             )
         )
 

--- a/streamflow/core/utils.py
+++ b/streamflow/core/utils.py
@@ -7,6 +7,7 @@ import importlib
 import itertools
 import os
 import posixpath
+import pwd
 import shlex
 import uuid
 from collections.abc import Iterable, MutableMapping, MutableSequence
@@ -230,6 +231,10 @@ async def get_local_to_remote_destination(
     else:
         # Keep current dst
         return dst
+
+
+def get_local_username() -> str:
+    return pwd.getpwuid(os.getuid()).pw_name
 
 
 def get_option(

--- a/streamflow/deployment/connector/local.py
+++ b/streamflow/deployment/connector/local.py
@@ -118,7 +118,11 @@ class LocalConnector(BaseConnector):
 
     async def deploy(self, external: bool) -> None:
         os.makedirs(
-            os.path.join(os.path.realpath(tempfile.gettempdir()), "streamflow"),
+            os.path.join(
+                os.path.realpath(tempfile.gettempdir()),
+                utils.get_local_username(),
+                "streamflow",
+            ),
             exist_ok=True,
         )
 

--- a/streamflow/recovery/checkpoint_manager.py
+++ b/streamflow/recovery/checkpoint_manager.py
@@ -11,7 +11,6 @@ from streamflow.core import utils
 from streamflow.core.data import DataLocation
 from streamflow.core.deployment import ExecutionLocation, LocalTarget
 from streamflow.core.recovery import CheckpointManager
-from streamflow.core.utils import random_name
 
 if TYPE_CHECKING:
     from streamflow.core.context import StreamFlowContext
@@ -22,6 +21,7 @@ class DefaultCheckpointManager(CheckpointManager):
         super().__init__(context)
         self.checkpoint_dir = checkpoint_dir or os.path.join(
             os.path.realpath(tempfile.gettempdir()),
+            utils.get_local_username(),
             "streamflow",
             "checkpoint",
             utils.random_name(),
@@ -29,7 +29,7 @@ class DefaultCheckpointManager(CheckpointManager):
         self.copy_tasks: MutableSequence[asyncio.Task[None]] = []
 
     async def _async_local_copy(self, data_location: DataLocation) -> None:
-        parent_directory = os.path.join(self.checkpoint_dir, random_name())
+        parent_directory = os.path.join(self.checkpoint_dir, utils.random_name())
         local_path = os.path.join(parent_directory, data_location.relpath)
         await self.context.data_manager.transfer_data(
             src_location=data_location.location,

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -21,7 +21,6 @@ from streamflow.core.config import BindingConfig
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.deployment import Target
 from streamflow.core.exception import WorkflowDefinitionException
-from streamflow.core.utils import compare_tags
 from streamflow.core.workflow import Token
 from streamflow.cwl.runner import main
 from streamflow.cwl.step import CWLTransferStep
@@ -418,7 +417,7 @@ async def test_gather_order(context: StreamFlowContext) -> None:
         if prev_tag is None:
             assert token.tag == "0.0"
         else:
-            assert compare_tags(token.tag, prev_tag) > 0
+            assert utils.compare_tags(token.tag, prev_tag) > 0
         prev_tag = token.tag
 
 
@@ -508,9 +507,13 @@ async def test_workdir_inheritance() -> None:
     assert binding_config.targets[3].deployment.name == "wrapper_4"
     assert binding_config.targets[3].deployment.workdir is None
     assert binding_config.targets[3].workdir == (
-        os.path.join(os.path.realpath(tempfile.gettempdir()), "streamflow")
+        os.path.join(
+            os.path.realpath(tempfile.gettempdir()),
+            utils.get_local_username(),
+            "streamflow",
+        )
         if binding_config.targets[3].deployment == "local"
-        else posixpath.join("/tmp", "streamflow")
+        else posixpath.join("/tmp", "${USER}", "streamflow")
     )
 
 

--- a/tests/utils/deployment.py
+++ b/tests/utils/deployment.py
@@ -21,7 +21,6 @@ from streamflow.core.deployment import (
     Target,
     WrapsConfig,
 )
-from streamflow.core.utils import random_name
 from streamflow.core.workflow import Job
 from streamflow.deployment import DefaultDeploymentManager
 from tests.utils.data import get_data_path
@@ -75,8 +74,9 @@ async def get_deployment_config(
                 name="local-fs-volatile",
                 workdir=os.path.join(
                     os.path.realpath(tempfile.gettempdir()),
+                    utils.get_local_username(),
                     "streamflow-test",
-                    random_name(),
+                    utils.random_name(),
                     "test-fs-volatile",
                 ),
             )
@@ -108,7 +108,7 @@ def get_docker_compose_deployment_config():
             "files": [
                 str(get_data_path("deployment", "docker-compose", "docker-compose.yml"))
             ],
-            "projectName": random_name(),
+            "projectName": utils.random_name(),
         },
         external=False,
         lazy=False,
@@ -179,7 +179,10 @@ def get_local_deployment_config(
     name: str | None = None, workdir: str | None = None
 ) -> DeploymentConfig:
     workdir = workdir or os.path.join(
-        os.path.realpath(tempfile.gettempdir()), "streamflow-test", random_name()
+        os.path.realpath(tempfile.gettempdir()),
+        utils.get_local_username(),
+        "streamflow-test",
+        utils.random_name(),
     )
     os.makedirs(workdir, exist_ok=True)
     return DeploymentConfig(
@@ -204,7 +207,10 @@ async def get_location(
 
 def get_parameterizable_hardware_deployment_config():
     workdir = os.path.join(
-        os.path.realpath(tempfile.gettempdir()), "streamflow-test", random_name()
+        os.path.realpath(tempfile.gettempdir()),
+        utils.get_local_username(),
+        "streamflow-test",
+        utils.random_name(),
     )
     os.makedirs(workdir, exist_ok=True)
     return DeploymentConfig(
@@ -255,7 +261,7 @@ async def get_slurm_deployment_config(_context: StreamFlowContext):
         type="docker-compose",
         config={
             "files": [str(get_data_path("deployment", "slurm", "docker-compose.yml"))],
-            "projectName": random_name(),
+            "projectName": utils.random_name(),
         },
         external=False,
     )


### PR DESCRIPTION
This commit updates the default StreamFlow workdir. It now creates a user-specific directory containing the StreamFlow folder, which helps avoid permission issues when multiple users share a node.