### PR TITLE
Fix permission propagation when transferring files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix permission propagation when transferring files between locations ([#1085](https://github.com/alpha-unito/streamflow/pull/1085))
 - Fix provenance of empty unbound inputs ([#968](https://github.com/alpha-unito/streamflow/pull/968))
 - Fix bind mount inspection in `SingularityConnector` ([#1058](https://github.com/alpha-unito/streamflow/pull/1058))
 - Fix `--wait` flag in `Helm4Connector` for Cobra parser ([#1050](https://github.com/alpha-unito/streamflow/pull/1050))

--- a/streamflow/core/utils.py
+++ b/streamflow/core/utils.py
@@ -261,7 +261,7 @@ async def get_remote_to_remote_write_command(
         raise WorkflowExecutionException(is_dst_dir)
     # If destination path exists and is a directory
     elif status == 0:
-        return ["tar", "xf", "-", "-C", dst]
+        return ["tar", "xpf", "-", "-C", dst]
     # Otherwise, if destination path does not exist
     else:
         # If basename must be renamed during transfer
@@ -285,13 +285,13 @@ async def get_remote_to_remote_write_command(
                         for dst_location in dst_locations
                     )
                 )
-                return ["tar", "xf", "-", "-C", dst, "--strip-components", "1"]
+                return ["tar", "xpf", "-", "-C", dst, "--strip-components", "1"]
             # Otherwise, if source path is a file
             else:
-                return ["tar", "xf", "-", "-O", "|", "tee", dst, ">", "/dev/null"]
+                return ["tar", "xpf", "-", "-O", "|", "tee", dst, ">", "/dev/null"]
         # Otherwise, if basename must be preserved
         else:
-            return ["tar", "xf", "-", "-C", posixpath.dirname(dst)]
+            return ["tar", "xpf", "-", "-C", posixpath.dirname(dst)]
 
 
 def get_tag(tokens: Iterable[Token]) -> str:

--- a/streamflow/data/remotepath.py
+++ b/streamflow/data/remotepath.py
@@ -170,6 +170,9 @@ class StreamFlowPath(PurePath, ABC):
     async def checksum(self) -> str | None: ...
 
     @abstractmethod
+    async def chmod(self, mode: int, *, follow_symlinks: bool = True): ...
+
+    @abstractmethod
     async def exists(self) -> bool: ...
 
     @abstractmethod
@@ -179,6 +182,9 @@ class StreamFlowPath(PurePath, ABC):
 
     @abstractmethod
     async def is_dir(self) -> bool: ...
+
+    @abstractmethod
+    async def is_executable(self) -> bool: ...
 
     @abstractmethod
     async def is_file(self) -> bool: ...
@@ -351,6 +357,9 @@ class LocalStreamFlowPath(
         else:
             return None
 
+    async def chmod(self, mode: int, *, follow_symlinks: bool = True) -> None:
+        cast(Path, super()).chmod(mode, follow_symlinks=follow_symlinks)
+
     async def exists(self) -> bool:
         return cast(Path, super()).exists()
 
@@ -362,6 +371,9 @@ class LocalStreamFlowPath(
 
     async def is_dir(self) -> bool:
         return cast(Path, super()).is_dir()
+
+    async def is_executable(self) -> bool:
+        return os.access(str(self), os.X_OK)
 
     async def is_file(self) -> bool:
         return cast(Path, super()).is_file()
@@ -613,6 +625,19 @@ class RemoteStreamFlowPath(
                 )
             return result.strip()
 
+    async def chmod(self, mode: int, *, follow_symlinks=True):
+        if (inner_path := await self._get_inner_path()) != self:
+            await inner_path.chmod(mode, follow_symlinks=follow_symlinks)
+        else:
+            command = ["chmod"]
+            if not follow_symlinks:
+                command.append("-h")
+            command.extend([f"{mode:o}", self.__str__()])
+            result, status = await self.connector.run(
+                location=self.location, command=command, capture_output=True
+            )
+            _check_status(command, self.location, result, status)
+
     async def exists(self) -> bool:
         if (inner_path := await self._get_inner_path()) != self:
             return await inner_path.exists()
@@ -659,6 +684,12 @@ class RemoteStreamFlowPath(
             return await inner_path.is_dir()
         else:
             return await self._test(command=["-d", shlex.quote(self.__str__())])
+
+    async def is_executable(self) -> bool:
+        if (inner_path := await self._get_inner_path()) != self:
+            return await inner_path.is_executable()
+        else:
+            return await self._test(command=["-x", shlex.quote(self.__str__())])
 
     async def is_file(self) -> bool:
         if (inner_path := await self._get_inner_path()) != self:

--- a/streamflow/deployment/connector/base.py
+++ b/streamflow/deployment/connector/base.py
@@ -54,10 +54,11 @@ async def extract_tar_stream(
     async for member in tar:
         # If `dst` is a directory, copy the content of `src` inside `dst`
         if os.path.isdir(dst) and member.path == posixpath.basename(src):
-            await tar.extract(member, dst)
+            await tar.extract(member, dst, numeric_owner=True)
 
         # Otherwise, if copying a file, simply move it inside `dst`
         elif member.isfile():
+            tarinfo = await tar.getmember(member) if isinstance(member, str) else member
             async with await tar.extractfile(member) as inputfile:
                 path = os.path.normpath(
                     os.path.join(
@@ -67,6 +68,7 @@ async def extract_tar_stream(
                 with open(path, "wb") as outputfile:
                     while content := await inputfile.read(transferBufferSize):
                         outputfile.write(content)
+                os.chmod(path, tarinfo.mode)
 
         # Otherwise, if copying a directory, modify the member path to
         # move all the file hierarchy inside `dst`
@@ -79,7 +81,9 @@ async def extract_tar_stream(
                     member.linkname, posixpath.basename(src)
                 )
             await tar.extract(
-                member, os.path.normpath(os.path.join(dst, os.path.curdir))
+                member,
+                os.path.normpath(os.path.join(dst, os.path.curdir)),
+                numeric_owner=True,
             )
 
 
@@ -399,7 +403,7 @@ class BaseConnector(Connector, FutureAware, ABC):
                         location=location,
                         src=src,
                         dst=dst,
-                        writer_command=["tar", "xf", "-", "-C", "/"],
+                        writer_command=["tar", "xpf", "-", "-C", "/"],
                     )
                 )
                 for location in locations

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -38,7 +38,11 @@ async def _create_tmp_dir(
     file_lvl = f"-{lvl}" if lvl else ""
     for i in range(n_files):
         file_name = f"file{file_lvl}-{i}-{utils.random_name()}"
-        await (dir_path / file_name).write_text(f"Hello from {file_name}")
+        file_path = dir_path / file_name
+        await file_path.write_text(f"Hello from {file_name}")
+        if i == 1:
+            await file_path.chmod(0o755)
+            assert await file_path.is_executable()
     return dir_path
 
 
@@ -49,18 +53,18 @@ async def test_directory_to_directory(
     """Test transferring a directory and its content from one location to another."""
     # dir
     #   |- file_0
-    #   |- file_1
+    #   |- file_1 (executable)
     #   |- file_2
     #   |- file_3
     #   |- dir_0
     #   |   |- file_0_0
-    #   |   |- file_0_1
+    #   |   |- file_0_1 (executable)
     #   |   |- dir_0_0
-    #   |   |   |- file_0_0_1
+    #   |   |   |- file_0_0_1 (executable)
     #   |   |   |- file_0_0_2
     #   |- dir_1
     #   |   |- file_1_0
-    #   |   |- file_1_1
+    #   |   |- file_1_1 (executable)
     #   |   |- file_1_2
     #   |- dir_2
     #   |   |   empty

--- a/tests/utils/utils.py
+++ b/tests/utils/utils.py
@@ -136,6 +136,8 @@ async def compare_remote_dirs(
             await (src_path / src_file).checksum()
             == await (dst_path / dst_file).checksum()
         )
+        if await (src_path / src_file).is_executable():
+            assert await (dst_path / dst_file).is_executable()
     assert len(src_dirs) == len(dst_dirs)
     tasks = []
     for src_dir, dst_dir in zip(sorted(src_dirs), sorted(dst_dirs), strict=True):


### PR DESCRIPTION
Preserve file and directory permissions when transferring data between locations. This adds `chmod` and `is_executable` methods to the path abstraction layer, enables the `-p` flag in tar extraction commands and `numeric_owner=True`, and applies `os.chmod` in the local extraction path. Tests are updated to verify executable bit preservation after transfer.