### PR TITLE
Fix provenance handling for secondary files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix provenance handling for secondary files ([#1068](https://github.com/alpha-unito/streamflow/pull/1068))
 - Fix bind mount inspection in `SingularityConnector` ([#1058](https://github.com/alpha-unito/streamflow/pull/1058))
 - Fix `--wait` flag in `Helm4Connector` for Cobra parser ([#1050](https://github.com/alpha-unito/streamflow/pull/1050))
 - Fix shell reuse collision across execution locations ([#1045](https://github.com/alpha-unito/streamflow/pull/1045))

--- a/streamflow/provenance/run_crate.py
+++ b/streamflow/provenance/run_crate.py
@@ -1483,16 +1483,19 @@ class CWLRunCrateProvenanceManager(RunCrateProvenanceManager):
             )
             value = []
             for property_value in (k for k in property_values if k is not None):
-                if property_value["@type"] in ["Dataset", "File"]:
-                    # Check for duplicate checksums
-                    if property_value["@id"] not in self.graph:
-                        self.graph["./"]["hasPart"].append(
-                            {"@id": property_value["@id"]}
-                        )
-                        self.graph[property_value["@id"]] = property_value
-                    value.append({"@id": property_value["@id"]})
-                else:
-                    value.append(property_value["value"])
+                match property_value["@type"]:
+                    case "Collection":
+                        value.append({"@id": property_value["@id"]})
+                    case "Dataset" | "File":
+                        # Check for duplicate checksums
+                        if property_value["@id"] not in self.graph:
+                            self.graph["./"]["hasPart"].append(
+                                {"@id": property_value["@id"]}
+                            )
+                            self.graph[property_value["@id"]] = property_value
+                        value.append({"@id": property_value["@id"]})
+                    case _:
+                        value.append(property_value["value"])
             value = streamflow.core.utils.flatten_list(value)
             return {
                 "@id": "#" + str(uuid.uuid4()),


### PR DESCRIPTION
Add a `Collection` case to the `property_values` match block in `CWLRunCrateProvenanceManager` so that Collection-typed secondary files are tracked by `@id` in provenance graphs instead of being incorrectly treated as primitive values.