### PR TITLE
Fix source port resolution in CWL translator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix source port resolution in CWL translator
 - Fix shell reuse collision across execution locations ([#1045](https://github.com/alpha-unito/streamflow/pull/1045))
 - Fix operators in `Hardware` and `Storage` ([#1044](https://github.com/alpha-unito/streamflow/pull/1044))
 - Fix Docker Compose NDJSON location parsing ([#1043](https://github.com/alpha-unito/streamflow/pull/1043))

--- a/streamflow/cwl/translator.py
+++ b/streamflow/cwl/translator.py
@@ -1780,13 +1780,19 @@ class CWLTranslator:
         return input_port
 
     def _get_source_port(self, workflow: Workflow, source_name: str) -> Port:
-        if source_name in self.output_ports:
+        # Return the output port of a previous step.
+        # If the port has no input step, it means it is the output of the workflow
+        if (
+            source_name in self.output_ports
+            and self.output_ports[source_name].get_input_steps()
+        ):
             return self.output_ports[source_name]
         if source_name not in self.input_ports:
             if source_name not in self.output_ports:
                 self.output_ports[source_name] = workflow.create_port()
             return self.output_ports[source_name]
         else:
+            # The `source_port` is an input of the workflow
             return self.input_ports[source_name]
 
     def _handle_default_port(


### PR DESCRIPTION
This commit fixes an issue where a CWL workflow defines an input and an output with the same name. Before this commit, the StreamFlow translator created a malformed workflow, leading to a deadlock or erroneous execution.

The fix leverages the StreamFlow approach for translating inner objects to outer objects. When a step requires a source port and it is a port of another step, the port is already attached to the step. If the port is not an output of a step, it means the port is the output of the workflow