### PR TITLE
Handle single-element list for CWL Workflow outputs

### DIFF
--- a/streamflow/cwl/transformer.py
+++ b/streamflow/cwl/transformer.py
@@ -24,18 +24,11 @@ from streamflow.workflow.utils import get_token_value
 
 
 class AllNonNullTransformer(OneToOneTransformer):
-    def __init__(self, name: str, workflow: CWLWorkflow, single: bool = False) -> None:
-        super().__init__(name, workflow)
-        self.single: bool = single
-
     def _transform(self, name: str, token: Token) -> Token:
         if isinstance(token, ListToken):
-            token = token.update(
+            return token.update(
                 [t for t in token.value if get_token_value(t) is not None]
             )
-            if self.single and len(token.value) == 1:
-                token = token.value[0]
-            return token
         else:
             raise WorkflowExecutionException(f"Invalid value for token {name}")
 


### PR DESCRIPTION
This commit fixes a special case of the `pickValue` directive. As defined in https://www.commonwl.org/v1.2/Workflow.html#WorkflowStepInput, if the `pickValue` has a single source and the resulting list contains only one element (i.e., the source is not null), the element itself is returned, rather than a single-element list.