### PR TITLE
Fix `--wait` flag in `Helm4Connector` for Cobra parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `--wait` flag in `Helm4Connector` for Cobra parser ([#1050](https://github.com/alpha-unito/streamflow/pull/1050))
 - Fix shell reuse collision across execution locations ([#1045](https://github.com/alpha-unito/streamflow/pull/1045))
 - Fix operators in `Hardware` and `Storage` ([#1044](https://github.com/alpha-unito/streamflow/pull/1044))
 - Fix Docker Compose NDJSON location parsing ([#1043](https://github.com/alpha-unito/streamflow/pull/1043))

--- a/streamflow/deployment/connector/kubernetes.py
+++ b/streamflow/deployment/connector/kubernetes.py
@@ -1368,7 +1368,7 @@ class Helm3Connector(HelmConnector):
         )
 
     def _get_undeploy_command(self) -> str:
-        return f"{super()._get_undeploy_command()}{get_option('wait', self.wait)}"
+        return f"{super()._get_undeploy_command()}" f"{get_option('wait', self.wait)}"
 
     @classmethod
     def get_schema(cls) -> str:
@@ -1557,11 +1557,11 @@ class Helm4Connector(HelmConnector):
             f"{get_option('force-replace', self.forceReplace)}"
             f"{get_option('post-renderer', self.postRenderer)}"
             f"{get_option('server-side', self.serverSide)}"
-            f"{get_option('wait', self.wait)}"
+            f"--wait={self.wait} "
         )
 
     def _get_undeploy_command(self) -> str:
-        return f"{super()._get_undeploy_command()}{get_option('wait', self.wait)}"
+        return f"{super()._get_undeploy_command()}" f"--wait={self.wait} "
 
     @classmethod
     def get_schema(cls) -> str:


### PR DESCRIPTION
Cobra's argument parser treats `--wait` as an optional boolean flag where its bare presence (without `=<value>`) always implies `true`. The previous use of `get_option('wait', self.wait)` makes Cobra interpret `--wait` and `<value>` as two separate flags, resulting in errors when running `helm install`.

Replace `get_option('wait', self.wait)` with `--wait={self.wait} ` in `Helm4Connector._get_deploy_command` and `_get_undeploy_command` so that Cobra always receives a correct value for `-wait`.