### PR TITLE
Fix operators in `Hardware` and `Storage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix operators in `Hardware` and `Storage` ([#1044](https://github.com/alpha-unito/streamflow/pull/1044))
 - Fix Docker Compose NDJSON location parsing ([#1043](https://github.com/alpha-unito/streamflow/pull/1043))
 
 ### Removed

--- a/streamflow/core/scheduling.py
+++ b/streamflow/core/scheduling.py
@@ -109,7 +109,7 @@ class Hardware:
             ),
         )
 
-    def __ior__(self, other: Hardware) -> None:
+    def __ior__(self, other: Hardware) -> Self:
         if not isinstance(other, Hardware):
             raise NotImplementedError
         self.cores += other.cores
@@ -119,6 +119,7 @@ class Hardware:
                 self.storage[key] = disk
             else:
                 self.storage[key] |= disk
+        return self
 
     def __or__(self, other: Hardware) -> Hardware:
         if not isinstance(other, Hardware):
@@ -403,7 +404,7 @@ class Storage:
         if not isinstance(other, Storage):
             raise NotImplementedError
         if self.mount_point != other.mount_point:
-            raise WorkflowExecutionException(
+            raise ArithmeticError(
                 f"Cannot sum two storages with different mount points: {self.mount_point} and {other.mount_point}"
             )
         return Storage(
@@ -413,21 +414,22 @@ class Storage:
             bind=self.bind,
         )
 
-    def __ior__(self, other: Storage) -> None:
+    def __ior__(self, other: Storage) -> Self:
         if not isinstance(other, Storage):
             raise NotImplementedError
         if self.mount_point != other.mount_point:
-            raise WorkflowExecutionException(
+            raise ArithmeticError(
                 f"Cannot merge two storages with different mount points: {self.mount_point} and {other.mount_point}"
             )
         self.size = max(self.size, other.size)
         self.paths |= other.paths
+        return self
 
     def __or__(self, other: Storage) -> Storage:
         if not isinstance(other, Storage):
             raise NotImplementedError
         if self.mount_point != other.mount_point:
-            raise WorkflowExecutionException(
+            raise ArithmeticError(
                 f"Cannot merge two storages with different mount points: {self.mount_point} and {other.mount_point}"
             )
         return Storage(
@@ -441,7 +443,7 @@ class Storage:
         if not isinstance(other, Storage):
             raise NotImplementedError
         if self.mount_point != other.mount_point:
-            raise WorkflowExecutionException(
+            raise ArithmeticError(
                 f"Cannot subtract two storages with different mount points: {self.mount_point} and {other.mount_point}"
             )
         return Storage(


### PR DESCRIPTION
Both `Hardware.__ior__` and `Storage.__ior__` were returning `None` instead of `Self`, causing `|=` augmented assignment to silently assign `None` to the left-hand operand. Adds `return self` and corrects the return type annotation to `Self`.

Also changes the exception raised in `Storage` operators when merging storages with different mount points from `WorkflowExecutionException` to `ArithmeticError`.