### PR TITLE
Fix root folder always added to hardware storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix root folder always added to hardware storage ([#1040](https://github.com/alpha-unito/streamflow/pull/1040))
 - Correctly skip nested subworkflows ([#1019](https://github.com/alpha-unito/streamflow/pull/1019))
 - Fix container `mount` parsing ([#1032](https://github.com/alpha-unito/streamflow/pull/1032))
 - Fix lock releasing logic in scheduler ([#1031](https://github.com/alpha-unito/streamflow/pull/1031))
@@ -33,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump cachebox from 5.2.2 to 5.2.3 ([#1027](https://github.com/alpha-unito/streamflow/pull/1027))
 - Bump cryptography from 46.0.6 to 46.0.7 ([#1025](https://github.com/alpha-unito/streamflow/pull/1025))
 - Bump cwl-utils from 0.40 to 0.41 ([#1012](https://github.com/alpha-unito/streamflow/pull/1012))
+- Bump lxml from 6.0.2 to 6.1.0 ([#1038](https://github.com/alpha-unito/streamflow/pull/1038))
 - Bump plotly from 6.6.0 to 6.7.0 ([#1026](https://github.com/alpha-unito/streamflow/pull/1026))
 
 ### Dev Dependencies

--- a/streamflow/deployment/connector/local.py
+++ b/streamflow/deployment/connector/local.py
@@ -56,8 +56,10 @@ class LocalConnector(BaseConnector):
         super().__init__(deployment_name, config_dir, transferBufferSize)
         storage = {}
         for disk in psutil.disk_partitions(all=True):
-            if disk.fstype not in FS_TYPES_TO_SKIP and os.access(
-                disk.mountpoint, os.R_OK
+            if (
+                disk.fstype not in FS_TYPES_TO_SKIP
+                and os.access(disk.mountpoint, os.R_OK)
+                or disk.mountpoint == os.path.abspath(os.sep)
             ):
                 try:
                     storage[disk.mountpoint] = Storage(

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import logging
 import os
+import posixpath
 from abc import ABC
 from collections.abc import MutableMapping, MutableSequence
 from importlib.resources import files
@@ -529,7 +530,10 @@ class SSHConnector(BaseConnector):
                     for line in dir_info_list:
                         try:
                             mount_point, fs_type, size = line.split(" ")
-                            if fs_type not in FS_TYPES_TO_SKIP:
+                            if (
+                                mount_point == posixpath.sep
+                                or fs_type not in FS_TYPES_TO_SKIP
+                            ):
                                 self.hardware[location].storage[mount_point] = Storage(
                                     mount_point=mount_point,
                                     size=float(size) / 2**10,


### PR DESCRIPTION
Ensure the root folder (`/`) is always included in hardware storage across all unwrappable connectors (`LocalConnector`, `SSHConnector`), independently of the filesystem type. This prevents errors when `get_mount_point` returns the root folder as a fallback for files on unrecognised filesystem types.