### PR TITLE
Improve `StreamFlowExecutor` termination protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improve `StreamFlowExecutor` termination protocol ([#1000](https://github.com/alpha-unito/streamflow/pull/1000))
 - Improve save protocol and SQLite pragmas ([#1036](https://github.com/alpha-unito/streamflow/pull/1036))
 - Refactor `load` API to drop the `context` parameter ([#1035](https://github.com/alpha-unito/streamflow/pull/1035))
 - Refactor `save` API to take a `Database` argument ([#1034](https://github.com/alpha-unito/streamflow/pull/1034))

--- a/cwl-conformance-test.sh
+++ b/cwl-conformance-test.sh
@@ -20,14 +20,15 @@ venv() {
   if ! test -d "$1" ; then
 	  if command -v uv > /dev/null; then
 	    uv venv "$1"
-	    uv sync --locked --no-dev || exit 1
+	    source "$1/bin/activate"
+	    uv sync --active --locked --no-dev || exit 1
 	  elif command -v virtualenv > /dev/null; then
       virtualenv -p python3 "$1"
 	  else
 	    python3 -m venv "$1"
 	  fi
   fi
-  source "$1"/bin/activate
+  source "$1/bin/activate"
 }
 
 # Version of the standard to test against

--- a/streamflow/core/workflow.py
+++ b/streamflow/core/workflow.py
@@ -138,6 +138,12 @@ class Executor(ABC):
         self.workflow: Workflow = workflow
 
     @abstractmethod
+    async def close(self) -> None: ...
+
+    @abstractmethod
+    async def closed(self) -> bool: ...
+
+    @abstractmethod
     async def run(self) -> MutableMapping[str, Any]: ...
 
 

--- a/streamflow/workflow/executor.py
+++ b/streamflow/workflow/executor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from collections.abc import MutableMapping, MutableSequence
+from collections.abc import Iterable, MutableMapping, MutableSequence
 from typing import TYPE_CHECKING, overload
 
 from streamflow.core import utils
@@ -24,7 +24,8 @@ class StreamFlowExecutor(Executor):
         self.executions: MutableSequence[asyncio.Task[None]] = []
         self.output_tasks: MutableMapping[str, asyncio.Task[Token]] = {}
         self.received: MutableSequence[str] = []
-        self.closed: bool = False
+        self._closed: bool = False
+        self._closing: asyncio.Event | None = None
 
     if TYPE_CHECKING:
 
@@ -33,6 +34,19 @@ class StreamFlowExecutor(Executor):
         @overload
         async def _handle_exception(self, task: asyncio.Task[None]) -> None: ...
 
+    async def _cancel(self, tasks: Iterable[asyncio.Task]) -> None:
+        if self._closed:
+            return
+        if self._closing is not None:
+            await self._closing.wait()
+        else:
+            # Cancel all tasks
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks)
+            # Mark the executor as closed
+            self._closed = True
+
     async def _handle_exception(self, task: asyncio.Task[Token | None]) -> Token | None:
         try:
             return await task
@@ -40,21 +54,8 @@ class StreamFlowExecutor(Executor):
             pass
         except Exception as exc:
             logger.exception(exc)
-            if not self.closed:
-                await self._shutdown()
+            await self.close()
             return None
-
-    async def _shutdown(self) -> None:
-        # Terminate all steps
-        await asyncio.gather(
-            *(
-                asyncio.create_task(step.terminate(Status.CANCELLED))
-                for step in self.workflow.steps.values()
-                if not step.terminated
-            )
-        )
-        # Mark the executor as closed
-        self.closed = True
 
     async def _wait_outputs(
         self, output_consumer: str, output_tokens: MutableMapping[str, Any]
@@ -73,15 +74,13 @@ class StreamFlowExecutor(Executor):
             # If a TerminationToken is received, the corresponding port terminated its outputs
             if isinstance(token, TerminationToken):
                 if token.value in (Status.CANCELLED, Status.FAILED):
-                    self.closed = True
-                    for t in unfinished:
-                        t.cancel()
+                    await self._cancel(unfinished)
                     return output_tokens
                 else:
                     self.received.append(task_name)
                     # When the last port terminates, the entire executor terminates
                     if len(self.received) == len(self.workflow.output_ports):
-                        self.closed = True
+                        await self.close()
             else:
                 # Collect result
                 output_tokens[task_name] = get_token_value(token)
@@ -106,9 +105,34 @@ class StreamFlowExecutor(Executor):
                     ),
                     name=port_name,
                 )
-                self.closed = False
+                # Reopen the executor if it was closed
+                if await self.closed():
+                    self._closing = None
+                    self._closed = False
         # Return output tokens
         return output_tokens
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        if self._closing is not None:
+            await self._closing.wait()
+        else:
+            # Terminate all steps
+            await asyncio.gather(
+                *(
+                    asyncio.create_task(step.terminate(Status.CANCELLED))
+                    for step in self.workflow.steps.values()
+                    if not step.terminated
+                )
+            )
+            # Mark the executor as closed
+            self._closed = True
+
+    async def closed(self) -> bool:
+        if self._closing is not None:
+            await self._closing.wait()
+        return self._closed
 
     async def run(self) -> MutableMapping[str, Any]:
         try:
@@ -138,7 +162,7 @@ class StreamFlowExecutor(Executor):
                         ),
                         name=port_name,
                     )
-                while not self.closed:
+                while not await self.closed():
                     output_tokens = await self._wait_outputs(
                         output_consumer, output_tokens
                     )
@@ -156,12 +180,11 @@ class StreamFlowExecutor(Executor):
                 )
             # Print output tokens
             return output_tokens
-        except Exception:
+        except BaseException:
             if self.workflow.persistent_id:
                 await self.workflow.context.database.update_workflow(
                     self.workflow.persistent_id,
                     {"status": Status.FAILED.value, "end_time": time.time_ns()},
                 )
-            if not self.closed:
-                await self._shutdown()
+            await self.close()
             raise


### PR DESCRIPTION
This commit improves the termination protocol of the `StreamFlowExecutor` class, adopting the same behaviour used in `BaseShell`. This new protocol should guarantee that all tasks are correctly terminated before closing the `StreamFlowContext`, allowing cleaner terminations of the StreamFlow application.