### PR TITLE
Update Helm connector to v4 API

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -129,7 +129,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           build-args: |
-            HELM_VERSION=v3.19.0
+            HELM_VERSION=v4.1.1
           load: true
           tags: alphaunito/streamflow:latest
       - name: "Run test with Docker"
@@ -159,7 +159,7 @@ jobs:
         run: uv sync --locked --no-dev --group docs
       - name: "Build documentation and check for consistency"
         env:
-          CHECKSUM: "317f244de13d76d1787d68cd8ca26519dfb2b73660139d9c4854e3f428c92d8f"
+          CHECKSUM: "ed740b88ca9f41250ba30d95e2525ca3739c30a8b116ad1f65f4b296414faa67"
         run: |
           cd docs
           HASH="$(uv run --no-sync make checksum | tail -n1)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           build-args: |
-            HELM_VERSION=v3.19.0
+            HELM_VERSION=v4.1.1
           push: true
           tags: |
             alphaunito/streamflow:${{ env.STREAMFLOW_VERSION }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- Update HelmConnector to v4 API ([#1046](https://github.com/alpha-unito/streamflow/pull/1046))
+
 ### Added
 
 - Add fault tolerance paper reference in the documentation ([#1049](https://github.com/alpha-unito/streamflow/pull/1049))

--- a/docs/source/connector/helm3.rst
+++ b/docs/source/connector/helm3.rst
@@ -2,7 +2,11 @@
 Helm3Connector
 ==============
 
-The `Helm v3 <https://helm.sh/>`_ connector can spawn complex, multi-container environments on a `Kubernetes <https://kubernetes.io/>`_ cluster. The deployment unit is the entire Helm release, while the binding unit is the single container in a ``Pod``. StreamFlow requires each container in a Helm release to have a unique ``name`` attribute, allowing an unambiguous identification. Finally, the scheduling unit is the single instance of a potentially replicated container in a ``ReplicaSet``.
+The `Helm v3 <https://helm.sh/docs/v3/>`_ connector can spawn complex, multi-container environments on a `Kubernetes <https://kubernetes.io/>`_ cluster. The deployment unit is the entire Helm release, while the binding unit is the single container in a ``Pod``. StreamFlow requires each container in a Helm release to have a unique ``name`` attribute, allowing an unambiguous identification. Finally, the scheduling unit is the single instance of a potentially replicated container in a ``ReplicaSet``.
+
+.. warning::
+
+   The ``Helm3Connector`` is deprecated and will be removed in StreamFlow ``v0.3``. Please migrate to ``Helm4Connector`` as soon as possible.
 
 .. jsonschema:: https://streamflow.di.unito.it/schemas/deployment/connector/helm3.json
     :lift_description: true

--- a/docs/source/connector/helm4.rst
+++ b/docs/source/connector/helm4.rst
@@ -1,0 +1,8 @@
+==============
+Helm4Connector
+==============
+
+The `Helm v4 <https://helm.sh/docs/>`_ connector can spawn complex, multi-container environments on a `Kubernetes <https://kubernetes.io/>`_ cluster. The deployment unit is the entire Helm release, while the binding unit is the single container in a ``Pod``. StreamFlow requires each container in a Helm release to have a unique ``name`` attribute, allowing an unambiguous identification. Finally, the scheduling unit is the single instance of a potentially replicated container in a ``ReplicaSet``.
+
+.. jsonschema:: https://streamflow.di.unito.it/schemas/deployment/connector/helm4.json
+    :lift_description: true

--- a/docs/source/ext/connector.rst
+++ b/docs/source/ext/connector.rst
@@ -168,8 +168,9 @@ Name                                                        Class
 :ref:`docker <DockerConnector>`                             streamflow.deployment.connector.docker.DockerConnector
 :ref:`docker-compose <DockerComposeConnector>`              streamflow.deployment.connector.docker.DockerComposeConnector
 :ref:`flux <FluxConnector>`                                 streamflow.deployment.connector.queue_manager.FluxConnector
-:ref:`helm <Helm3Connector>`                                streamflow.deployment.connector.kubernetes.Helm3Connector
+:ref:`helm <Helm4Connector>`                                streamflow.deployment.connector.kubernetes.Helm4Connector
 :ref:`helm3 <Helm3Connector>`                               streamflow.deployment.connector.kubernetes.Helm3Connector
+:ref:`helm4 <Helm4Connector>`                               streamflow.deployment.connector.kubernetes.Helm4Connector
 :ref:`kubernetes <KubernetesConnector>`                     streamflow.deployment.connector.kubernetes.KubernetesConnector
 :ref:`pbs <PBSConnector>`                                   streamflow.deployment.connector.queue_manager.PBSConnector
 :ref:`singularity <SingularityConnector>`                   streamflow.deployment.connector.singularity.SingularityConnector

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -85,6 +85,7 @@ For LaTeX users, the following BibTeX entry can be used:
    connector/docker-compose.rst
    connector/flux.rst
    connector/helm3.rst
+   connector/helm4.rst
    connector/kubernetes.rst
    connector/pbs.rst
    connector/queue-manager.rst

--- a/streamflow/config/__init__.py
+++ b/streamflow/config/__init__.py
@@ -16,6 +16,10 @@ ext_schemas: MutableSequence[Traversable] = [
     files("streamflow.deployment.connector")
     .joinpath("schemas")
     .joinpath("base")
+    .joinpath("helm.json"),
+    files("streamflow.deployment.connector")
+    .joinpath("schemas")
+    .joinpath("base")
     .joinpath("kubernetes.json"),
     files("streamflow.deployment.connector")
     .joinpath("schemas")

--- a/streamflow/deployment/connector/__init__.py
+++ b/streamflow/deployment/connector/__init__.py
@@ -10,6 +10,7 @@ from streamflow.deployment.connector.container import (
 )
 from streamflow.deployment.connector.kubernetes import (
     Helm3Connector,
+    Helm4Connector,
     KubernetesConnector,
 )
 from streamflow.deployment.connector.local import LocalConnector
@@ -24,8 +25,9 @@ connector_classes: MutableMapping[str, type[Connector]] = {
     "docker": DockerConnector,
     "docker-compose": DockerComposeConnector,
     "flux": FluxConnector,
-    "helm": Helm3Connector,
+    "helm": Helm4Connector,
     "helm3": Helm3Connector,
+    "helm4": Helm4Connector,
     "kubernetes": KubernetesConnector,
     "local": LocalConnector,
     "pbs": PBSConnector,

--- a/streamflow/deployment/connector/kubernetes.py
+++ b/streamflow/deployment/connector/kubernetes.py
@@ -913,32 +913,44 @@ class KubernetesConnector(KubernetesBaseConnector):
         await super().undeploy(external)
 
 
-class Helm3Connector(KubernetesBaseConnector):
+class HelmConnector(KubernetesBaseConnector, ABC):
     def __init__(
         self,
         deployment_name: str,
         config_dir: str,
         chart: str,
+        burstLimit: int = 100,
         debug: bool = False,
         kubeContext: str | None = None,
         kubeconfig: str | None = None,
-        atomic: bool = False,
         caFile: str | None = None,
+        cascade: str | None = None,
         certFile: str | None = None,
-        depUp: bool = False,
+        dependencyUpdate: bool = False,
         devel: bool = False,
         inCluster: bool = False,
         keepHistory: bool = False,
         keyFile: str | None = None,
         keyring: str | None = None,
+        kubeApiserver: str | None = None,
+        kubeAsGroup: MutableSequence[str] | None = None,
+        kubeAsUser: str | None = None,
+        kubeCaFile: str | None = None,
+        kubeInsecureSkipTLSVerify: bool = False,
+        kubeTLSServerName: str | None = None,
+        kubeToken: str | None = None,
         locationsCacheSize: int | None = None,
         locationsCacheTTL: int | None = None,
         maxConcurrentConnections: int = 4096,
         nameTemplate: str | None = None,
         namespace: str | None = None,
         noHooks: bool = False,
+        output: str | None = None,
+        passCredentials: bool = False,
         password: str | None = None,
+        queriesPerSecond: float | None = None,
         renderSubchartNotes: bool = False,
+        replace: bool = False,
         repo: str | None = None,
         commandLineValues: MutableSequence[str] | None = None,
         fileValues: MutableSequence[str] | None = None,
@@ -949,14 +961,29 @@ class Helm3Connector(KubernetesBaseConnector):
         repositoryConfig: str | None = None,
         resourcesCacheSize: int | None = None,
         resourcesCacheTTL: int | None = None,
+        rollbackOnFailure: bool = False,
         skipCrds: bool = False,
+        skipSchemaValidation: bool = False,
+        takeOwnership: bool = False,
         timeout: str | None = "1000m",
         transferBufferSize: int = (32 << 20) - 1,
         username: str | None = None,
         yamlValues: MutableSequence[str] | None = None,
         verify: bool = False,
         chartVersion: str | None = None,
-        wait: bool = True,
+        createNamespace: bool = False,
+        description: str | None = None,
+        disableOpenapiValidation: bool = False,
+        enableDns: bool = False,
+        generateFlag: bool = False,
+        hideNotes: bool = False,
+        insecureSkipTLSVerify: bool = False,
+        labels: str | None = None,
+        plainHttp: bool = False,
+        postRendererArgs: MutableSequence[str] | None = None,
+        setJson: MutableSequence[str] | None = None,
+        setLiteral: MutableSequence[str] | None = None,
+        waitForJobs: bool = False,
     ):
         super().__init__(
             deployment_name=deployment_name,
@@ -976,23 +1003,37 @@ class Helm3Connector(KubernetesBaseConnector):
             chart if os.path.isabs(chart) else os.path.join(self.config_dir, chart)
         )
         self.debug: bool = debug
-        self.atomic: bool = atomic
+        self.burstLimit: int = burstLimit
         self.caFile: str | None = caFile
+        self.cascade: str | None = cascade
         self.certFile: str | None = certFile
-        self.depUp: bool = depUp
+        self.dependencyUpdate: bool = dependencyUpdate
         self.devel: bool = devel
         self.keepHistory: bool = keepHistory
         self.keyFile: str | None = keyFile
         self.keyring: str | None = keyring
+        self.kubeApiserver: str | None = kubeApiserver
+        self.kubeAsGroup: MutableSequence[str] | None = kubeAsGroup
+        self.kubeAsUser: str | None = kubeAsUser
+        self.kubeCaFile: str | None = kubeCaFile
+        self.kubeInsecureSkipTLSVerify: bool = kubeInsecureSkipTLSVerify
+        self.kubeTLSServerName: str | None = kubeTLSServerName
+        self.kubeToken: str | None = kubeToken
         self.nameTemplate: str | None = nameTemplate
         self.noHooks: bool = noHooks
+        self.output: str | None = output
+        self.passCredentials: bool = passCredentials
         self.password: str | None = password
+        self.queriesPerSecond: float | None = queriesPerSecond
         self.renderSubchartNotes: bool = renderSubchartNotes
+        self.replace: bool = replace
         self.repo: str | None = repo
         self.commandLineValues: MutableSequence[str] | None = commandLineValues
         self.fileValues: MutableSequence[str] | None = fileValues
         self.stringValues: MutableSequence[str] | None = stringValues
         self.skipCrds: bool = skipCrds
+        self.skipSchemaValidation: bool = skipSchemaValidation
+        self.takeOwnership: bool = takeOwnership
         self.registryConfig = (
             str(Path(registryConfig).expanduser())
             if registryConfig is not None
@@ -1011,23 +1052,92 @@ class Helm3Connector(KubernetesBaseConnector):
             if repositoryConfig is not None
             else os.path.join(str(Path.home()), ".config/helm/repositories.yaml")
         )
+        self.rollbackOnFailure: bool = rollbackOnFailure
         self.timeout: str | None = timeout
         self.username: str | None = username
         self.yamlValues: MutableSequence[str] | None = yamlValues
         self.verify: bool = verify
         self.chartVersion: str | None = chartVersion
-        self.wait: bool = wait
+        self.createNamespace: bool = createNamespace
+        self.description: str | None = description
+        self.disableOpenapiValidation: bool = disableOpenapiValidation
+        self.enableDns: bool = enableDns
+        self.generateFlag: bool = generateFlag
+        self.hideNotes: bool = hideNotes
+        self.insecureSkipTLSVerify: bool = insecureSkipTLSVerify
+        self.labels: str | None = labels
+        self.plainHttp: bool = plainHttp
+        self.postRendererArgs: MutableSequence[str] | None = postRendererArgs
+        self.setJson: MutableSequence[str] | None = setJson
+        self.setLiteral: MutableSequence[str] | None = setLiteral
+        self.waitForJobs: bool = waitForJobs
+
+    @abstractmethod
+    async def _check_version(self) -> None: ...
 
     def _get_base_command(self) -> str:
         return (
             f"helm "
+            f"{get_option('burst-limit', self.burstLimit)}"
             f"{get_option('debug', self.debug)}"
+            f"{get_option('kube-apiserver', self.kubeApiserver)}"
+            f"{get_option('kube-as-group', self.kubeAsGroup)}"
+            f"{get_option('kube-as-user', self.kubeAsUser)}"
+            f"{get_option('kube-ca-file', self.kubeCaFile)}"
             f"{get_option('kube-context', self.kubeContext)}"
             f"{get_option('kubeconfig', self.kubeconfig)}"
+            f"{get_option('kube-insecure-skip-tls-verify', self.kubeInsecureSkipTLSVerify)}"
+            f"{get_option('kube-tls-server-name', self.kubeTLSServerName)}"
+            f"{get_option('kube-token', self.kubeToken)}"
             f"{get_option('namespace', self.namespace)}"
+            f"{get_option('qps', self.queriesPerSecond)}"
             f"{get_option('registry-config', self.registryConfig)}"
             f"{get_option('repository-cache', self.repositoryCache)}"
             f"{get_option('repository-config', self.repositoryConfig)}"
+        )
+
+    def _get_deploy_command(self) -> str:
+        return (
+            f"{self._get_base_command()} install "
+            f"{get_option('ca-file', self.caFile)}"
+            f"{get_option('cert-file', self.certFile)}"
+            f"{get_option('create-namespace', self.createNamespace)}"
+            f"{get_option('dependency-update', self.dependencyUpdate)}"
+            f"{get_option('description', self.description)}"
+            f"{get_option('devel', self.devel)}"
+            f"{get_option('disable-openapi-validation', self.disableOpenapiValidation)}"
+            f"{get_option('enable-dns', self.enableDns)}"
+            f"{get_option('generate-name', self.generateFlag)}"
+            f"{get_option('hide-notes', self.hideNotes)}"
+            f"{get_option('insecure-skip-tls-verify', self.insecureSkipTLSVerify)}"
+            f"{get_option('key-file', self.keyFile)}"
+            f"{get_option('keyring', self.keyring)}"
+            f"{get_option('labels', self.labels)}"
+            f"{get_option('name-template', self.nameTemplate)}"
+            f"{get_option('no-hooks', self.noHooks)}"
+            f"{get_option('output', self.output)}"
+            f"{get_option('pass-credentials', self.passCredentials)}"
+            f"{get_option('password', self.password)}"
+            f"{get_option('plain-http', self.plainHttp)}"
+            f"{get_option('post-renderer-args', self.postRendererArgs)}"
+            f"{get_option('render-subchart-notes', self.renderSubchartNotes)}"
+            f"{get_option('replace', self.replace)}"
+            f"{get_option('repo', self.repo)}"
+            f"{get_option('rollback-on-failure', self.rollbackOnFailure)}"
+            f"{get_option('set', self.commandLineValues)}"
+            f"{get_option('set-file', self.fileValues)}"
+            f"{get_option('set-json', self.setJson)}"
+            f"{get_option('set-literal', self.setLiteral)}"
+            f"{get_option('set-string', self.stringValues)}"
+            f"{get_option('skip-crds', self.skipCrds)}"
+            f"{get_option('skip-schema-validation', self.skipSchemaValidation)}"
+            f"{get_option('take-ownership', self.takeOwnership)}"
+            f"{get_option('timeout', self.timeout)}"
+            f"{get_option('username', self.username)}"
+            f"{get_option('values', self.yamlValues)}"
+            f"{get_option('verify', self.verify)}"
+            f"{get_option('version', self.chartVersion)}"
+            f"{get_option('wait-for-jobs', self.waitForJobs)}"
         )
 
     async def _get_running_pods(self) -> V1PodList:
@@ -1044,45 +1154,12 @@ class Helm3Connector(KubernetesBaseConnector):
             # Check if Helm is installed
             _check_helm_installed()
             # Check correct version of Helm
-            version = await _get_helm_version()
-            if not version.startswith("v3"):
-                raise WorkflowExecutionException(
-                    f"Helm {version} is not compatible with Helm3Connector"
-                )
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.debug(f"Using Helm {version}.")
+            await self._check_version()
             # Deploy Helm charts
-            deploy_command = (
-                f"{self._get_base_command()} install "
-                f"{get_option('atomic', self.atomic)}"
-                f"{get_option('ca-file', self.caFile)}"
-                f"{get_option('cert-file', self.certFile)}"
-                f"{get_option('dep-up', self.depUp)}"
-                f"{get_option('devel', self.devel)}"
-                f"{get_option('key-file', self.keyFile)}"
-                f"{get_option('keyring', self.keyring)}"
-                f"{get_option('name-template', self.nameTemplate)}"
-                f"{get_option('no-hooks', self.noHooks)}"
-                f"{get_option('password', self.password)}"
-                f"{get_option('render-subchart-notes', self.renderSubchartNotes)}"
-                f"{get_option('repo', self.repo)}"
-                f"{get_option('set', self.commandLineValues)}"
-                f"{get_option('set-file', self.fileValues)}"
-                f"{get_option('set-string', self.stringValues)}"
-                f"{get_option('skip-crds', self.skipCrds)}"
-                f"{get_option('timeout', self.timeout)}"
-                f"{get_option('username', self.username)}"
-                f"{get_option('values', self.yamlValues)}"
-                f"{get_option('verify', self.verify)}"
-                f"{get_option('version', self.chartVersion)}"
-                f"{get_option('wait', self.wait)}"
-                f"{self.releaseName} "
-                f"{self.chart}"
-            )
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.debug(f"EXECUTING {deploy_command}")
             proc = await asyncio.create_subprocess_exec(
-                *shlex.split(deploy_command),
+                *shlex.split(
+                    f"{self._get_deploy_command()} {self.releaseName} {self.chart}"
+                ),
                 stderr=asyncio.subprocess.STDOUT,
                 stdout=asyncio.subprocess.PIPE,
             )
@@ -1092,29 +1169,21 @@ class Helm3Connector(KubernetesBaseConnector):
                     f"FAILED Deployment of {self.deployment_name} environment:\n\t{stdout.decode().strip()}"
                 )
 
-    @classmethod
-    def get_schema(cls) -> str:
+    def _get_undeploy_command(self) -> str:
         return (
-            files(__package__)
-            .joinpath("schemas")
-            .joinpath("helm3.json")
-            .read_text("utf-8")
+            f"{self._get_base_command()} uninstall "
+            f"{get_option('cascade', self.cascade)}"
+            f"{get_option('description', self.description)}"
+            f"{get_option('keep-history', self.keepHistory)}"
+            f"{get_option('no-hooks', self.noHooks)}"
+            f"{get_option('timeout', self.timeout)}"
         )
 
     async def undeploy(self, external: bool) -> None:
         if not external:
             # Undeploy
-            undeploy_command = (
-                f"{self._get_base_command()}  uninstall "
-                f"{get_option('keep-history', self.keepHistory)}"
-                f"{get_option('no-hooks', self.noHooks)}"
-                f"{get_option('timeout', self.timeout)}"
-                f"{self.releaseName}"
-            )
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.debug(f"EXECUTING {undeploy_command}")
             proc = await asyncio.create_subprocess_exec(
-                *shlex.split(undeploy_command),
+                *shlex.split(f"{self._get_undeploy_command()} {self.releaseName}"),
                 stderr=asyncio.subprocess.STDOUT,
                 stdout=asyncio.subprocess.PIPE,
             )
@@ -1125,3 +1194,380 @@ class Helm3Connector(KubernetesBaseConnector):
                 )
         # Close connections
         await super().undeploy(external)
+
+
+class Helm3Connector(HelmConnector):
+    def __init__(
+        self,
+        deployment_name: str,
+        config_dir: str,
+        chart: str,
+        burstLimit: int = 100,
+        debug: bool = False,
+        kubeContext: str | None = None,
+        kubeconfig: str | None = None,
+        caFile: str | None = None,
+        cascade: str | None = None,
+        certFile: str | None = None,
+        dependencyUpdate: bool = False,
+        devel: bool = False,
+        inCluster: bool = False,
+        keepHistory: bool = False,
+        keyFile: str | None = None,
+        keyring: str | None = None,
+        kubeApiserver: str | None = None,
+        kubeAsGroup: MutableSequence[str] | None = None,
+        kubeAsUser: str | None = None,
+        kubeCaFile: str | None = None,
+        kubeInsecureSkipTLSVerify: bool = False,
+        kubeTLSServerName: str | None = None,
+        kubeToken: str | None = None,
+        locationsCacheSize: int | None = None,
+        locationsCacheTTL: int | None = None,
+        maxConcurrentConnections: int = 4096,
+        nameTemplate: str | None = None,
+        namespace: str | None = None,
+        noHooks: bool = False,
+        output: str | None = None,
+        passCredentials: bool = False,
+        password: str | None = None,
+        queriesPerSecond: float | None = None,
+        renderSubchartNotes: bool = False,
+        replace: bool = False,
+        repo: str | None = None,
+        commandLineValues: MutableSequence[str] | None = None,
+        fileValues: MutableSequence[str] | None = None,
+        stringValues: MutableSequence[str] | None = None,
+        registryConfig: str | None = None,
+        releaseName: str | None = None,
+        repositoryCache: str | None = None,
+        repositoryConfig: str | None = None,
+        resourcesCacheSize: int | None = None,
+        resourcesCacheTTL: int | None = None,
+        rollbackOnFailure: bool = False,
+        skipCrds: bool = False,
+        skipSchemaValidation: bool = False,
+        takeOwnership: bool = False,
+        timeout: str | None = "1000m",
+        transferBufferSize: int = (32 << 20) - 1,
+        username: str | None = None,
+        yamlValues: MutableSequence[str] | None = None,
+        verify: bool = False,
+        chartVersion: str | None = None,
+        createNamespace: bool = False,
+        description: str | None = None,
+        disableOpenapiValidation: bool = False,
+        enableDns: bool = False,
+        force: bool = False,
+        generateFlag: bool = False,
+        hideNotes: bool = False,
+        insecureSkipTLSVerify: bool = False,
+        labels: str | None = None,
+        plainHttp: bool = False,
+        postRenderer: str | None = None,
+        postRendererArgs: MutableSequence[str] | None = None,
+        setJson: MutableSequence[str] | None = None,
+        setLiteral: MutableSequence[str] | None = None,
+        waitForJobs: bool = False,
+        wait: bool = True,
+    ):
+        super().__init__(
+            deployment_name=deployment_name,
+            config_dir=config_dir,
+            chart=chart,
+            burstLimit=burstLimit,
+            debug=debug,
+            kubeContext=kubeContext,
+            kubeconfig=kubeconfig,
+            caFile=caFile,
+            cascade=cascade,
+            certFile=certFile,
+            dependencyUpdate=dependencyUpdate,
+            devel=devel,
+            inCluster=inCluster,
+            keepHistory=keepHistory,
+            keyFile=keyFile,
+            keyring=keyring,
+            kubeApiserver=kubeApiserver,
+            kubeAsGroup=kubeAsGroup,
+            kubeAsUser=kubeAsUser,
+            kubeCaFile=kubeCaFile,
+            kubeInsecureSkipTLSVerify=kubeInsecureSkipTLSVerify,
+            kubeTLSServerName=kubeTLSServerName,
+            kubeToken=kubeToken,
+            locationsCacheSize=locationsCacheSize,
+            locationsCacheTTL=locationsCacheTTL,
+            maxConcurrentConnections=maxConcurrentConnections,
+            nameTemplate=nameTemplate,
+            namespace=namespace,
+            noHooks=noHooks,
+            output=output,
+            passCredentials=passCredentials,
+            password=password,
+            queriesPerSecond=queriesPerSecond,
+            renderSubchartNotes=renderSubchartNotes,
+            replace=replace,
+            repo=repo,
+            commandLineValues=commandLineValues,
+            fileValues=fileValues,
+            stringValues=stringValues,
+            registryConfig=registryConfig,
+            releaseName=releaseName,
+            repositoryCache=repositoryCache,
+            repositoryConfig=repositoryConfig,
+            resourcesCacheSize=resourcesCacheSize,
+            resourcesCacheTTL=resourcesCacheTTL,
+            rollbackOnFailure=rollbackOnFailure,
+            skipCrds=skipCrds,
+            skipSchemaValidation=skipSchemaValidation,
+            takeOwnership=takeOwnership,
+            timeout=timeout,
+            transferBufferSize=transferBufferSize,
+            username=username,
+            yamlValues=yamlValues,
+            verify=verify,
+            chartVersion=chartVersion,
+            createNamespace=createNamespace,
+            description=description,
+            disableOpenapiValidation=disableOpenapiValidation,
+            enableDns=enableDns,
+            generateFlag=generateFlag,
+            hideNotes=hideNotes,
+            insecureSkipTLSVerify=insecureSkipTLSVerify,
+            labels=labels,
+            plainHttp=plainHttp,
+            postRendererArgs=postRendererArgs,
+            setJson=setJson,
+            setLiteral=setLiteral,
+            waitForJobs=waitForJobs,
+        )
+        if logger.isEnabledFor(logging.WARNING):
+            logger.warning(
+                "The Helm3Connector is deprecated and will be removed in StreamFlow 0.3. "
+                "Please migrate to the Helm4Connector as soon as possible."
+            )
+        self.force: bool = force
+        self.postRenderer: str | None = postRenderer
+        self.wait: bool = wait
+
+    async def _check_version(self) -> None:
+        version = await _get_helm_version()
+        if not version.startswith("v3"):
+            raise WorkflowExecutionException(
+                f"Helm {version} is not compatible with Helm3Connector"
+            )
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(f"Using Helm {version}.")
+
+    def _get_deploy_command(self) -> str:
+        return (
+            f"{super()._get_deploy_command()}"
+            f"{get_option('force', self.force)}"
+            f"{get_option('post-renderer', self.postRenderer)}"
+            f"{get_option('wait', self.wait)}"
+        )
+
+    def _get_undeploy_command(self) -> str:
+        return f"{super()._get_undeploy_command()}{get_option('wait', self.wait)}"
+
+    @classmethod
+    def get_schema(cls) -> str:
+        return (
+            files(__package__)
+            .joinpath("schemas")
+            .joinpath("helm3.json")
+            .read_text("utf-8")
+        )
+
+
+class Helm4Connector(HelmConnector):
+    def __init__(
+        self,
+        deployment_name: str,
+        config_dir: str,
+        chart: str,
+        burstLimit: int = 100,
+        debug: bool = False,
+        kubeContext: str | None = None,
+        kubeconfig: str | None = None,
+        caFile: str | None = None,
+        cascade: str | None = None,
+        certFile: str | None = None,
+        contentCache: str | None = None,
+        dependencyUpdate: bool = False,
+        devel: bool = False,
+        inCluster: bool = False,
+        keepHistory: bool = False,
+        keyFile: str | None = None,
+        keyring: str | None = None,
+        kubeApiserver: str | None = None,
+        kubeAsGroup: MutableSequence[str] | None = None,
+        kubeAsUser: str | None = None,
+        kubeCaFile: str | None = None,
+        kubeInsecureSkipTLSVerify: bool = False,
+        kubeTLSServerName: str | None = None,
+        kubeToken: str | None = None,
+        locationsCacheSize: int | None = None,
+        locationsCacheTTL: int | None = None,
+        maxConcurrentConnections: int = 4096,
+        nameTemplate: str | None = None,
+        namespace: str | None = None,
+        noHooks: bool = False,
+        output: str | None = None,
+        passCredentials: bool = False,
+        password: str | None = None,
+        queriesPerSecond: float | None = None,
+        renderSubchartNotes: bool = False,
+        replace: bool = False,
+        repo: str | None = None,
+        commandLineValues: MutableSequence[str] | None = None,
+        fileValues: MutableSequence[str] | None = None,
+        stringValues: MutableSequence[str] | None = None,
+        registryConfig: str | None = None,
+        releaseName: str | None = None,
+        repositoryCache: str | None = None,
+        repositoryConfig: str | None = None,
+        resourcesCacheSize: int | None = None,
+        resourcesCacheTTL: int | None = None,
+        rollbackOnFailure: bool = False,
+        serverSide: bool = False,
+        skipCrds: bool = False,
+        skipSchemaValidation: bool = False,
+        takeOwnership: bool = False,
+        timeout: str | None = "1000m",
+        transferBufferSize: int = (32 << 20) - 1,
+        username: str | None = None,
+        yamlValues: MutableSequence[str] | None = None,
+        verify: bool = False,
+        chartVersion: str | None = None,
+        createNamespace: bool = False,
+        description: str | None = None,
+        disableOpenapiValidation: bool = False,
+        enableDns: bool = False,
+        forceConflicts: bool = False,
+        forceReplace: bool = False,
+        generateFlag: bool = False,
+        hideNotes: bool = False,
+        insecureSkipTLSVerify: bool = False,
+        labels: str | None = None,
+        plainHttp: bool = False,
+        postRenderer: str | None = None,
+        postRendererArgs: MutableSequence[str] | None = None,
+        setJson: MutableSequence[str] | None = None,
+        setLiteral: MutableSequence[str] | None = None,
+        waitForJobs: bool = False,
+        wait: str = "watcher",
+    ):
+        super().__init__(
+            deployment_name=deployment_name,
+            config_dir=config_dir,
+            chart=chart,
+            burstLimit=burstLimit,
+            debug=debug,
+            kubeContext=kubeContext,
+            kubeconfig=kubeconfig,
+            caFile=caFile,
+            cascade=cascade,
+            certFile=certFile,
+            dependencyUpdate=dependencyUpdate,
+            devel=devel,
+            inCluster=inCluster,
+            keepHistory=keepHistory,
+            keyFile=keyFile,
+            keyring=keyring,
+            kubeApiserver=kubeApiserver,
+            kubeAsGroup=kubeAsGroup,
+            kubeAsUser=kubeAsUser,
+            kubeCaFile=kubeCaFile,
+            kubeInsecureSkipTLSVerify=kubeInsecureSkipTLSVerify,
+            kubeTLSServerName=kubeTLSServerName,
+            kubeToken=kubeToken,
+            locationsCacheSize=locationsCacheSize,
+            locationsCacheTTL=locationsCacheTTL,
+            maxConcurrentConnections=maxConcurrentConnections,
+            nameTemplate=nameTemplate,
+            namespace=namespace,
+            noHooks=noHooks,
+            output=output,
+            passCredentials=passCredentials,
+            password=password,
+            queriesPerSecond=queriesPerSecond,
+            renderSubchartNotes=renderSubchartNotes,
+            replace=replace,
+            repo=repo,
+            commandLineValues=commandLineValues,
+            fileValues=fileValues,
+            stringValues=stringValues,
+            registryConfig=registryConfig,
+            releaseName=releaseName,
+            repositoryCache=repositoryCache,
+            repositoryConfig=repositoryConfig,
+            resourcesCacheSize=resourcesCacheSize,
+            resourcesCacheTTL=resourcesCacheTTL,
+            rollbackOnFailure=rollbackOnFailure,
+            skipCrds=skipCrds,
+            skipSchemaValidation=skipSchemaValidation,
+            takeOwnership=takeOwnership,
+            timeout=timeout,
+            transferBufferSize=transferBufferSize,
+            username=username,
+            yamlValues=yamlValues,
+            verify=verify,
+            chartVersion=chartVersion,
+            createNamespace=createNamespace,
+            description=description,
+            disableOpenapiValidation=disableOpenapiValidation,
+            enableDns=enableDns,
+            generateFlag=generateFlag,
+            hideNotes=hideNotes,
+            insecureSkipTLSVerify=insecureSkipTLSVerify,
+            labels=labels,
+            plainHttp=plainHttp,
+            postRendererArgs=postRendererArgs,
+            setJson=setJson,
+            setLiteral=setLiteral,
+            waitForJobs=waitForJobs,
+        )
+        self.contentCache: str | None = contentCache
+        self.forceConflicts: bool = forceConflicts
+        self.forceReplace: bool = forceReplace
+        self.postRenderer: str | None = postRenderer
+        self.serverSide: bool = serverSide
+        self.wait: str = wait
+
+    async def _check_version(self) -> None:
+        version = await _get_helm_version()
+        if not version.startswith("v4"):
+            raise WorkflowExecutionException(
+                f"Helm {version} is not compatible with Helm4Connector"
+            )
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(f"Using Helm {version}.")
+
+    def _get_base_command(self) -> str:
+        return (
+            f"{super()._get_base_command()} "
+            f"{get_option('content-cache', self.contentCache)}"
+        )
+
+    def _get_deploy_command(self) -> str:
+        return (
+            f"{super()._get_deploy_command()}"
+            f"{get_option('force-conflicts', self.forceConflicts)}"
+            f"{get_option('force-replace', self.forceReplace)}"
+            f"{get_option('post-renderer', self.postRenderer)}"
+            f"{get_option('server-side', self.serverSide)}"
+            f"{get_option('wait', self.wait)}"
+        )
+
+    def _get_undeploy_command(self) -> str:
+        return f"{super()._get_undeploy_command()}{get_option('wait', self.wait)}"
+
+    @classmethod
+    def get_schema(cls) -> str:
+        return (
+            files(__package__)
+            .joinpath("schemas")
+            .joinpath("helm4.json")
+            .read_text("utf-8")
+        )

--- a/streamflow/deployment/connector/schemas/base/helm.json
+++ b/streamflow/deployment/connector/schemas/base/helm.json
@@ -1,0 +1,373 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://streamflow.di.unito.it/schemas/deployment/connector/base/helm.json",
+  "type": "object",
+  "properties": {
+    "burstLimit": {
+      "type": "integer",
+      "title": "Burst limit",
+      "default": 100,
+      "description": "Client-side default throttling limit"
+    },
+    "caFile": {
+      "type": "string",
+      "title": "CA file",
+      "description": "Verify certificates of HTTPS-enabled servers using this CA bundle"
+    },
+    "cascade": {
+      "type": "string",
+      "title": "Cascade",
+      "enum": ["background", "foreground", "orphan"],
+      "description": "Selects the deletion cascading strategy for the dependents"
+    },
+    "certFile": {
+      "type": "string",
+      "title": "Certificate file",
+      "description": "Identify HTTPS client using this SSL certificate file"
+    },
+    "chart": {
+      "type": "string",
+      "title": "Chart",
+      "description": "A chart archive. This can be a chart reference, a path to a packaged chart, a path to an unpacked chart directory or a URL"
+    },
+    "chartVersion": {
+      "type": "string",
+      "title": "Chart version",
+      "description": "Specify the exact chart version to install",
+      "default": "latest"
+    },
+    "commandLineValues": {
+      "type": "string",
+      "title": "Command line values",
+      "description": "Set values on the command line. Can separate values with commas: key1=val1,key2=val2"
+    },
+    "createNamespace": {
+      "type": "boolean",
+      "title": "Create namespace",
+      "description": "Create the release namespace if not present",
+      "default": false
+    },
+    "debug": {
+      "type": "boolean",
+      "title": "Debug",
+      "description": "Enable verbose output"
+    },
+    "dependencyUpdate": {
+      "type": "boolean",
+      "title": "Dependency update",
+      "description": "Update dependencies if they are missing before installing the chart"
+    },
+    "description": {
+      "type": "string",
+      "title": "Description",
+      "description": "Add a custom description to the release"
+    },
+    "devel": {
+      "type": "boolean",
+      "title": "Development versions",
+      "description": "Use development versions, too (equivalent to version >0.0.0-0). If version is set, this is ignored"
+    },
+    "disableOpenapiValidation": {
+      "type": "boolean",
+      "title": "Disable OpenAPI validation",
+      "description": "If set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema",
+      "default": false
+    },
+    "enableDns": {
+      "type": "boolean",
+      "title": "Enable DNS",
+      "description": "Enable DNS lookups when rendering templates",
+      "default": false
+    },
+    "fileValues": {
+      "type": "string",
+      "title": "File values",
+      "description": "Set values from respective files. Can separate values with commas: key1=path1,key2=path2"
+    },
+    "generateFlag": {
+      "type": "boolean",
+      "title": "Generate name",
+      "description": "Generate the release name (omit the NAME parameter)",
+      "default": false
+    },
+    "hideNotes": {
+      "type": "boolean",
+      "title": "Hide notes",
+      "description": "If set, do not show notes in install output. Does not affect presence in chart metadata",
+      "default": false
+    },
+    "inCluster": {
+      "type": "boolean",
+      "title": "In cluster",
+      "description": "If true, the Helm connector will use a ServiceAccount to connect to the Kubernetes cluster. This is useful when StreamFlow runs directly inside a Kubernetes Pod",
+      "default": false
+    },
+    "insecureSkipTLSVerify": {
+      "type": "boolean",
+      "title": "Insecure skip TLS verify",
+      "description": "Skip TLS certificate checks for the chart download",
+      "default": false
+    },
+    "keepHistory": {
+      "type": "boolean",
+      "title": "Keep history",
+      "description": "Remove all associated resources and mark the release as deleted, but retain the release history",
+      "default": false
+    },
+    "keyFile": {
+      "type": "string",
+      "title": "Key file",
+      "description": "Identify HTTPS client using this SSL key file"
+    },
+    "keyring": {
+      "type": "string",
+      "title": "Key ring",
+      "description": "Location of public keys used for verification"
+    },
+    "kubeApiserver": {
+      "type": "string",
+      "title": "Kubernetes API server",
+      "description": "The address and the port for the Kubernetes API server"
+    },
+    "kubeAsGroup": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "title": "Impersonate groups",
+      "description": "Groups to impersonate for the operation"
+    },
+    "kubeAsUser": {
+      "type": "string",
+      "title": "Impersonate user",
+      "description": "Username to impersonate for the operation"
+    },
+    "kubeCaFile": {
+      "type": "string",
+      "title": "Kubernetes CA file",
+      "description": "The certificate authority file for the Kubernetes API server connection"
+    },
+    "kubeContext": {
+      "type": "string",
+      "title": "Kubernetes context",
+      "description": "Name of the kubeconfig context to use"
+    },
+    "kubeconfig": {
+      "type": "string",
+      "title": "Kubernetes config",
+      "description": "Absolute path of the kubeconfig file to be used"
+    },
+    "kubeInsecureSkipTLSVerify": {
+      "type": "boolean",
+      "title": "Kubernetes insecure skip TLS verify",
+      "default": false,
+      "description": "If true, the Kubernetes API server's server certificate will not be checked for validity. This will make your Kubernetes cluster insecure"
+    },
+    "kubeTLSServerName": {
+      "type": "string",
+      "title": "Kubernetes TLS server name",
+      "description": "Server name to use for Kubernetes API server certificate validation. If it is not provided, the hostname used to contact the server is used"
+    },
+    "kubeToken": {
+      "type": "string",
+      "title": "Kubernetes bearer token",
+      "description": "Bearer token for authentication"
+    },
+    "labels": {
+      "type": "string",
+      "title": "Labels",
+      "description": "Labels to add to release metadata, divided by comma: key1=val1,key2=val2"
+    },
+    "maxConcurrentConnections": {
+      "type": "integer",
+      "title": "Max concurrent connections",
+      "description": "Maximum number of concurrent connections to open for a single Kubernetes client",
+      "default": 4096
+    },
+    "namespace": {
+      "type": "string",
+      "title": "Namespace",
+      "description": "Namespace to install the release into"
+    },
+    "nameTemplate": {
+      "type": "string",
+      "title": "Name template",
+      "description": "Specify template used to name the release"
+    },
+    "noHooks": {
+      "type": "boolean",
+      "title": "No hooks",
+      "description": "Prevent hooks from running during install"
+    },
+    "output": {
+      "type": "string",
+      "title": "Output",
+      "enum": ["json", "table", "yaml"],
+      "description": "Print the output in the specified format"
+    },
+    "passCredentials": {
+      "type": "boolean",
+      "title": "Pass credentials",
+      "description": "Pass credentials to all domains",
+      "default": false
+    },
+    "password": {
+      "type": "string",
+      "title": "Password",
+      "description": "Chart repository password where to locate the requested chart"
+    },
+    "plainHttp": {
+      "type": "boolean",
+      "title": "Plain HTTP",
+      "description": "Use insecure HTTP connections for the chart download",
+      "default": false
+    },
+    "postRendererArgs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "title": "Post renderer args",
+      "description": "Arguments to pass to the post-renderer (can specify multiple)"
+    },
+    "queriesPerSecond": {
+      "type": "float",
+      "title": "Queries per second",
+      "description": "Queries per second used when communicating with the Kubernetes API, not including bursting"
+    },
+    "registryConfig": {
+      "type": "string",
+      "title": "Registry config",
+      "description": "Path to the registry config file"
+    },
+    "repositoryCache": {
+      "type": "string",
+      "title": "Repository cache",
+      "description": "Path to the file containing cached repository indexes"
+    },
+    "repositoryConfig": {
+      "type": "string",
+      "title": "Repository config",
+      "description": "Path to the file containing repository names and URLs"
+    },
+    "releaseName": {
+      "type": "string",
+      "title": "Release name",
+      "description": "The release name. If unspecified, it will autogenerate one for you"
+    },
+    "renderSubchartNotes": {
+      "type": "boolean",
+      "title": "Render subchart notes",
+      "description": "Render subchart notes along with the parent"
+    },
+    "replace": {
+      "type": "boolean",
+      "title": "Replace",
+      "description": "Reuse the given name, only if that name is a deleted release which remains in the history. This is unsafe in production",
+      "default": false
+    },
+    "repo": {
+      "type": "string",
+      "title": "Repository",
+      "description": "Chart repository url where to locate the requested chart"
+    },
+    "locationsCacheTTL": {
+      "type": "integer",
+      "title": "Locations cache TTL",
+      "description": "Available locations cache TTL (in seconds). When such cache expires, the connector performs a new request to check locations availability",
+      "default": 10
+    },
+    "resourcesCacheTTL": {
+      "type": "integer",
+      "title": "Resources cache TTL",
+      "deprecated": true,
+      "description": "(**Deprecated.** Use locationsCacheTTL.) Available resources cache TTL (in seconds). When such cache expires, the connector performs a new request to check resources availability",
+      "default": 10
+    },
+    "rollbackOnFailure": {
+      "type": "boolean",
+      "title": "Rollback on failure",
+      "default": false,
+      "description": "If set, Helm will rollback (uninstall) the installation upon failure"
+    },
+    "setJson": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "title": "Set JSON values",
+      "description": "Set JSON values on the command line (can specify multiple or separate values with commas: key1=jsonval1,key2=jsonval2)"
+    },
+    "setLiteral": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "title": "Set literal values",
+      "description": "Set a literal STRING value on the command line (can specify multiple)"
+    },
+    "skipCrds": {
+      "type": "boolean",
+      "title": "Skip CRDs",
+      "description": "If set, no CRDs will be installed",
+      "default": false
+    },
+    "skipSchemaValidation": {
+      "type": "boolean",
+      "title": "Skip schema validation",
+      "description": "If set, disables JSON schema validation",
+      "default": false
+    },
+    "stringValues": {
+      "type": "string",
+      "title": "String values",
+      "description": "Set string values. Can separate values with commas: key1=val1,key2=val2"
+    },
+    "takeOwnership": {
+      "type": "boolean",
+      "title": "Take ownership",
+      "description": "If set, install will ignore the check for helm annotations and take ownership of the existing resources",
+      "default": false
+    },
+    "timeout": {
+      "type": "string",
+      "title": "Timeout",
+      "description": "Time to wait for any individual Kubernetes operation",
+      "default": "1000m"
+    },
+    "transferBufferSize": {
+      "type": "integer",
+      "title": "Transfer buffer size",
+      "description": "Buffer size allocated for local and remote data transfers",
+      "default": 33554431
+    },
+    "username": {
+      "type": "string",
+      "title": "Username",
+      "description": "Chart repository username where to locate the requested chart"
+    },
+    "yamlValues": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "title": "YAML values",
+      "description": "Specify values in a list of YAML files and/or URLs"
+    },
+    "verify": {
+      "type": "boolean",
+      "title": "Verify",
+      "description": "Verify the package before installing it"
+    },
+    "waitForJobs": {
+      "type": "boolean",
+      "title": "Wait for jobs",
+      "description": "If set and --wait is enabled, will wait until all Jobs have been completed before marking the release as successful. It will wait for as long as timeout",
+      "default": false
+    }
+  },
+  "required": [
+    "chart"
+  ],
+  "additionalProperties": false
+}

--- a/streamflow/deployment/connector/schemas/helm3.json
+++ b/streamflow/deployment/connector/schemas/helm3.json
@@ -2,200 +2,19 @@
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://streamflow.di.unito.it/schemas/deployment/connector/helm3.json",
   "type": "object",
+  "deprecated": true,
+  "$ref": "base/helm.json",
   "properties": {
-    "atomic": {
+    "force": {
       "type": "boolean",
-      "title": "Atomic",
-      "description": "If set, installation process purges chart on fail (also sets wait flag)"
-    },
-    "caFile": {
-      "type": "string",
-      "title": "CA file",
-      "description": "Verify certificates of HTTPS-enabled servers using this CA bundle"
-    },
-    "certFile": {
-      "type": "string",
-      "title": "Certificate file",
-      "description": "Identify HTTPS client using this SSL certificate file"
-    },
-    "chart": {
-      "type": "string",
-      "title": "Chart",
-      "description": "A chart archive. This can be a chart reference, a path to a packaged chart, a path to an unpacked chart directory or a URL"
-    },
-    "chartVersion": {
-      "type": "string",
-      "title": "Chart version",
-      "description": "Specify the exact chart version to install",
-      "default": "latest"
-    },
-    "commandLineValues": {
-      "type": "string",
-      "title": "Command line values",
-      "description": "Set values on the command line. Can separate values with commas: key1=val1,key2=val2"
-    },
-    "debug": {
-      "type": "boolean",
-      "title": "Debug",
-      "description": "Enable verbose output"
-    },
-    "depUp": {
-      "type": "boolean",
-      "title": "Dependencies update",
-      "description": "Run helm dependency update before installing the chart"
-    },
-    "devel": {
-      "type": "boolean",
-      "title": "Development versions",
-      "description": "Use development versions, too (equivalent to version >0.0.0-0). If version is set, this is ignored"
-    },
-    "fileValues": {
-      "type": "string",
-      "title": "File values",
-      "description": "Set values from respective files. Can separate values with commas: key1=path1,key2=path2"
-    },
-    "inCluster": {
-      "type": "boolean",
-      "title": "In cluster",
-      "description": "If true, the Helm connector will use a ServiceAccount to connect to the Kubernetes cluster. This is useful when StreamFlow runs directly inside a Kubernetes Pod",
+      "title": "Force",
+      "description": "Force resource updates through a replacement strategy (delete and recreate the resource)",
       "default": false
     },
-    "keepHistory": {
-      "type": "boolean",
-      "title": "Keep history",
-      "description": "Remove all associated resources and mark the release as deleted, but retain the release history",
-      "default": false
-    },
-    "keyFile": {
+    "postRenderer": {
       "type": "string",
-      "title": "Key file",
-      "description": "Identify HTTPS client using this SSL key file"
-    },
-    "keyring": {
-      "type": "string",
-      "title": "Key ring",
-      "description": "Location of public keys used for verification"
-    },
-    "kubeContext": {
-      "type": "string",
-      "title": "Kubernetes context",
-      "description": "Name of the kubeconfig context to use"
-    },
-    "kubeconfig": {
-      "type": "string",
-      "title": "Kubernetes config",
-      "description": "Absolute path of the kubeconfig file to be used"
-    },
-    "maxConcurrentConnections": {
-      "type": "integer",
-      "title": "Max concurrent connections",
-      "description": "Maximum number of concurrent connections to open for a single Kubernetes client",
-      "default": 4096
-    },
-    "namespace": {
-      "type": "string",
-      "title": "Namespace",
-      "description": "Namespace to install the release into"
-    },
-    "nameTemplate": {
-      "type": "string",
-      "title": "Name template",
-      "description": "Specify template used to name the release"
-    },
-    "noHooks": {
-      "type": "boolean",
-      "title": "No hooks",
-      "description": "Prevent hooks from running during install"
-    },
-    "password": {
-      "type": "string",
-      "title": "Password",
-      "description": "Chart repository password where to locate the requested chart"
-    },
-    "registryConfig": {
-      "type": "string",
-      "title": "Registry config",
-      "description": "Path to the registry config file"
-    },
-    "repositoryCache": {
-      "type": "string",
-      "title": "Repository cache",
-      "description": "Path to the file containing cached repository indexes"
-    },
-    "repositoryConfig": {
-      "type": "string",
-      "title": "Repository config",
-      "description": "Path to the file containing repository names and URLs"
-    },
-    "releaseName": {
-      "type": "string",
-      "title": "Release name",
-      "description": "The release name. If unspecified, it will autogenerate one for you"
-    },
-    "renderSubchartNotes": {
-      "type": "boolean",
-      "title": "Render subchart notes",
-      "description": "Render subchart notes along with the parent"
-    },
-    "repo": {
-      "type": "string",
-      "title": "Repository",
-      "description": "Chart repository url where to locate the requested chart"
-    },
-    "locationsCacheTTL": {
-      "type": "integer",
-      "title": "Locations cache TTL",
-      "description": "Available locations cache TTL (in seconds). When such cache expires, the connector performs a new request to check locations availability",
-      "default": 10
-    },
-    "resourcesCacheTTL": {
-      "type": "integer",
-      "title": "Resources cache TTL",
-     "deprecated": true,
-      "description": "(**Deprecated.** Use locationsCacheTTL.) Available resources cache TTL (in seconds). When such cache expires, the connector performs a new request to check resources availability",
-      "default": 10
-    },
-    "skipCrds": {
-      "type": "boolean",
-      "title": "Skip CRDs",
-      "description": "If set, no CRDs will be installed",
-      "default": false
-    },
-    "stringValues": {
-      "type": "string",
-      "title": "String values",
-      "description": "Set string values. Can separate values with commas: key1=val1,key2=val2"
-    },
-    "timeout": {
-      "type": "string",
-      "title": "Timeout",
-      "description": "Time to wait for any individual Kubernetes operation",
-      "default": "1000m"
-    },
-    "transferBufferSize": {
-      "type": "integer",
-      "title": "Transfer buffer size",
-      "description": "Buffer size allocated for local and remote data transfers",
-      "default": 33554431,
-      "$comment": "Kubernetes Python client talks with its server counterpart, written in Golang, via Websocket protocol. The standard websocket package in Golang defines DefaultMaxPayloadBytes equal to 32 MB. Nevertheless, since kubernetes-client prepends channel number to the actual payload (which is always 0 for STDIN), we must reserve 1 byte for this purpose"
-    },
-    "username": {
-      "type": "string",
-      "title": "Username",
-      "description": "Chart repository username where to locate the requested chart"
-    },
-    "yamlValues": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "title": "YAML values",
-      "description": "Specify values in a list of YAML files and/or URLs"
-    },
-    "verify": {
-      "type": "boolean",
-      "title": "Verify",
-      "description": "Verify the package before installing it"
+      "title": "Post renderer",
+      "description": "The path to an executable to be used for post rendering. If it exists in $PATH, the binary will be used, otherwise it will try to look for the executable at the given path"
     },
     "wait": {
       "type": "boolean",
@@ -204,8 +23,5 @@
       "default": true
     }
   },
-  "required": [
-    "chart"
-  ],
   "additionalProperties": false
 }

--- a/streamflow/deployment/connector/schemas/helm4.json
+++ b/streamflow/deployment/connector/schemas/helm4.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://streamflow.di.unito.it/schemas/deployment/connector/helm4.json",
+  "type": "object",
+  "$ref": "base/helm.json",
+  "properties": {
+    "contentCache": {
+      "type": "string",
+      "title": "Content cache",
+      "description": "Path to the directory containing cached content (e.g. charts)"
+    },
+    "forceConflicts": {
+      "type": "boolean",
+      "title": "Force conflicts",
+      "description": "If set, server-side apply will force changes against field ownership conflicts",
+      "default": false
+    },
+    "forceReplace": {
+      "type": "boolean",
+      "title": "Force replace",
+      "description": "Force resource updates by replacement (delete and recreate the resource)",
+      "default": false
+    },
+    "postRenderer": {
+      "type": "string",
+      "title": "Post renderer",
+      "description": "The name of a post renderer type plugin to be used for post rendering. If it exists, the plugin will be used"
+    },
+    "serverSide": {
+      "type": "boolean",
+      "title": "Server side",
+      "default": true,
+      "description": "Object updates run in the server instead of the client"
+    },
+    "wait": {
+      "type": "string",
+      "enum": [
+        "hookOnly",
+        "legacy",
+        "watcher"
+      ],
+      "title": "Wait",
+      "default": "watcher",
+      "description": "If specified, wait until resources are ready, up to timeout"
+    }
+  },
+  "unevaluatedProperties": false
+}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -190,11 +190,11 @@ def test_schema_generation() -> None:
     """Check that the `streamflow schema` command generates a correct JSON Schema."""
     assert (
         hashlib.sha256(SfSchema().dump("v1.0", False).encode()).hexdigest()
-        == "db98b881908ff1307903083f1ecdda9c72d79d41a1c78d4d218b9b4eab7ddd50"
+        == "13af64923e2be054e735edd5dddfd491ad75e5727872b4a9d982b98763f863e1"
     )
     assert (
         hashlib.sha256(SfSchema().dump("v1.0", True).encode()).hexdigest()
-        == "f00ff804860f09c25555721adda5bb971e6c647562657760e70e04d76841a730"
+        == "15e501744c3ab18204fff9157876395b366e2d1fffc9a3653152bc23cfcbb93c"
     )
 
 


### PR DESCRIPTION
BREAKING_CHANGE: now the helm deployments points to Helm v4 instead of Helm v3, which is now deprecated.

Audit `Helm3Connector` and `Helm4Connector` against the Helm v3 and v4 CLI references and bring the implementation fully in line:

- Remove flags absent from either version: `--atomic`, `--cleanup-on-fail`
- Fix incorrect flag names: `--dep-up` -> `--dependency-update`, `--insecure-skip-verify` -> `--insecure-skip-tls-verify`
- Confine `--force` to `Helm3Connector`; replace it with `--force-conflicts` and `--force-replace` in `Helm4Connector`
- Add all previously missing install/uninstall flags: `--cascade`, `--generate-name`, `--ignore-not-found`, `--labels`, `--output`, `--pass-credentials`, `--replace`, `--skip-schema-validation`, `--take-ownership`
- Introduce overridable `_get_undeploy_command()` on `HelmConnector` so subclasses append version-specific uninstall flags cleanly; fixes a double-space bug in the inlined uninstall command
- Sync `base/helm.json` schema with all of the above changes
- Update Helm version in the CI/CD pipeline to v4.1.1