### PR TITLE
Fix shell reuse collision across execution locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix shell reuse collision across execution locations ([#1045](https://github.com/alpha-unito/streamflow/pull/1045))
 - Fix operators in `Hardware` and `Storage` ([#1044](https://github.com/alpha-unito/streamflow/pull/1044))
 - Fix Docker Compose NDJSON location parsing ([#1043](https://github.com/alpha-unito/streamflow/pull/1043))
 

--- a/streamflow/data/manager.py
+++ b/streamflow/data/manager.py
@@ -334,18 +334,15 @@ class DefaultDataManager(DataManager):
                         dst_path, context=self.context, location=location
                     ).parent.mkdir(mode=0o777, parents=True, exist_ok=True)
                 )
-                for location in (
-                    loc
-                    for loc in dst_locations
-                    if len(
-                        self.get_data_locations(
-                            path=os.path.dirname(dst_path),
-                            deployment=loc.deployment,
-                            location_name=loc.name,
-                        )
+                for location in dst_locations
+                if len(
+                    self.get_data_locations(
+                        path=os.path.dirname(dst_path),
+                        deployment=location.deployment,
+                        location_name=location.name,
                     )
-                    == 0
                 )
+                == 0
             )
         )
         # Follow symlink for source path

--- a/streamflow/deployment/connector/base.py
+++ b/streamflow/deployment/connector/base.py
@@ -367,7 +367,7 @@ class BaseConnector(Connector, FutureAware, ABC):
             config_dir=config_dir,
             transferBufferSize=transferBufferSize,
         )
-        self._shells: MutableMapping[str, Shell] = {}
+        self._shells: MutableMapping[str, MutableMapping[str, Shell]] = {}
         self._shells_lock: asyncio.Lock = asyncio.Lock()
 
     async def _create_shell(
@@ -453,18 +453,23 @@ class BaseConnector(Connector, FutureAware, ABC):
         self, command: MutableSequence[str], location: ExecutionLocation
     ) -> Shell:
         async with self._shells_lock:
-            if (key := str(hash("".join(command)))) in self._shells:
-                shell = self._shells[key]
+            if (key := str(hash("".join(command)))) in self._shells.setdefault(
+                location.name, {}
+            ):
+                shell = self._shells[location.name][key]
                 if not await shell.closed():
                     return shell
                 else:
-                    del self._shells[key]
+                    del self._shells[location.name][key]
             try:
-                self._shells[key] = await self._create_shell(command, location)
-                return self._shells[key]
+                self._shells[location.name][key] = await self._create_shell(
+                    command, location
+                )
+                return self._shells[location.name][key]
             except Exception as e:
                 raise WorkflowExecutionException(
-                    f"Failed to create shell with command `{' '.join(command)}`: {e}"
+                    f"Failed to create shell on location {location.name} "
+                    f"with command `{' '.join(command)}`: {e}"
                 ) from e
 
     async def get_stream_reader(
@@ -546,7 +551,11 @@ class BaseConnector(Connector, FutureAware, ABC):
     async def undeploy(self, external: bool) -> None:
         async with self._shells_lock:
             await asyncio.gather(
-                *(asyncio.create_task(shell.close()) for shell in self._shells.values())
+                *(
+                    asyncio.create_task(shell.close())
+                    for loc in self._shells.values()
+                    for shell in loc.values()
+                )
             )
             self._shells.clear()
 


### PR DESCRIPTION
Change `_shells` from a flat `MutableMapping[str, Shell]` to a nested `MutableMapping[str, MutableMapping[str, Shell]]`, keyed first by `location.name`. Previously, tasks running on different locations but sharing the same command hash could incorrectly reuse or overwrite each other's shell connections.