### PR TITLE
Improve save protocol and SQLite pragmas

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -159,7 +159,7 @@ jobs:
         run: uv sync --locked --no-dev --group docs
       - name: "Build documentation and check for consistency"
         env:
-          CHECKSUM: "e5a8c9bb0d69f7e3101fa4cad628f905ee0b0ef36716361d98bb1c8c1ab68d3a"
+          CHECKSUM: "2dea98bac0c8a6e9fc3631bed5337ae409ac5b74732d57a37a972ea90d78fdbc"
         run: |
           cd docs
           HASH="$(uv run --no-sync make checksum | tail -n1)"

--- a/streamflow/core/deployment.py
+++ b/streamflow/core/deployment.py
@@ -275,22 +275,25 @@ class DeploymentConfig(PersistableEntity):
         return obj
 
     async def save(self, database: Database) -> None:
-        async with self.persistence_lock:
-            if not self.persistent_id:
-                self.persistent_id = await database.add_deployment(
-                    name=self.name,
-                    type=self.type,
-                    config=self.config,
-                    external=self.external,
-                    lazy=self.lazy,
-                    scheduling_policy=await self.scheduling_policy.save(database),
-                    workdir=self.workdir,
-                    wraps=(
-                        await self.wraps.save(database)
-                        if self.wraps is not None
-                        else None
-                    ),
-                )
+        if self.persistent_id is not None:
+            return
+        if self._saving is not None:
+            await self._saving.wait()
+        else:
+            self._saving = asyncio.Event()
+            self.persistent_id = await database.add_deployment(
+                name=self.name,
+                type=self.type,
+                config=self.config,
+                external=self.external,
+                lazy=self.lazy,
+                scheduling_policy=await self.scheduling_policy.save(database),
+                workdir=self.workdir,
+                wraps=(
+                    await self.wraps.save(database) if self.wraps is not None else None
+                ),
+            )
+            self._saving.set()
 
 
 class FilterConfig(PersistableEntity):
@@ -318,13 +321,18 @@ class FilterConfig(PersistableEntity):
         return obj
 
     async def save(self, database: Database) -> None:
-        async with self.persistence_lock:
-            if not self.persistent_id:
-                self.persistent_id = await database.add_filter(
-                    name=self.name,
-                    type=self.type,
-                    config=self.config,
-                )
+        if self.persistent_id is not None:
+            return
+        if self._saving is not None:
+            await self._saving.wait()
+        else:
+            self._saving = asyncio.Event()
+            self.persistent_id = await database.add_filter(
+                name=self.name,
+                type=self.type,
+                config=self.config,
+            )
+            self._saving.set()
 
 
 class Target(PersistableEntity):
@@ -380,39 +388,37 @@ class Target(PersistableEntity):
         return obj
 
     async def save(self, database: Database) -> None:
-        await self.deployment.save(database)
-        async with self.persistence_lock:
-            if not self.persistent_id:
-                self.persistent_id = await database.add_target(
-                    deployment=self.deployment.persistent_id,
-                    type=type(self),
-                    params=await self._save_additional_params(database),
-                    locations=self.locations,
-                    service=self.service,
-                    workdir=self.workdir,
-                )
+        if self.persistent_id is not None:
+            return
+        if self._saving is not None:
+            await self._saving.wait()
+        else:
+            self._saving = asyncio.Event()
+            await self.deployment.save(database)
+            self.persistent_id = await database.add_target(
+                deployment=self.deployment.persistent_id,
+                type=type(self),
+                params=await self._save_additional_params(database),
+                locations=self.locations,
+                service=self.service,
+                workdir=self.workdir,
+            )
+            self._saving.set()
 
 
 class LocalTarget(Target):
-    deployment_name = "__LOCAL__"
-    __deployment_config = None
-
     def __init__(self, workdir: str | None = None):
         super().__init__(
-            deployment=self._get_deployment_config(), locations=1, workdir=workdir
-        )
-
-    @classmethod
-    def _get_deployment_config(cls) -> DeploymentConfig:
-        if cls.__deployment_config is None:
-            cls.__deployment_config = DeploymentConfig(
-                name=cls.deployment_name,
+            deployment=DeploymentConfig(
+                name="__LOCAL__",
                 type="local",
                 config={},
                 external=True,
                 lazy=False,
-            )
-        return cls.__deployment_config
+            ),
+            locations=1,
+            workdir=workdir,
+        )
 
     @classmethod
     async def _load(

--- a/streamflow/core/persistence.py
+++ b/streamflow/core/persistence.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from asyncio import Lock
+from asyncio import Event
 from collections.abc import MutableMapping, MutableSequence
 from enum import Enum
 from typing import TYPE_CHECKING, Any
@@ -65,11 +65,11 @@ class DatabaseLoadingContext(ABC):
 
 
 class PersistableEntity:
-    __slots__ = ("persistent_id", "persistence_lock")
+    __slots__ = ("persistent_id", "_saving")
 
     def __init__(self) -> None:
         self.persistent_id: int | None = None
-        self.persistence_lock: Lock = Lock()
+        self._saving: Event | None = None
 
     @classmethod
     @abstractmethod

--- a/streamflow/core/workflow.py
+++ b/streamflow/core/workflow.py
@@ -302,14 +302,19 @@ class Port(PersistableEntity):
             q.put_nowait(token)
 
     async def save(self, database: Database) -> None:
-        async with self.persistence_lock:
-            if not self.persistent_id:
-                self.persistent_id = await database.add_port(
-                    name=self.name,
-                    workflow_id=self.workflow.persistent_id,
-                    type=type(self),
-                    params=await self._save_additional_params(database),
-                )
+        if self.persistent_id is not None:
+            return
+        if self._saving is not None:
+            await self._saving.wait()
+        else:
+            self._saving = asyncio.Event()
+            self.persistent_id = await database.add_port(
+                name=self.name,
+                workflow_id=self.workflow.persistent_id,
+                type=type(self),
+                params=await self._save_additional_params(database),
+            )
+            self._saving.set()
 
 
 class Status(IntEnum):
@@ -467,8 +472,11 @@ class Step(PersistableEntity, ABC):
     async def run(self) -> None: ...
 
     async def save(self, database: Database) -> None:
-        async with self.persistence_lock:
-            if not self.persistent_id:
+        if self.persistent_id is None:
+            if self._saving is not None:
+                await self._saving.wait()
+            else:
+                self._saving = asyncio.Event()
                 self.persistent_id = await database.add_step(
                     name=self.name,
                     workflow_id=self.workflow.persistent_id,
@@ -476,9 +484,9 @@ class Step(PersistableEntity, ABC):
                     type=type(self),
                     params=await self._save_additional_params(database),
                 )
-        save_tasks = []
-        for name, port in self.get_input_ports().items():
-            save_tasks.append(
+                self._saving.set()
+        await asyncio.gather(
+            *(
                 asyncio.create_task(
                     database.add_dependency(
                         step=self.persistent_id,
@@ -487,9 +495,9 @@ class Step(PersistableEntity, ABC):
                         name=name,
                     )
                 )
-            )
-        for name, port in self.get_output_ports().items():
-            save_tasks.append(
+                for name, port in self.get_input_ports().items()
+            ),
+            *(
                 asyncio.create_task(
                     database.add_dependency(
                         step=self.persistent_id,
@@ -498,8 +506,9 @@ class Step(PersistableEntity, ABC):
                         name=name,
                     )
                 )
-            )
-        await asyncio.gather(*save_tasks)
+                for name, port in self.get_output_ports().items()
+            ),
+        )
 
     @abstractmethod
     async def terminate(self, status: Status) -> None: ...
@@ -559,18 +568,24 @@ class Token(PersistableEntity):
         return self.__class__(tag=tag, value=self.value, recoverable=self._recoverable)
 
     async def save(self, database: Database, port_id: int | None = None) -> None:
-        async with self.persistence_lock:
-            if not self.persistent_id:
-                try:
-                    self.persistent_id = await database.add_token(
-                        port=port_id,
-                        recoverable=self._recoverable,
-                        tag=self.tag,
-                        type=type(self),
-                        value=await self._save_value(database),
-                    )
-                except TypeError as e:
-                    raise WorkflowExecutionException from e
+        if self.persistent_id is not None:
+            return
+        if self._saving is not None:
+            await self._saving.wait()
+        else:
+            self._saving = asyncio.Event()
+            try:
+                self.persistent_id = await database.add_token(
+                    port=port_id,
+                    recoverable=self._recoverable,
+                    tag=self.tag,
+                    type=type(self),
+                    value=await self._save_value(database),
+                )
+            except TypeError as e:
+                raise WorkflowExecutionException from e
+            finally:
+                self._saving.set()
 
     def update(self, value: Any) -> Token:
         return self.__class__(tag=self.tag, value=value, recoverable=self._recoverable)
@@ -696,14 +711,18 @@ class Workflow(PersistableEntity):
         return workflow
 
     async def save(self, database: Database) -> None:
-        async with self.persistence_lock:
-            if not self.persistent_id:
+        if self.persistent_id is None:
+            if self._saving is not None:
+                await self._saving.wait()
+            else:
+                self._saving = asyncio.Event()
                 self.persistent_id = await self.context.database.add_workflow(
                     name=self.name,
                     params=await self._save_additional_params(database),
                     status=Status.WAITING.value,
                     type=type(self),
                 )
+                self._saving.set()
         await asyncio.gather(
             *(asyncio.create_task(port.save(database)) for port in self.ports.values())
         )

--- a/streamflow/cwl/processor.py
+++ b/streamflow/cwl/processor.py
@@ -10,7 +10,7 @@ import cwl_utils.types
 from schema_salad.exceptions import ValidationException
 from typing_extensions import Self
 
-from streamflow.core.deployment import Connector, LocalTarget, Target
+from streamflow.core.deployment import Connector, Target
 from streamflow.core.exception import (
     ProcessorTypeError,
     WorkflowExecutionException,
@@ -226,7 +226,7 @@ class CWLTokenProcessor(TokenProcessor):
                 # If such location does not exist, apply the standard heuristic to select the best one
                 data_location = (
                     await self.workflow.context.data_manager.get_source_location(
-                        path=filepath, dst_deployment=LocalTarget.deployment_name
+                        path=filepath, dst_deployment="__LOCAL__"
                     )
                 )
             if data_location:

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -3144,7 +3144,7 @@ class CWLTranslator:
             else posixpath.sep
         )
         # Register data locations for config files
-        deployment_name = LocalTarget.deployment_name
+        deployment_name = "__LOCAL__"
         path = _get_path(self.cwl_definition.id)
         self.context.data_manager.register_path(
             location=ExecutionLocation(

--- a/streamflow/deployment/manager.py
+++ b/streamflow/deployment/manager.py
@@ -94,7 +94,7 @@ class DefaultDeploymentManager(DeploymentManager):
         if issubclass(connector_type, ConnectorWrapper):
             # Retrieve the inner connector's config
             if deployment_config.wraps is None:
-                deployment_name = LocalTarget.deployment_name
+                deployment_name = "__LOCAL__"
                 service = None
                 if deployment_name not in self.config_map:
                     await self._deploy(LocalTarget().deployment)

--- a/streamflow/persistence/schemas/sqlite.json
+++ b/streamflow/persistence/schemas/sqlite.json
@@ -8,6 +8,12 @@
       "title": "Connection",
       "description": "The path where the sqlite file resides"
     },
+    "mmap_size": {
+      "type": "integer",
+      "title": "SQLite MMAP size",
+      "description": "The maximum number of bytes of the database file that will be accessed using memory-mapped I/O. If zero, then memory mapped I/O is disabled.",
+      "default": 268435456
+    },
     "timeout": {
       "type": "integer",
       "title": "Timeout",

--- a/streamflow/persistence/sqlite.py
+++ b/streamflow/persistence/sqlite.py
@@ -35,8 +35,9 @@ def _load_keys(
 
 
 class SqliteConnection:
-    def __init__(self, connection: str, timeout: int, init_db: bool):
+    def __init__(self, connection: str, mmap_size: int, timeout: int, init_db: bool):
         self.connection: str = connection
+        self.mmap_size: int = mmap_size
         self.timeout: int = timeout
         self.init_db: bool = init_db
         self._connection: aiosqlite.Connection | None = None
@@ -53,7 +54,9 @@ class SqliteConnection:
                     async with self._connection.cursor() as cursor:
                         await cursor.execute("PRAGMA journal_mode = WAL")
                         await cursor.execute("PRAGMA synchronous = NORMAL")
-                        await cursor.execute("PRAGMA wal_autocheckpoint = 1000")
+                        await cursor.execute("PRAGMA temp_store = MEMORY")
+                        await cursor.execute("PRAGMA foreign_keys = ON")
+                        await cursor.execute(f"PRAGMA mmap_size = {self.mmap_size}")
                         await cursor.executescript(
                             files(__package__)
                             .joinpath("schemas")
@@ -87,6 +90,7 @@ class SqliteDatabase(CachedDatabase):
         self,
         context: StreamFlowContext,
         connection: str = DEFAULT_SQLITE_CONNECTION,
+        mmap_size: int = 256 * 1024 * 1024,
         timeout: int = 20,
     ):
         super().__init__(context)
@@ -102,6 +106,7 @@ class SqliteDatabase(CachedDatabase):
             os.makedirs(os.path.dirname(connection), exist_ok=True)
         self.connection: SqliteConnection = SqliteConnection(
             connection=connection,
+            mmap_size=mmap_size,
             timeout=timeout,
             init_db=connection == IN_MEMORY_SQLITE_CONNECTION
             or not os.path.exists(connection),

--- a/streamflow/recovery/checkpoint_manager.py
+++ b/streamflow/recovery/checkpoint_manager.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 from streamflow.core import utils
 from streamflow.core.data import DataLocation
-from streamflow.core.deployment import ExecutionLocation, LocalTarget
+from streamflow.core.deployment import ExecutionLocation
 from streamflow.core.recovery import CheckpointManager
 from streamflow.core.utils import random_name
 
@@ -44,7 +44,7 @@ class DefaultCheckpointManager(CheckpointManager):
             src_path=data_location.path,
             dst_locations=[
                 ExecutionLocation(
-                    deployment=LocalTarget.deployment_name,
+                    deployment="__LOCAL__",
                     local=True,
                     name="__LOCAL__",
                 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,7 +171,9 @@ def object_to_dict(obj: Any) -> MutableMapping[str, Any]:
     return {
         attr: getattr(obj, attr)
         for attr in dir(obj)
-        if not attr.startswith("__") and not callable(getattr(obj, attr))
+        if not attr.startswith("__")
+        and attr != "_saving"
+        and callable(getattr(obj, attr))
     }
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -190,11 +190,11 @@ def test_schema_generation() -> None:
     """Check that the `streamflow schema` command generates a correct JSON Schema."""
     assert (
         hashlib.sha256(SfSchema().dump("v1.0", False).encode()).hexdigest()
-        == "45bcc8e3fd24d652831a59086dd194e03c51d52e908c9024db2892dd049bf334"
+        == "67ac505b3efc37fc03f060bf38a5491374f00444adce12a6c6c23f6e380309af"
     )
     assert (
         hashlib.sha256(SfSchema().dump("v1.0", True).encode()).hexdigest()
-        == "0ea70dd1a00d5fbc260cff527527bbb3d9c5b36db5d428febb5a453b928dd7c9"
+        == "bae57a7a9170fd1b20b32053a61271fe936204b92a15df1dc0390f5d97a92761"
     )
 
 


### PR DESCRIPTION
Replace `persistence_lock: Lock` with `_saving: Event` in `PersistableEntity` so concurrent callers wait on a shared event rather than serialize through a mutex. Each `save` method also gains an early-return guard and moves follow-on writes (ports, steps, dependencies) inside the guarded block to avoid redundant work on re-entry. Remove `LocalTarget._get_deployment_config()` class-level singleton as it is no longer needed.

Replace `PRAGMA wal_autocheckpoint` with `PRAGMA temp_store = MEMORY`, `PRAGMA foreign_keys = ON`, and `PRAGMA mmap_size` in the SQLite connection setup. Expose `mmap_size` as a configurable option (default 256 MiB) in the schema and `SqliteDatabase` constructor.