### PR TITLE
Migrate linting from `flake8`+`isort` to `ruff`

### DIFF
--- a/.agents/skills/code-style/SKILL.md
+++ b/.agents/skills/code-style/SKILL.md
@@ -18,7 +18,7 @@ Exclude `streamflow/cwl/antlr` from all checks. Use American English in all code
 
 ## Imports: Two Manual Rules
 
-Everything else is handled by isort automatically. Two things isort never does for you:
+Everything else is handled by ruff automatically. Two things ruff never does for you:
 
 **1. Always add `from __future__ import annotations`** as the first import in every file:
 

--- a/.agents/skills/git/SKILL.md
+++ b/.agents/skills/git/SKILL.md
@@ -42,6 +42,8 @@ Commit message conventions for StreamFlow. The approval rule (never commit witho
 - Blank line separating subject from body
 - Explain *what* and *why*, not *how*
 - Wrap at 72 characters
+- Use backticks around package names, rule/error codes, file names,
+  and Python identifiers (functions, classes, variables, methods)
 - Reference issues: `Fixes #123`, `Closes #456`
 
 ## Examples

--- a/.agents/skills/mypy/SKILL.md
+++ b/.agents/skills/mypy/SKILL.md
@@ -27,7 +27,7 @@ version: 0.1.0
    ```
 4. **Quality check** — must pass:
    ```bash
-   uv run make format-check flake8 codespell-check typing
+   uv run make format-check codespell-check typing
    ```
 5. **Commit:** See `.agents/skills/git/SKILL.md`
 

--- a/.agents/skills/mypy/no-untyped-def/SKILL.md
+++ b/.agents/skills/mypy/no-untyped-def/SKILL.md
@@ -22,12 +22,7 @@ For each function: can all parameters and the return type use concrete types?
    ```
 2. **Classify** each function as FIXABLE or UNFIXABLE (see above)
 3. **Add annotations** to FIXABLE functions only
-4. **Validate** — must return no output:
-   ```bash
-   git diff | grep -E "Any\b|MutableMapping\[.*Any|MutableSequence\[.*Any|list\[Any|dict\[.*Any"
-   uv run make format-check flake8 codespell-check typing
-   ```
-5. **Commit:** See `../../git/SKILL.md`
+4. **Validate & commit:** See `../SKILL.md` — General Workflow steps 3–5
 
 ## Key Patterns
 

--- a/.agents/skills/mypy/var-annotated/SKILL.md
+++ b/.agents/skills/mypy/var-annotated/SKILL.md
@@ -14,11 +14,7 @@ version: 0.1.0
 2. **Determine the concrete type** from usage, signatures, or similar patterns nearby
 3. **Check:** does the type need `Any` or other forbidden types? If YES → skip
 4. **Apply:** `variable: ConcreteType = value`
-5. **Validate** — must return no output:
-   ```bash
-   git diff | grep -E "Any\b|dict\[.*Any"
-   uv run make format-check flake8 codespell-check typing
-   ```
+5. **Validate & commit:** See `../SKILL.md` — General Workflow steps 3–5
 
 ## Fix Patterns
 

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-exclude = streamflow/cwl/antlr
-max-line-length = 88
-extend-ignore = E203,E501

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Obtain explicit user permission before installing or updating any packages or de
 ### Git Commits
 
 Never create git commits without explicit user approval. Required sequence:
-1. Run `uv run make format-check flake8 codespell-check typing` — all must pass
+1. Run `uv run make format-check codespell-check typing` — all must pass
 2. Present the full commit message + `git diff --stat` + full `git diff`
 3. Ask explicitly for approval and wait — do not commit until confirmed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ StreamFlow supports Python 3.10 to 3.14, so use compatible code features.
 
 The StreamFlow code style complies with [PEP 8](https://peps.python.org/pep-0008/). You can verify that your PR respects the code style with the following command
 ```bash
-uv run make format-check flake8 codespell-check
+uv run make format-check codespell-check
 ```
 
 You can also apply the suggested changes in bulk with the following command 

--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,12 @@ coverage.xml: testcov
 coverage-report: testcov
 	coverage report
 
-flake8:
-	flake8 --exclude streamflow/cwl/antlr streamflow tests
-
 format:
-	isort streamflow tests
+	ruff check --fix streamflow tests
 	black --target-version py310 streamflow tests
 
 format-check:
-	isort --check-only streamflow tests
+	ruff check streamflow tests
 	black --target-version py310 --diff --check streamflow tests
 
 pyupgrade:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,9 +86,8 @@ docs = [
 lint = [
     "black==26.3.1",
     "codespell==2.4.2",
-    "flake8-bugbear==25.11.29",
-    "isort==8.0.1",
-    "pyupgrade==3.21.2"
+    "pyupgrade==3.21.2",
+    "ruff==0.15.11"
 ]
 test = [
     "cwltest==2.6.20251216093331",
@@ -173,9 +172,14 @@ omit = [
 [tool.black]
 exclude = "streamflow/cwl/antlr"
 
-[tool.isort]
-profile = "black"
-skip = "streamflow/cwl/antlr"
+[tool.ruff]
+exclude = ["streamflow/cwl/antlr"]
+line-length = 88
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "B", "I"]
+ignore = ["E203", "E501", "B904"]
 
 [tool.mypy]
 strict = true

--- a/streamflow/core/processor.py
+++ b/streamflow/core/processor.py
@@ -177,8 +177,7 @@ class MapCommandOutputProcessor(CommandOutputProcessor):
         values = result.value
         if not isinstance(values, MutableSequence):
             raise ProcessorTypeError(
-                f"Invalid value {values} "
-                f"for {self.name} command output: expected list"
+                f"Invalid value {values} for {self.name} command output: expected list"
             )
         return ListToken(
             value=await asyncio.gather(
@@ -421,6 +420,7 @@ class ObjectTokenProcessor(TokenProcessor):
                             for p in self.processors.values()
                         )
                     ),
+                    strict=True,
                 )
             },
         }

--- a/streamflow/core/workflow.py
+++ b/streamflow/core/workflow.py
@@ -66,7 +66,7 @@ class Command(ABC):
         return {}
 
 
-class CommandOptions(ABC):
+class CommandOptions:
     pass
 
 

--- a/streamflow/deployment/filter/matching.py
+++ b/streamflow/deployment/filter/matching.py
@@ -105,7 +105,7 @@ class MatchingBindingFilter(BindingFilter):
     ) -> MutableSequence[Target]:
         if (
             logger.isEnabledFor(logging.WARNING)
-            and not (step_name := get_job_step_name(job.name)) in self._evaluated_steps
+            and (step_name := get_job_step_name(job.name)) not in self._evaluated_steps
         ):
             self._evaluated_steps.add(step_name)
             if (target_deployments := {t.deployment.name for t in targets}) - (

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -149,6 +149,7 @@ async def _get_token_value(
                             for i in range(int(kwargs.get("obj_len", 3)))
                         )
                     ),
+                    strict=True,
                 )
             )
         case _:

--- a/tests/test_remotepath.py
+++ b/tests/test_remotepath.py
@@ -51,7 +51,7 @@ async def test_directory(
         await (path / "dir2").mkdir(mode=0o777)
         await (path / "file1.txt").write_text("StreamFlow")
         await (path / "file2.csv").write_text("StreamFlow")
-        async for dirpath, dirnames, filenames in path.walk(follow_symlinks=True):
+        async for _, dirnames, filenames in path.walk(follow_symlinks=True):
             assert len(dirnames) == 2
             assert "dir1" in dirnames
             assert "dir2" in dirnames

--- a/tests/utils/workflow.py
+++ b/tests/utils/workflow.py
@@ -497,6 +497,7 @@ class BaseLoopConditionalStep(ConditionalStep):
                     for port_id in row["params"]["skip_ports"].values()
                 )
             ),
+            strict=True,
         ):
             step.add_skip_port(k, port)
         return step
@@ -993,7 +994,6 @@ class InjectorFailureTransferStep(TransferStep):
 
 
 class RecoveryTranslator:
-
     # Error types
     SOFT_ERROR = "soft_error"
     FAIL_STOP = "fail_stop"

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ passenv =
 
 [testenv:lint]
 allowlist_externals = make
-commands = make flake8 format-check codespell-check pyupgrade
+commands = make format-check codespell-check pyupgrade
 dependency_groups = lint
 description = Lint the Python code
 

--- a/uv.lock
+++ b/uv.lock
@@ -1022,33 +1022,6 @@ wheels = [
 ]
 
 [[package]]
-name = "flake8"
-version = "7.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mccabe" },
-    { name = "pycodestyle" },
-    { name = "pyflakes" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
-]
-
-[[package]]
-name = "flake8-bugbear"
-version = "25.11.29"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "flake8" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/20/2a996e2fca7810bd1b031901d65fc4292630895afcb946ebd00568bdc669/flake8_bugbear-25.11.29.tar.gz", hash = "sha256:b5d06710f3d26e595541ad303ad4d5cb52578bd4bccbb2c2c0b2c72e243dafc8", size = 84896, upload-time = "2025-11-29T20:51:57.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/42/c18f199780d99a6f6a64c4a36f4ad28a445d9e11968a6025b21d0c8b6802/flake8_bugbear-25.11.29-py3-none-any.whl", hash = "sha256:9bf15e2970e736d2340da4c0a70493db964061c9c38f708cfe1f7b2d87392298", size = 37861, upload-time = "2025-11-29T20:51:56.439Z" },
-]
-
-[[package]]
 name = "frozenlist"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1227,15 +1200,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
-]
-
-[[package]]
-name = "isort"
-version = "8.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
 ]
 
 [[package]]
@@ -1644,15 +1608,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
-]
-
-[[package]]
-name = "mccabe"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
 ]
 
 [[package]]
@@ -2501,15 +2456,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pycodestyle"
-version = "2.14.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "2.23"
 source = { registry = "https://pypi.org/simple" }
@@ -2528,15 +2474,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/35/b17cb89ff865484c6a20ef46bf9d95a5f07328292578de0b295f4a6beec2/pydot-4.0.1.tar.gz", hash = "sha256:c2148f681c4a33e08bf0e26a9e5f8e4099a82e0e2a068098f32ce86577364ad5", size = 162594, upload-time = "2025-06-17T20:09:56.454Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/32/a7125fb28c4261a627f999d5fb4afff25b523800faed2c30979949d6facd/pydot-4.0.1-py3-none-any.whl", hash = "sha256:869c0efadd2708c0be1f916eb669f3d664ca684bc57ffb7ecc08e70d5e93fee6", size = 37087, upload-time = "2025-06-17T20:09:55.25Z" },
-]
-
-[[package]]
-name = "pyflakes"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
 ]
 
 [[package]]
@@ -3033,6 +2970,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/192f3d7103816158dfd5ea50d098ef2aec19194e6cbccd4b3485bdb2eb2d/ruff-0.15.11.tar.gz", hash = "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33", size = 4637264, upload-time = "2026-04-16T18:46:26.58Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/1e/6aca3427f751295ab011828e15e9bf452200ac74484f1db4be0197b8170b/ruff-0.15.11-py3-none-linux_armv6l.whl", hash = "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7", size = 10607943, upload-time = "2026-04-16T18:46:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/26/1341c262e74f36d4e84f3d6f4df0ac68cd53331a66bfc5080daa17c84c0b/ruff-0.15.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e", size = 10988592, upload-time = "2026-04-16T18:46:00.742Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/850b1d6ffa9564fbb6740429bad53df1094082fe515c8c1e74b6d8d05f18/ruff-0.15.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb", size = 10338501, upload-time = "2026-04-16T18:46:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/11/cc1284d3e298c45a817a6aadb6c3e1d70b45c9b36d8d9cce3387b495a03a/ruff-0.15.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4", size = 10670693, upload-time = "2026-04-16T18:46:41.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/9e/f8288b034ab72b371513c13f9a41d9ba3effac54e24bfb467b007daee2ca/ruff-0.15.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb", size = 10416177, upload-time = "2026-04-16T18:46:21.717Z" },
+    { url = "https://files.pythonhosted.org/packages/85/71/504d79abfd3d92532ba6bbe3d1c19fada03e494332a59e37c7c2dabae427/ruff-0.15.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d", size = 11221886, upload-time = "2026-04-16T18:46:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/43/5a/947e6ab7a5ad603d65b474be15a4cbc6d29832db5d762cd142e4e3a74164/ruff-0.15.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7", size = 12075183, upload-time = "2026-04-16T18:46:07.944Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a1/0b7bb6268775fdd3a0818aee8efd8f5b4e231d24dd4d528ced2534023182/ruff-0.15.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e", size = 11516575, upload-time = "2026-04-16T18:46:31.687Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431", size = 11306537, upload-time = "2026-04-16T18:46:36.988Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/92/4cfae6441f3967317946f3b788136eecf093729b94d6561f963ed810c82e/ruff-0.15.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19", size = 11296813, upload-time = "2026-04-16T18:46:24.182Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/972784c5dde8313acde8ac71ba8ac65475b85db4a2352a76c9934361f9bc/ruff-0.15.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890", size = 10633136, upload-time = "2026-04-16T18:46:39.802Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/53/3985a4f185020c2f367f2e08a103032e12564829742a1b417980ce1514a0/ruff-0.15.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5", size = 10424701, upload-time = "2026-04-16T18:46:10.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/57/bf0dfb32241b56c83bb663a826133da4bf17f682ba8c096973065f6e6a68/ruff-0.15.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0", size = 10873887, upload-time = "2026-04-16T18:46:29.157Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/e48076b2a57dc33ee8c7a957296f97c744ca891a8ffb4ffb1aaa3b3f517d/ruff-0.15.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c", size = 11404316, upload-time = "2026-04-16T18:46:19.462Z" },
+    { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
+]
+
+[[package]]
 name = "schema-salad"
 version = "8.9.20251102115403"
 source = { registry = "https://pypi.org/simple" }
@@ -3368,8 +3330,6 @@ dev = [
     { name = "codespell" },
     { name = "cwltest" },
     { name = "cwltool" },
-    { name = "flake8-bugbear" },
-    { name = "isort" },
     { name = "mypy" },
     { name = "pandas-stubs" },
     { name = "pytest" },
@@ -3377,6 +3337,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
     { name = "pyupgrade" },
+    { name = "ruff" },
     { name = "sphinx" },
     { name = "sphinx-jsonschema" },
     { name = "sphinx-llms-txt" },
@@ -3396,9 +3357,8 @@ docs = [
 lint = [
     { name = "black" },
     { name = "codespell" },
-    { name = "flake8-bugbear" },
-    { name = "isort" },
     { name = "pyupgrade" },
+    { name = "ruff" },
 ]
 test = [
     { name = "cwltest" },
@@ -3451,8 +3411,6 @@ dev = [
     { name = "codespell", specifier = "==2.4.2" },
     { name = "cwltest", specifier = "==2.6.20251216093331" },
     { name = "cwltool", specifier = "==3.2.20260413085819" },
-    { name = "flake8-bugbear", specifier = "==25.11.29" },
-    { name = "isort", specifier = "==8.0.1" },
     { name = "mypy", specifier = "==1.20.1" },
     { name = "pandas-stubs", specifier = "==2.3.3.260113" },
     { name = "pytest", specifier = "==9.0.3" },
@@ -3460,6 +3418,7 @@ dev = [
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "pyupgrade", specifier = "==3.21.2" },
+    { name = "ruff", specifier = "==0.15.11" },
     { name = "sphinx", specifier = "==8.1.3" },
     { name = "sphinx-jsonschema", specifier = "==1.19.2" },
     { name = "sphinx-llms-txt", specifier = "==0.7.1" },
@@ -3479,9 +3438,8 @@ docs = [
 lint = [
     { name = "black", specifier = "==26.3.1" },
     { name = "codespell", specifier = "==2.4.2" },
-    { name = "flake8-bugbear", specifier = "==25.11.29" },
-    { name = "isort", specifier = "==8.0.1" },
     { name = "pyupgrade", specifier = "==3.21.2" },
+    { name = "ruff", specifier = "==0.15.11" },
 ]
 test = [
     { name = "cwltest", specifier = "==2.6.20251216093331" },


### PR DESCRIPTION
Replace `flake8`, `flake8-bugbear`, and `isort` with `ruff` (rules `E`, `W`, `F`, `B`, `I`). `black` remains the sole formatter; `ruff format` is not used.

- Delete `.flake8`; add `[tool.ruff]` sections to `pyproject.toml`
- Update `Makefile`: fold `flake8` target into `format`/`format-check`
- Update `tox.ini`, `AGENTS.md`, `CONTRIBUTING.md`, and skill files
- Fix pre-existing violations surfaced by `ruff`: `E713` (auto-fix), `B007` (rename to `_dirpath`), `B024` (remove spurious `ABC` from `CommandOptions`), `B905` (add `strict=True` to `zip()` calls)
- Suppress `B904` globally (pre-existing raise-without-from violations)
- Deduplicate validate/commit steps in mypy sub-skills; point to parent `SKILL.md` as the single source of truth