### PR TITLE
Enforce `CHANGELOG.md` updates in PRs

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -10,6 +10,24 @@ concurrency:
   group: build-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
+  check-changelog:
+    name: "Enforce CHANGELOG updates"
+    runs-on: ubuntu-24.04
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check if CHANGELOG.md changed
+        run: |
+          BASE_BRANCH="${{ github.event.pull_request.base.ref }}"          
+          git fetch origin $BASE_BRANCH
+          if ! git diff --name-only origin/$BASE_BRANCH...HEAD | grep -q "^CHANGELOG.md$"; then
+            echo "Error: CHANGELOG.md has not been updated!"
+            exit 1
+          fi
   code-ql-check:
     name: "StreamFlow CodeQL check"
     runs-on: ubuntu-24.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove `OccamConnector` and all associated files ([#1041](https://github.com/alpha-unito/streamflow/pull/1041))
 
+### Dependencies
+
+- Bump asyncssh from 2.22.0 to 2.23.0 ([#1064](https://github.com/alpha-unito/streamflow/pull/1064))
+- Bump kaleido from 1.2.0 to 1.3.0 ([#1055](https://github.com/alpha-unito/streamflow/pull/1055))
+- Bump urllib3 from 2.6.3 to 2.7.0 ([#1063](https://github.com/alpha-unito/streamflow/pull/1063))
+
+### Dev Dependencies
+
+- Bump azure/setup-helm from 4 to 5 ([#1051](https://github.com/alpha-unito/streamflow/pull/1051))
+- Bump mistune from 3.1.4 to 3.2.1 ([#1060](https://github.com/alpha-unito/streamflow/pull/1060))
+- Bump mypy from 1.20.2 to 2.1.0 ([#1059](https://github.com/alpha-unito/streamflow/pull/1059), [#1065](https://github.com/alpha-unito/streamflow/pull/1065))
+- Bump ruff from 0.15.11 to 0.15.12 ([#1047](https://github.com/alpha-unito/streamflow/pull/1047))
+- Bump sphinxcontrib-bibtex from 2.6.5 to 2.7.0 ([#1057](https://github.com/alpha-unito/streamflow/pull/1057))
+- Bump types-cachetools from 6.2.0.20260408 to 7.0.0.20260503 ([#1052](https://github.com/alpha-unito/streamflow/pull/1052))
+- Bump types-jsonschema from 4.26.0.20260408 to 4.26.0.20260508 ([#1062](https://github.com/alpha-unito/streamflow/pull/1062))
+- Bump types-psutil from 7.2.2.20260408 to 7.2.2.20260508 ([#1061](https://github.com/alpha-unito/streamflow/pull/1061))
+
 ## [0.2.0rc2] - 2026-04-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Enforce `CHANGELOG.md` updates in PRs ([#1066](https://github.com/alpha-unito/streamflow/pull/1066))
 - Add MPI application tutorial and docs agent skills ([#1042](https://github.com/alpha-unito/streamflow/pull/1042))
 - Add fault tolerance paper reference in the documentation ([#1049](https://github.com/alpha-unito/streamflow/pull/1049))
 


### PR DESCRIPTION
This commit adds a new Continuous Integration check to ensure that `CHANGELOG.md` is updated in every pull request before it can be merged into the `master` branch.