### PR TITLE
Fix lock releasing logic in scheduler

### DIFF
--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -417,35 +417,35 @@ class DefaultScheduler(Scheduler):
                                     f"on deployment {deployment_name}, "
                                     f"but only {len(valid_locations)} are available."
                                 )
-                async with contextlib.AsyncExitStack() as exit_stack:
-                    for conn in stacked_connectors:
-                        if conn is not connector:
-                            await exit_stack.enter_async_context(
-                                self.wait_queues[conn.deployment_name]
-                            )
-                    finished, unfinished = await asyncio.wait(
-                        [
-                            asyncio.create_task(
-                                self.wait_queues[conn.deployment_name].wait(),
-                                name=conn.deployment_name,
-                            )
-                            for conn in stacked_connectors
-                        ],
-                        timeout=self.retry_interval,
-                        return_when=asyncio.FIRST_COMPLETED,
+                for conn in stacked_connectors:
+                    if conn.deployment_name != connector.deployment_name:
+                        await self.wait_queues[conn.deployment_name].acquire()
+                finished, unfinished = await asyncio.wait(
+                    [
+                        asyncio.create_task(
+                            self.wait_queues[conn.deployment_name].wait(),
+                            name=conn.deployment_name,
+                        )
+                        for conn in stacked_connectors
+                    ],
+                    timeout=self.retry_interval,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                for t in finished:
+                    if t.get_name() != connector.deployment_name:
+                        self.wait_queues[t.get_name()].release()
+                for t in unfinished:
+                    t.cancel()
+                if not finished and logger.isEnabledFor(logging.DEBUG):
+                    target_name = (
+                        "/".join([target.deployment.name, target.service])
+                        if target.service is not None
+                        else target.deployment.name
                     )
-                    for t in unfinished:
-                        t.cancel()
-                    if not finished and logger.isEnabledFor(logging.DEBUG):
-                        target_name = (
-                            "/".join([target.deployment.name, target.service])
-                            if target.service is not None
-                            else target.deployment.name
-                        )
-                        logger.debug(
-                            f"No locations available for job {job_context.job.name} "
-                            f"in target {target_name}. Waiting {self.retry_interval} seconds."
-                        )
+                    logger.debug(
+                        f"No locations available for job {job_context.job.name} "
+                        f"in target {target_name}. Waiting {self.retry_interval} seconds."
+                    )
 
     async def _resolve_hardware_requirement(
         self,

--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 import os
 import posixpath
@@ -60,10 +59,9 @@ class DefaultScheduler(Scheduler):
         super().__init__(context)
         self.binding_filter_map: MutableMapping[str, BindingFilter] = {}
         self.hardware_locations: MutableMapping[str, Hardware] = {}
-        self.locks: MutableMapping[str, asyncio.Lock] = {}
         self.policy_map: MutableMapping[str, Policy] = {}
         self.retry_interval: int | None = retry_delay if retry_delay != 0 else None
-        self.wait_queues: MutableMapping[str, asyncio.Condition] = {}
+        self.wait_queue: asyncio.Condition = asyncio.Condition()
 
     def _allocate_job(
         self,
@@ -130,62 +128,57 @@ class DefaultScheduler(Scheduler):
                     conn = cast(ConnectorWrapper, conn).connector
 
     async def _free_resources(
-        self, connector: Connector, job_allocation: JobAllocation, status: Status
+        self, connector: Connector, job_allocation: JobAllocation
     ) -> None:
-        async with contextlib.AsyncExitStack() as exit_stack:
-            for conn in _get_connector_stack(connector):
-                await exit_stack.enter_async_context(self.locks[conn.deployment_name])
-            conn = connector
-            locations = job_allocation.locations
-            job_hardware = job_allocation.hardware
-            while locations:
-                for loc in locations:
-                    if loc.name in self.hardware_locations.keys():
-                        try:
-                            storage_usage = Hardware(
-                                storage=(
-                                    {
-                                        k: Storage(
-                                            mount_point=job_hardware.storage[
-                                                k
-                                            ].mount_point,
-                                            size=size / 2**20,
-                                        )
-                                        for k, size in (
-                                            await remotepath.get_storage_usages(
-                                                self.context,
-                                                loc,
-                                                job_hardware,
-                                            )
-                                        ).items()
-                                    }
-                                )
-                            )
-                        except WorkflowExecutionException as err:
-                            logger.warning(
-                                f"Impossible to retrieve the actual storage usage in "
-                                f"the {job_allocation.job} job working directories: {err}"
-                            )
-                            storage_usage = Hardware()
-                        self.hardware_locations[loc.name] = (
-                            self.hardware_locations[loc.name] - job_hardware
-                        ) + storage_usage
-                if locations := [loc.wraps for loc in locations if loc.stacked]:
-                    conn = cast(ConnectorWrapper, conn).connector
-                    for execution_loc in locations:
-                        job_hardware = await utils.bind_mount_point(
-                            self.context,
-                            next(
-                                available_loc
-                                for available_loc in (
-                                    await conn.get_available_locations(
-                                        execution_loc.service
+        conn = connector
+        locations = job_allocation.locations
+        job_hardware = job_allocation.hardware
+        while locations:
+            for loc in locations:
+                if loc.name in self.hardware_locations.keys():
+                    try:
+                        storage_usage = Hardware(
+                            storage=(
+                                {
+                                    k: Storage(
+                                        mount_point=job_hardware.storage[k].mount_point,
+                                        size=size / 2**20,
                                     )
-                                ).values()
-                                if available_loc.name == execution_loc.name
-                            ),
-                            job_hardware,
+                                    for k, size in (
+                                        await remotepath.get_storage_usages(
+                                            self.context,
+                                            loc,
+                                            job_hardware,
+                                        )
+                                    ).items()
+                                }
+                            )
                         )
+                    except WorkflowExecutionException as err:
+                        logger.warning(
+                            f"Impossible to retrieve the actual storage usage in "
+                            f"the {job_allocation.job} job working directories: {err}"
+                        )
+                        storage_usage = Hardware()
+                    self.hardware_locations[loc.name] = (
+                        self.hardware_locations[loc.name] - job_hardware
+                    ) + storage_usage
+            if locations := [loc.wraps for loc in locations if loc.stacked]:
+                conn = cast(ConnectorWrapper, conn).connector
+                for execution_loc in locations:
+                    job_hardware = await utils.bind_mount_point(
+                        self.context,
+                        next(
+                            available_loc
+                            for available_loc in (
+                                await conn.get_available_locations(
+                                    execution_loc.service
+                                )
+                            ).values()
+                            if available_loc.name == execution_loc.name
+                        ),
+                        job_hardware,
+                    )
 
     def _get_binding_filter(self, config: FilterConfig) -> BindingFilter:
         if config.name not in self.binding_filter_map:
@@ -294,9 +287,7 @@ class DefaultScheduler(Scheduler):
         hardware_requirement: HardwareRequirement | None,
     ) -> None:
         deployment = target.deployment.name
-        if deployment not in self.wait_queues:
-            self.wait_queues[deployment] = asyncio.Condition()
-        async with self.wait_queues[deployment]:
+        async with self.wait_queue:
             while True:
                 async with job_context.lock:
                     if job_context.scheduled:
@@ -350,102 +341,75 @@ class DefaultScheduler(Scheduler):
                                 hardware_requirements[key] = hardware
                             else:
                                 hardware_requirements[key] |= hardware
-                    async with contextlib.AsyncExitStack() as exit_stack:
-                        for conn in (
-                            stacked_connectors := _get_connector_stack(connector)
-                        ):
-                            if conn.deployment_name not in self.locks:
-                                self.locks[conn.deployment_name] = asyncio.Lock()
-                            if conn.deployment_name not in self.wait_queues:
-                                self.wait_queues[conn.deployment_name] = (
-                                    asyncio.Condition()
-                                )
-                            await exit_stack.enter_async_context(
-                                self.locks[conn.deployment_name]
-                            )
-                        valid_locations = {
-                            k: loc
-                            for k, loc in available_locations.items()
-                            if self._is_valid(
-                                connector=connector,
-                                location=loc,
-                                hardware_requirements=hardware_requirements,
-                                job_name=job.name,
-                            )
-                        }
-                        if len(valid_locations) >= target.locations:
-                            if logger.isEnabledFor(logging.DEBUG):
-                                logger.debug(
-                                    "Available locations for job {} on {} are {}.".format(
-                                        job_context.job.name,
-                                        (
-                                            posixpath.join(deployment, target.service)
-                                            if target.service
-                                            else deployment
-                                        ),
-                                        list(valid_locations.keys()),
-                                    )
-                                )
-                            if selected_locations := await self._get_locations(
-                                job=job_context.job,
-                                hardware_requirement=job_hardware,
-                                locations=target.locations,
-                                scheduling_policy=self._get_policy(
-                                    target.deployment.scheduling_policy
-                                ),
-                                available_locations=valid_locations,
-                            ):
-                                self._allocate_job(
-                                    job=job_context.job,
-                                    hardware=hardware_requirements,
-                                    connector=connector,
-                                    selected_locations=selected_locations,
-                                    target=target,
-                                )
-                                job_context.scheduled = True
-                                return
-                        else:
-                            if logger.isEnabledFor(logging.DEBUG):
-                                deployment_name = (
-                                    posixpath.join(deployment, target.service)
-                                    if target.service
-                                    else deployment
-                                )
-                                logger.debug(
-                                    f"Not enough available locations: job {job_context.job.name} "
-                                    f"requires {target.locations} locations "
-                                    f"on deployment {deployment_name}, "
-                                    f"but only {len(valid_locations)} are available."
-                                )
-                for conn in stacked_connectors:
-                    if conn.deployment_name != connector.deployment_name:
-                        await self.wait_queues[conn.deployment_name].acquire()
-                finished, unfinished = await asyncio.wait(
-                    [
-                        asyncio.create_task(
-                            self.wait_queues[conn.deployment_name].wait(),
-                            name=conn.deployment_name,
+                    valid_locations = {
+                        k: loc
+                        for k, loc in available_locations.items()
+                        if self._is_valid(
+                            connector=connector,
+                            location=loc,
+                            hardware_requirements=hardware_requirements,
+                            job_name=job.name,
                         )
-                        for conn in stacked_connectors
-                    ],
-                    timeout=self.retry_interval,
-                    return_when=asyncio.FIRST_COMPLETED,
-                )
-                for t in finished:
-                    if t.get_name() != connector.deployment_name:
-                        self.wait_queues[t.get_name()].release()
-                for t in unfinished:
-                    t.cancel()
-                if not finished and logger.isEnabledFor(logging.DEBUG):
-                    target_name = (
-                        "/".join([target.deployment.name, target.service])
-                        if target.service is not None
-                        else target.deployment.name
+                    }
+                    if len(valid_locations) >= target.locations:
+                        if logger.isEnabledFor(logging.DEBUG):
+                            logger.debug(
+                                "Available locations for job {} on {} are {}.".format(
+                                    job_context.job.name,
+                                    (
+                                        posixpath.join(deployment, target.service)
+                                        if target.service
+                                        else deployment
+                                    ),
+                                    list(valid_locations.keys()),
+                                )
+                            )
+                        if selected_locations := await self._get_locations(
+                            job=job_context.job,
+                            hardware_requirement=job_hardware,
+                            locations=target.locations,
+                            scheduling_policy=self._get_policy(
+                                target.deployment.scheduling_policy
+                            ),
+                            available_locations=valid_locations,
+                        ):
+                            self._allocate_job(
+                                job=job_context.job,
+                                hardware=hardware_requirements,
+                                connector=connector,
+                                selected_locations=selected_locations,
+                                target=target,
+                            )
+                            job_context.scheduled = True
+                            return
+                    else:
+                        if logger.isEnabledFor(logging.DEBUG):
+                            deployment_name = (
+                                posixpath.join(deployment, target.service)
+                                if target.service
+                                else deployment
+                            )
+                            logger.debug(
+                                f"Not enough available locations: job {job_context.job.name} "
+                                f"requires {target.locations} locations "
+                                f"on deployment {deployment_name}, "
+                                f"but only {len(valid_locations)} are available."
+                            )
+                try:
+                    await asyncio.wait_for(
+                        self.wait_queue.wait(), timeout=self.retry_interval
                     )
-                    logger.debug(
-                        f"No locations available for job {job_context.job.name} "
-                        f"in target {target_name}. Waiting {self.retry_interval} seconds."
-                    )
+                except (TimeoutError, asyncio.exceptions.TimeoutError):
+                    if logger.isEnabledFor(logging.DEBUG):
+                        target_name = (
+                            "/".join([target.deployment.name, target.service])
+                            if target.service is not None
+                            else target.deployment.name
+                        )
+                        logger.debug(
+                            f"No locations available for job {job_context.job.name} "
+                            f"in target {target_name}. Waiting {self.retry_interval} seconds."
+                        )
 
     async def _resolve_hardware_requirement(
         self,
@@ -508,46 +472,31 @@ class DefaultScheduler(Scheduler):
         )
 
     async def notify_status(self, job_name: str, status: Status) -> None:
-        if (
-            connector := self.get_connector(job_name)
-        ).deployment_name in self.wait_queues:
-            async with self.wait_queues[connector.deployment_name]:
-                if job_allocation := self.job_allocations.get(job_name):
-                    if status != (previous_status := job_allocation.status):
-                        job_allocation.status = status
-                        if logger.isEnabledFor(logging.DEBUG):
-                            logger.debug(
-                                f"Job {job_name} changed status to {status.name}"
-                            )
-                    # Job was running and changed status, or the job was ready to
-                    # run (i.e., fireable) but changed to a status different from the running one.
-                    if status != previous_status and (
-                        previous_status == Status.RUNNING
-                        or (
-                            previous_status == Status.FIREABLE
-                            and status != Status.RUNNING
-                        )
-                    ):
-                        await self._free_resources(connector, job_allocation, status)
-                    if status == Status.ROLLBACK:
-                        for loc in job_allocation.locations:
-                            if (
-                                job_name
-                                in self.location_allocations[loc.deployment][
-                                    loc.name
-                                ].jobs
-                            ):
-                                self.location_allocations[loc.deployment][
-                                    loc.name
-                                ].jobs.remove(job_name)
-                        job_allocation.locations.clear()
-                    self.wait_queues[connector.deployment_name].notify_all()
-            locations = job_allocation.locations
-            conn = connector
-            while locations := [loc.wraps for loc in locations if loc.stacked]:
-                conn = cast(ConnectorWrapper, conn).connector
-                async with (cond := self.wait_queues[conn.deployment_name]):
-                    cond.notify_all()
+        connector = self.get_connector(job_name)
+        async with self.wait_queue:
+            if job_allocation := self.job_allocations.get(job_name):
+                if status != (previous_status := job_allocation.status):
+                    job_allocation.status = status
+                    if logger.isEnabledFor(logging.DEBUG):
+                        logger.debug(f"Job {job_name} changed status to {status.name}")
+                # Job was running and changed status, or the job was ready to
+                # run (i.e., fireable) but changed to a status different from the running one.
+                if status != previous_status and (
+                    previous_status == Status.RUNNING
+                    or (previous_status == Status.FIREABLE and status != Status.RUNNING)
+                ):
+                    await self._free_resources(connector, job_allocation)
+                if status == Status.ROLLBACK:
+                    for loc in job_allocation.locations:
+                        if (
+                            job_name
+                            in self.location_allocations[loc.deployment][loc.name].jobs
+                        ):
+                            self.location_allocations[loc.deployment][
+                                loc.name
+                            ].jobs.remove(job_name)
+                    job_allocation.locations.clear()
+                self.wait_queue.notify_all()
 
     async def schedule(
         self,


### PR DESCRIPTION
This commit streamlines the `DefaultScheduler` by removing the `wait_queues` and `locks` attributes for each deployment and introducing a single `wait_queue`. Previously, the combination of double locks added unnecessary complexity and was difficult to maintain. Furthermore, stacked deployments were not handled properly, leading to deadlocks or exceptions when the `retry_interval` attribute was not defined by the user.
Now, when a job frees resources, the waiting jobs are notified.