### PR TITLE
Reduced overhead of the `transfer_data` method

### DIFF
--- a/streamflow/data/manager.py
+++ b/streamflow/data/manager.py
@@ -335,18 +335,18 @@ class DefaultDataManager(DataManager):
                         dst_path, context=self.context, location=location
                     ).parent.mkdir(mode=0o777, parents=True, exist_ok=True)
                 )
-                for location in [
-                    location
-                    for location in dst_locations
+                for location in (
+                    loc
+                    for loc in dst_locations
                     if len(
                         self.get_data_locations(
                             path=os.path.dirname(dst_path),
-                            deployment=location.deployment,
-                            location_name=location.name,
+                            deployment=loc.deployment,
+                            location_name=loc.name,
                         )
                     )
                     == 0
-                ]
+                )
             )
         )
         # Follow symlink for source path


### PR DESCRIPTION
This commit reduces the number of `mkdir` calls within the `transfer_data` method of the `DefaultDataManager`. Previously, `mkdir` was executed for the parent directory during every data transfer. Now, the `mkdir` call is performed only if the parent directory is not already registered in the `DataManager`.