### PR TITLE
Fix in-memory fs mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix in-memory fs mounts ([#1102](https://github.com/alpha-unito/streamflow/pull/1102))
 - Fix double-counting of occupied disk space ([#1103](https://github.com/alpha-unito/streamflow/pull/1103))
 - Fix NodeJS retrieval when Docker is unavailable ([#1054](https://github.com/alpha-unito/streamflow/pull/1054))
 - Fix permission propagation when transferring files between locations ([#1085](https://github.com/alpha-unito/streamflow/pull/1085))

--- a/streamflow/core/scheduling.py
+++ b/streamflow/core/scheduling.py
@@ -41,7 +41,7 @@ def _reduce_storages(
                 size=disk.size,
                 paths=disk.paths,
                 bind=disk.bind,
-                inmemory_usage=disk.inmemory_usage,
+                memory_usage=disk.memory_usage,
             )
     return storage
 
@@ -173,16 +173,16 @@ class Hardware:
             ) and (
                 self.memory
                 - sum(
-                    s.inmemory_usage
+                    s.memory_usage
                     for s in self_norm.values()
-                    if s.inmemory_usage is not None
+                    if s.memory_usage is not None
                 )
                 >= (
                     other.memory
                     + sum(
                         other_disk.size
                         for other_disk in other_norm.values()
-                        if other_disk.inmemory_usage is not None
+                        if other_disk.memory_usage is not None
                     )
                 )
             )
@@ -396,7 +396,7 @@ class Scheduler(SchemaEntity):
 
 
 class Storage:
-    __slots__ = ("mount_point", "size", "paths", "bind", "inmemory_usage")
+    __slots__ = ("mount_point", "size", "paths", "bind", "memory_usage")
 
     def __init__(
         self,
@@ -404,7 +404,7 @@ class Storage:
         size: float,
         paths: AbstractSet[str] | None = None,
         bind: str | None = None,
-        inmemory_usage: float | None = None,
+        memory_usage: float | None = None,
     ):
         """
         The `Storage` class represents a persistent volume
@@ -413,7 +413,8 @@ class Storage:
         :param size: the total size of the volume, expressed in Kilobyte
         :param paths: a list of paths inside the volume
         :param bind: the path bound by the volume, if any
-        :param inmemory_usage: amount of RAM consumed by files on this in-memory volume (None for non-in-memory volumes)
+        :param memory_usage: amount of memory consumed by files on the
+                             in-memory volume (None for a non-in-memory volume)
         """
         self.mount_point: str = mount_point
         self.paths: MutableSet[str] = paths or set()
@@ -423,7 +424,7 @@ class Storage:
             )
         self.size: float = size
         self.bind: str | None = bind
-        self.inmemory_usage: float | None = inmemory_usage
+        self.memory_usage: float | None = memory_usage
 
     def add_path(self, path: str) -> None:
         self.paths.add(path)
@@ -431,7 +432,7 @@ class Storage:
     def __repr__(self) -> str:
         return (
             f"Storage(mount_point={self.mount_point}, size={self.size}, "
-            f"bind={self.bind}, inmemory_usage={self.inmemory_usage}, paths={self.paths})"
+            f"bind={self.bind}, memory_usage={self.memory_usage}, paths={self.paths})"
         )
 
     def __add__(self, other: Any) -> Storage:
@@ -446,10 +447,10 @@ class Storage:
             size=self.size + other.size,
             paths=self.paths | other.paths,
             bind=self.bind,
-            inmemory_usage=(
+            memory_usage=(
                 None
-                if self.inmemory_usage is None and other.inmemory_usage is None
-                else (self.inmemory_usage or 0.0) + (other.inmemory_usage or 0.0)
+                if self.memory_usage is None and other.memory_usage is None
+                else (self.memory_usage or 0.0) + (other.memory_usage or 0.0)
             ),
         )
 
@@ -462,8 +463,8 @@ class Storage:
             )
         self.size = max(self.size, other.size)
         self.paths |= other.paths
-        if self.inmemory_usage is None:
-            self.inmemory_usage = other.inmemory_usage
+        if self.memory_usage is None:
+            self.memory_usage = other.memory_usage
         return self
 
     def __or__(self, other: Storage) -> Storage:
@@ -478,10 +479,10 @@ class Storage:
             size=max(self.size, other.size),
             paths=self.paths | other.paths,
             bind=self.bind,
-            inmemory_usage=(
-                self.inmemory_usage
-                if self.inmemory_usage is not None
-                else other.inmemory_usage
+            memory_usage=(
+                self.memory_usage
+                if self.memory_usage is not None
+                else other.memory_usage
             ),
         )
 
@@ -497,9 +498,9 @@ class Storage:
             size=self.size - other.size,
             paths=self.paths | other.paths,
             bind=self.bind,
-            inmemory_usage=(
+            memory_usage=(
                 None
-                if self.inmemory_usage is None and other.inmemory_usage is None
-                else max(self.inmemory_usage or 0.0, other.inmemory_usage or 0.0)
+                if self.memory_usage is None and other.memory_usage is None
+                else max(self.memory_usage or 0.0, other.memory_usage or 0.0)
             ),
         )

--- a/streamflow/core/scheduling.py
+++ b/streamflow/core/scheduling.py
@@ -41,6 +41,7 @@ def _reduce_storages(
                 size=disk.size,
                 paths=disk.paths,
                 bind=disk.bind,
+                in_memory=disk.in_memory,
             )
     return storage
 
@@ -159,7 +160,7 @@ class Hardware:
         """Check if this hardware has enough resources to satisfy the requirement."""
         if not isinstance(other, Hardware):
             raise NotImplementedError
-        if self.cores >= other.cores and self.memory >= other.memory:
+        if self.cores >= other.cores:
             if set((other_norm := other._normalize_storage()).keys()) - set(
                 (self_norm := self._normalize_storage()).keys()
             ):
@@ -169,6 +170,16 @@ class Hardware:
             return all(
                 self_norm[other_disk.mount_point].size >= other_disk.size
                 for other_disk in other_norm.values()
+            ) and (
+                self.memory
+                >= (
+                    other.memory
+                    + sum(
+                        other_disk.size
+                        for other_disk in other_norm.values()
+                        if other_disk.in_memory
+                    )
+                )
             )
         else:
             return False
@@ -380,7 +391,7 @@ class Scheduler(SchemaEntity):
 
 
 class Storage:
-    __slots__ = ("mount_point", "size", "paths", "bind")
+    __slots__ = ("mount_point", "size", "paths", "bind", "in_memory")
 
     def __init__(
         self,
@@ -388,6 +399,7 @@ class Storage:
         size: float,
         paths: AbstractSet[str] | None = None,
         bind: str | None = None,
+        in_memory: bool = False,
     ):
         """
         The `Storage` class represents a persistent volume
@@ -396,6 +408,7 @@ class Storage:
         :param size: the total size of the volume, expressed in Kilobyte
         :param paths: a list of paths inside the volume
         :param bind: the path bound by the volume, if any
+        :param in_memory: whether the volume is in memory
         """
         self.mount_point: str = mount_point
         self.paths: MutableSet[str] = paths or set()
@@ -405,12 +418,16 @@ class Storage:
             )
         self.size: float = size
         self.bind: str | None = bind
+        self.in_memory: bool = in_memory
 
     def add_path(self, path: str) -> None:
         self.paths.add(path)
 
     def __repr__(self) -> str:
-        return f"Storage(mount_point={self.mount_point}, size={self.size}, bind={self.bind}, paths={self.paths})"
+        return (
+            f"Storage(mount_point={self.mount_point}, size={self.size}, "
+            f"bind={self.bind}, in_memory={self.in_memory}, paths={self.paths})"
+        )
 
     def __add__(self, other: Any) -> Storage:
         if not isinstance(other, Storage):
@@ -424,6 +441,7 @@ class Storage:
             size=self.size + other.size,
             paths=self.paths | other.paths,
             bind=self.bind,
+            in_memory=self.in_memory,
         )
 
     def __ior__(self, other: Storage) -> Self:
@@ -449,6 +467,7 @@ class Storage:
             size=max(self.size, other.size),
             paths=self.paths | other.paths,
             bind=self.bind,
+            in_memory=self.in_memory,
         )
 
     def __sub__(self, other: Any) -> Storage:
@@ -463,4 +482,5 @@ class Storage:
             size=self.size - other.size,
             paths=self.paths | other.paths,
             bind=self.bind,
+            in_memory=self.in_memory,
         )

--- a/streamflow/core/scheduling.py
+++ b/streamflow/core/scheduling.py
@@ -42,6 +42,7 @@ def _reduce_storages(
                 paths=disk.paths,
                 bind=disk.bind,
                 in_memory=disk.in_memory,
+                usage=disk.usage,
             )
     return storage
 
@@ -171,7 +172,7 @@ class Hardware:
                 self_norm[other_disk.mount_point].size >= other_disk.size
                 for other_disk in other_norm.values()
             ) and (
-                self.memory
+                self.memory - sum(s.usage for s in self_norm.values() if s.in_memory)
                 >= (
                     other.memory
                     + sum(
@@ -391,7 +392,7 @@ class Scheduler(SchemaEntity):
 
 
 class Storage:
-    __slots__ = ("mount_point", "size", "paths", "bind", "in_memory")
+    __slots__ = ("mount_point", "size", "paths", "bind", "in_memory", "usage")
 
     def __init__(
         self,
@@ -400,6 +401,7 @@ class Storage:
         paths: AbstractSet[str] | None = None,
         bind: str | None = None,
         in_memory: bool = False,
+        usage: float = 0.0,
     ):
         """
         The `Storage` class represents a persistent volume
@@ -409,6 +411,7 @@ class Storage:
         :param paths: a list of paths inside the volume
         :param bind: the path bound by the volume, if any
         :param in_memory: whether the volume is in memory
+        :param usage: amount of volume capacity currently in use, in MB
         """
         self.mount_point: str = mount_point
         self.paths: MutableSet[str] = paths or set()
@@ -419,6 +422,7 @@ class Storage:
         self.size: float = size
         self.bind: str | None = bind
         self.in_memory: bool = in_memory
+        self.usage: float = usage
 
     def add_path(self, path: str) -> None:
         self.paths.add(path)
@@ -441,7 +445,8 @@ class Storage:
             size=self.size + other.size,
             paths=self.paths | other.paths,
             bind=self.bind,
-            in_memory=self.in_memory,
+            in_memory=self.in_memory or other.in_memory,
+            usage=self.usage + other.usage,
         )
 
     def __ior__(self, other: Storage) -> Self:
@@ -453,6 +458,7 @@ class Storage:
             )
         self.size = max(self.size, other.size)
         self.paths |= other.paths
+        self.in_memory |= other.in_memory
         return self
 
     def __or__(self, other: Storage) -> Storage:
@@ -467,7 +473,7 @@ class Storage:
             size=max(self.size, other.size),
             paths=self.paths | other.paths,
             bind=self.bind,
-            in_memory=self.in_memory,
+            in_memory=self.in_memory or other.in_memory,
         )
 
     def __sub__(self, other: Any) -> Storage:
@@ -483,4 +489,5 @@ class Storage:
             paths=self.paths | other.paths,
             bind=self.bind,
             in_memory=self.in_memory,
+            usage=max(self.usage, other.usage),
         )

--- a/streamflow/core/scheduling.py
+++ b/streamflow/core/scheduling.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import copy
 import os
 from abc import ABC, abstractmethod
 from collections.abc import (
@@ -41,7 +40,7 @@ def _reduce_storages(
                 size=disk.size,
                 paths=disk.paths,
                 bind=disk.bind,
-                memory_usage=disk.memory_usage,
+                in_memory=disk.in_memory,
             )
     return storage
 
@@ -95,25 +94,6 @@ class Hardware:
             ),
         )
 
-    def __ior__(self, other: Hardware) -> Self:
-        if not isinstance(other, Hardware):
-            raise NotImplementedError
-        self.cores += other.cores
-        self.memory += other.memory
-        for key, disk in other.storage.items():
-            if key not in self.storage.keys():
-                self.storage[key] = disk
-            else:
-                self.storage[key] |= disk
-        return self
-
-    def __or__(self, other: Hardware) -> Hardware:
-        if not isinstance(other, Hardware):
-            raise NotImplementedError
-        hardware = copy.deepcopy(self)
-        hardware |= other
-        return hardware
-
     def __sub__(self, other: Hardware) -> Hardware:
         if not isinstance(other, Hardware):
             raise NotImplementedError
@@ -160,7 +140,7 @@ class Hardware:
         """Check if this hardware has enough resources to satisfy the requirement."""
         if not isinstance(other, Hardware):
             raise NotImplementedError
-        if self.cores >= other.cores:
+        if self.cores >= other.cores and self.memory >= other.memory:
             if set((other_norm := other._normalize_storage()).keys()) - set(
                 (self_norm := self._normalize_storage()).keys()
             ):
@@ -170,21 +150,6 @@ class Hardware:
             return all(
                 self_norm[other_disk.mount_point].size >= other_disk.size
                 for other_disk in other_norm.values()
-            ) and (
-                self.memory
-                - sum(
-                    s.memory_usage
-                    for s in self_norm.values()
-                    if s.memory_usage is not None
-                )
-                >= (
-                    other.memory
-                    + sum(
-                        other_disk.size
-                        for other_disk in other_norm.values()
-                        if other_disk.memory_usage is not None
-                    )
-                )
             )
         else:
             return False
@@ -396,7 +361,7 @@ class Scheduler(SchemaEntity):
 
 
 class Storage:
-    __slots__ = ("mount_point", "size", "paths", "bind", "memory_usage")
+    __slots__ = ("mount_point", "size", "paths", "bind", "in_memory")
 
     def __init__(
         self,
@@ -404,17 +369,16 @@ class Storage:
         size: float,
         paths: AbstractSet[str] | None = None,
         bind: str | None = None,
-        memory_usage: float | None = None,
+        in_memory: bool = False,
     ):
         """
         The `Storage` class represents a persistent volume
 
         :param mount_point: the path of the volume's mount point
-        :param size: the total size of the volume, expressed in Kilobyte
+        :param size: the total size of the volume, expressed in MB
         :param paths: a list of paths inside the volume
         :param bind: the path bound by the volume, if any
-        :param memory_usage: amount of memory consumed by files on the
-                             in-memory volume (None for a non-in-memory volume)
+        :param in_memory: whether the volume is in memory
         """
         self.mount_point: str = mount_point
         self.paths: MutableSet[str] = paths or set()
@@ -424,7 +388,7 @@ class Storage:
             )
         self.size: float = size
         self.bind: str | None = bind
-        self.memory_usage: float | None = memory_usage
+        self.in_memory: bool = in_memory
 
     def add_path(self, path: str) -> None:
         self.paths.add(path)
@@ -432,7 +396,7 @@ class Storage:
     def __repr__(self) -> str:
         return (
             f"Storage(mount_point={self.mount_point}, size={self.size}, "
-            f"bind={self.bind}, memory_usage={self.memory_usage}, paths={self.paths})"
+            f"bind={self.bind}, in_memory={self.in_memory}, paths={self.paths})"
         )
 
     def __add__(self, other: Any) -> Storage:
@@ -447,43 +411,7 @@ class Storage:
             size=self.size + other.size,
             paths=self.paths | other.paths,
             bind=self.bind,
-            memory_usage=(
-                None
-                if self.memory_usage is None and other.memory_usage is None
-                else (self.memory_usage or 0.0) + (other.memory_usage or 0.0)
-            ),
-        )
-
-    def __ior__(self, other: Storage) -> Self:
-        if not isinstance(other, Storage):
-            raise NotImplementedError
-        if self.mount_point != other.mount_point:
-            raise ArithmeticError(
-                f"Cannot merge two storages with different mount points: {self.mount_point} and {other.mount_point}"
-            )
-        self.size = max(self.size, other.size)
-        self.paths |= other.paths
-        if self.memory_usage is None:
-            self.memory_usage = other.memory_usage
-        return self
-
-    def __or__(self, other: Storage) -> Storage:
-        if not isinstance(other, Storage):
-            raise NotImplementedError
-        if self.mount_point != other.mount_point:
-            raise ArithmeticError(
-                f"Cannot merge two storages with different mount points: {self.mount_point} and {other.mount_point}"
-            )
-        return Storage(
-            mount_point=self.mount_point,
-            size=max(self.size, other.size),
-            paths=self.paths | other.paths,
-            bind=self.bind,
-            memory_usage=(
-                self.memory_usage
-                if self.memory_usage is not None
-                else other.memory_usage
-            ),
+            in_memory=self.in_memory or other.in_memory,
         )
 
     def __sub__(self, other: Any) -> Storage:
@@ -498,9 +426,5 @@ class Storage:
             size=self.size - other.size,
             paths=self.paths | other.paths,
             bind=self.bind,
-            memory_usage=(
-                None
-                if self.memory_usage is None and other.memory_usage is None
-                else max(self.memory_usage or 0.0, other.memory_usage or 0.0)
-            ),
+            in_memory=self.in_memory or other.in_memory,
         )

--- a/streamflow/core/scheduling.py
+++ b/streamflow/core/scheduling.py
@@ -41,8 +41,7 @@ def _reduce_storages(
                 size=disk.size,
                 paths=disk.paths,
                 bind=disk.bind,
-                in_memory=disk.in_memory,
-                usage=disk.usage,
+                inmemory_usage=disk.inmemory_usage,
             )
     return storage
 
@@ -172,13 +171,18 @@ class Hardware:
                 self_norm[other_disk.mount_point].size >= other_disk.size
                 for other_disk in other_norm.values()
             ) and (
-                self.memory - sum(s.usage for s in self_norm.values() if s.in_memory)
+                self.memory
+                - sum(
+                    s.inmemory_usage
+                    for s in self_norm.values()
+                    if s.inmemory_usage is not None
+                )
                 >= (
                     other.memory
                     + sum(
                         other_disk.size
                         for other_disk in other_norm.values()
-                        if other_disk.in_memory
+                        if other_disk.inmemory_usage is not None
                     )
                 )
             )
@@ -392,7 +396,7 @@ class Scheduler(SchemaEntity):
 
 
 class Storage:
-    __slots__ = ("mount_point", "size", "paths", "bind", "in_memory", "usage")
+    __slots__ = ("mount_point", "size", "paths", "bind", "inmemory_usage")
 
     def __init__(
         self,
@@ -400,8 +404,7 @@ class Storage:
         size: float,
         paths: AbstractSet[str] | None = None,
         bind: str | None = None,
-        in_memory: bool = False,
-        usage: float = 0.0,
+        inmemory_usage: float | None = None,
     ):
         """
         The `Storage` class represents a persistent volume
@@ -410,8 +413,7 @@ class Storage:
         :param size: the total size of the volume, expressed in Kilobyte
         :param paths: a list of paths inside the volume
         :param bind: the path bound by the volume, if any
-        :param in_memory: whether the volume is in memory
-        :param usage: amount of volume capacity currently in use, in MB
+        :param inmemory_usage: amount of RAM consumed by files on this in-memory volume (None for non-in-memory volumes)
         """
         self.mount_point: str = mount_point
         self.paths: MutableSet[str] = paths or set()
@@ -421,8 +423,7 @@ class Storage:
             )
         self.size: float = size
         self.bind: str | None = bind
-        self.in_memory: bool = in_memory
-        self.usage: float = usage
+        self.inmemory_usage: float | None = inmemory_usage
 
     def add_path(self, path: str) -> None:
         self.paths.add(path)
@@ -430,7 +431,7 @@ class Storage:
     def __repr__(self) -> str:
         return (
             f"Storage(mount_point={self.mount_point}, size={self.size}, "
-            f"bind={self.bind}, in_memory={self.in_memory}, paths={self.paths})"
+            f"bind={self.bind}, inmemory_usage={self.inmemory_usage}, paths={self.paths})"
         )
 
     def __add__(self, other: Any) -> Storage:
@@ -445,8 +446,11 @@ class Storage:
             size=self.size + other.size,
             paths=self.paths | other.paths,
             bind=self.bind,
-            in_memory=self.in_memory or other.in_memory,
-            usage=self.usage + other.usage,
+            inmemory_usage=(
+                None
+                if self.inmemory_usage is None and other.inmemory_usage is None
+                else (self.inmemory_usage or 0.0) + (other.inmemory_usage or 0.0)
+            ),
         )
 
     def __ior__(self, other: Storage) -> Self:
@@ -458,7 +462,8 @@ class Storage:
             )
         self.size = max(self.size, other.size)
         self.paths |= other.paths
-        self.in_memory |= other.in_memory
+        if self.inmemory_usage is None:
+            self.inmemory_usage = other.inmemory_usage
         return self
 
     def __or__(self, other: Storage) -> Storage:
@@ -473,7 +478,11 @@ class Storage:
             size=max(self.size, other.size),
             paths=self.paths | other.paths,
             bind=self.bind,
-            in_memory=self.in_memory or other.in_memory,
+            inmemory_usage=(
+                self.inmemory_usage
+                if self.inmemory_usage is not None
+                else other.inmemory_usage
+            ),
         )
 
     def __sub__(self, other: Any) -> Storage:
@@ -488,6 +497,9 @@ class Storage:
             size=self.size - other.size,
             paths=self.paths | other.paths,
             bind=self.bind,
-            in_memory=self.in_memory,
-            usage=max(self.usage, other.usage),
+            inmemory_usage=(
+                None
+                if self.inmemory_usage is None and other.inmemory_usage is None
+                else max(self.inmemory_usage or 0.0, other.inmemory_usage or 0.0)
+            ),
         )

--- a/streamflow/data/utils.py
+++ b/streamflow/data/utils.py
@@ -45,7 +45,7 @@ async def bind_mount_point(
                     )
                     for p in disk.paths
                 },
-                in_memory=disk.in_memory,
+                memory_usage=disk.memory_usage,
             )
             if mount_point in storages:
                 storages[mount_point] += storage

--- a/streamflow/data/utils.py
+++ b/streamflow/data/utils.py
@@ -45,6 +45,7 @@ async def bind_mount_point(
                     )
                     for p in disk.paths
                 },
+                in_memory=disk.in_memory,
             )
             if mount_point in storages:
                 storages[mount_point] += storage

--- a/streamflow/data/utils.py
+++ b/streamflow/data/utils.py
@@ -45,7 +45,7 @@ async def bind_mount_point(
                     )
                     for p in disk.paths
                 },
-                memory_usage=disk.memory_usage,
+                in_memory=disk.in_memory,
             )
             if mount_point in storages:
                 storages[mount_point] += storage

--- a/streamflow/deployment/connector/base.py
+++ b/streamflow/deployment/connector/base.py
@@ -23,6 +23,13 @@ from streamflow.deployment.shell import BaseShell
 from streamflow.deployment.stream import BaseStreamWrapper
 from streamflow.log_handler import logger
 
+IN_MEMORY_FS_TYPES = {
+    "devtmpfs",
+    "hugetlbfs",
+    "ramfs",
+    "tmpfs",
+}
+
 FS_TYPES_TO_SKIP = {
     "-",
     "bpf",
@@ -31,16 +38,12 @@ FS_TYPES_TO_SKIP = {
     "configfs",
     "debugfs",
     "devpts",
-    "devtmpfs",
     "fusectl",
-    "hugetlbfs",
     "mqueue",
     "proc",
-    "pstore",
     "securityfs",
     "selinuxfs",
     "sysfs",
-    "tmpfs",
     "tracefs",
 }
 

--- a/streamflow/deployment/connector/base.py
+++ b/streamflow/deployment/connector/base.py
@@ -41,6 +41,7 @@ FS_TYPES_TO_SKIP = {
     "fusectl",
     "mqueue",
     "proc",
+    "pstore",
     "securityfs",
     "selinuxfs",
     "sysfs",

--- a/streamflow/deployment/connector/container.py
+++ b/streamflow/deployment/connector/container.py
@@ -88,7 +88,7 @@ async def _get_storage_from_binds(
                     storage[mount_point] = Storage(
                         mount_point=mount_point,
                         size=float(size) / 2**10,
-                        inmemory_usage=0.0 if fs_type in IN_MEMORY_FS_TYPES else None,
+                        memory_usage=0.0 if fs_type in IN_MEMORY_FS_TYPES else None,
                     )
                     if mount_point in binds:
                         storage[mount_point].bind = binds[mount_point]

--- a/streamflow/deployment/connector/container.py
+++ b/streamflow/deployment/connector/container.py
@@ -88,7 +88,7 @@ async def _get_storage_from_binds(
                     storage[mount_point] = Storage(
                         mount_point=mount_point,
                         size=float(size) / 2**10,
-                        memory_usage=0.0 if fs_type in IN_MEMORY_FS_TYPES else None,
+                        in_memory=fs_type in IN_MEMORY_FS_TYPES,
                     )
                     if mount_point in binds:
                         storage[mount_point].bind = binds[mount_point]

--- a/streamflow/deployment/connector/container.py
+++ b/streamflow/deployment/connector/container.py
@@ -34,6 +34,7 @@ from streamflow.core.utils import (
 )
 from streamflow.deployment.connector.base import (
     FS_TYPES_TO_SKIP,
+    IN_MEMORY_FS_TYPES,
     BatchConnector,
     copy_local_to_remote,
     copy_remote_to_local,
@@ -87,6 +88,7 @@ async def _get_storage_from_binds(
                     storage[mount_point] = Storage(
                         mount_point=mount_point,
                         size=float(size) / 2**10,
+                        in_memory=fs_type in IN_MEMORY_FS_TYPES,
                     )
                     if mount_point in binds:
                         storage[mount_point].bind = binds[mount_point]

--- a/streamflow/deployment/connector/container.py
+++ b/streamflow/deployment/connector/container.py
@@ -88,7 +88,7 @@ async def _get_storage_from_binds(
                     storage[mount_point] = Storage(
                         mount_point=mount_point,
                         size=float(size) / 2**10,
-                        in_memory=fs_type in IN_MEMORY_FS_TYPES,
+                        inmemory_usage=0.0 if fs_type in IN_MEMORY_FS_TYPES else None,
                     )
                     if mount_point in binds:
                         storage[mount_point].bind = binds[mount_point]

--- a/streamflow/deployment/connector/local.py
+++ b/streamflow/deployment/connector/local.py
@@ -69,9 +69,7 @@ class LocalConnector(BaseConnector):
                     storage[disk.mountpoint] = Storage(
                         mount_point=disk.mountpoint,
                         size=shutil.disk_usage(disk.mountpoint).free / 2**20,
-                        memory_usage=(
-                            0.0 if disk.fstype in IN_MEMORY_FS_TYPES else None
-                        ),
+                        in_memory=disk.fstype in IN_MEMORY_FS_TYPES,
                     )
                 except (PermissionError, TimeoutError) as e:
                     logger.warning(

--- a/streamflow/deployment/connector/local.py
+++ b/streamflow/deployment/connector/local.py
@@ -69,7 +69,9 @@ class LocalConnector(BaseConnector):
                     storage[disk.mountpoint] = Storage(
                         mount_point=disk.mountpoint,
                         size=shutil.disk_usage(disk.mountpoint).free / 2**20,
-                        in_memory=disk.fstype in IN_MEMORY_FS_TYPES,
+                        inmemory_usage=(
+                            0.0 if disk.fstype in IN_MEMORY_FS_TYPES else None
+                        ),
                     )
                 except (PermissionError, TimeoutError) as e:
                     logger.warning(

--- a/streamflow/deployment/connector/local.py
+++ b/streamflow/deployment/connector/local.py
@@ -69,7 +69,7 @@ class LocalConnector(BaseConnector):
                     storage[disk.mountpoint] = Storage(
                         mount_point=disk.mountpoint,
                         size=shutil.disk_usage(disk.mountpoint).free / 2**20,
-                        inmemory_usage=(
+                        memory_usage=(
                             0.0 if disk.fstype in IN_MEMORY_FS_TYPES else None
                         ),
                     )

--- a/streamflow/deployment/connector/local.py
+++ b/streamflow/deployment/connector/local.py
@@ -17,7 +17,11 @@ import psutil
 from streamflow.core import utils
 from streamflow.core.deployment import Connector, ExecutionLocation
 from streamflow.core.scheduling import AvailableLocation, Hardware, Storage
-from streamflow.deployment.connector.base import FS_TYPES_TO_SKIP, BaseConnector
+from streamflow.deployment.connector.base import (
+    FS_TYPES_TO_SKIP,
+    IN_MEMORY_FS_TYPES,
+    BaseConnector,
+)
 from streamflow.log_handler import logger
 
 
@@ -65,6 +69,7 @@ class LocalConnector(BaseConnector):
                     storage[disk.mountpoint] = Storage(
                         mount_point=disk.mountpoint,
                         size=shutil.disk_usage(disk.mountpoint).free / 2**20,
+                        in_memory=disk.fstype in IN_MEMORY_FS_TYPES,
                     )
                 except (PermissionError, TimeoutError) as e:
                     logger.warning(

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -21,6 +21,7 @@ from streamflow.core.exception import WorkflowExecutionException
 from streamflow.core.scheduling import AvailableLocation, Hardware, Storage
 from streamflow.deployment.connector.base import (
     FS_TYPES_TO_SKIP,
+    IN_MEMORY_FS_TYPES,
     BaseConnector,
     copy_remote_to_remote,
     copy_same_connector,
@@ -537,6 +538,7 @@ class SSHConnector(BaseConnector):
                                 self.hardware[location].storage[mount_point] = Storage(
                                     mount_point=mount_point,
                                     size=float(size) / 2**10,
+                                    in_memory=fs_type in IN_MEMORY_FS_TYPES,
                                 )
                         except ValueError as e:
                             logger.warning(

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -538,9 +538,7 @@ class SSHConnector(BaseConnector):
                                 self.hardware[location].storage[mount_point] = Storage(
                                     mount_point=mount_point,
                                     size=float(size) / 2**10,
-                                    memory_usage=(
-                                        0.0 if fs_type in IN_MEMORY_FS_TYPES else None
-                                    ),
+                                    in_memory=fs_type in IN_MEMORY_FS_TYPES,
                                 )
                         except ValueError as e:
                             logger.warning(

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -538,7 +538,9 @@ class SSHConnector(BaseConnector):
                                 self.hardware[location].storage[mount_point] = Storage(
                                     mount_point=mount_point,
                                     size=float(size) / 2**10,
-                                    in_memory=fs_type in IN_MEMORY_FS_TYPES,
+                                    inmemory_usage=(
+                                        0.0 if fs_type in IN_MEMORY_FS_TYPES else None
+                                    ),
                                 )
                         except ValueError as e:
                             logger.warning(

--- a/streamflow/deployment/connector/ssh.py
+++ b/streamflow/deployment/connector/ssh.py
@@ -538,7 +538,7 @@ class SSHConnector(BaseConnector):
                                 self.hardware[location].storage[mount_point] = Storage(
                                     mount_point=mount_point,
                                     size=float(size) / 2**10,
-                                    inmemory_usage=(
+                                    memory_usage=(
                                         0.0 if fs_type in IN_MEMORY_FS_TYPES else None
                                     ),
                                 )

--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -139,18 +139,25 @@ class DefaultScheduler(Scheduler):
             for loc in locations:
                 if loc.name in self.hardware_locations.keys():
                     try:
+                        job_norm_hw = Hardware() + job_hardware
                         storage_usage = Hardware(
                             storage=(
                                 {
                                     k: Storage(
-                                        mount_point=job_hardware.storage[k].mount_point,
+                                        mount_point=job_norm_hw.storage[k].mount_point,
                                         size=size / 2**20,
+                                        in_memory=job_norm_hw.storage[k].in_memory,
+                                        usage=(
+                                            size / 2**20
+                                            if job_norm_hw.storage[k].in_memory
+                                            else 0.0
+                                        ),
                                     )
                                     for k, size in (
                                         await remotepath.get_storage_usages(
                                             self.context,
                                             loc,
-                                            job_hardware,
+                                            job_norm_hw,
                                         )
                                     ).items()
                                 }

--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -146,11 +146,11 @@ class DefaultScheduler(Scheduler):
                                     k: Storage(
                                         mount_point=job_norm_hw.storage[k].mount_point,
                                         size=size / 2**20,
-                                        in_memory=job_norm_hw.storage[k].in_memory,
-                                        usage=(
+                                        inmemory_usage=(
                                             size / 2**20
-                                            if job_norm_hw.storage[k].in_memory
-                                            else 0.0
+                                            if job_norm_hw.storage[k].inmemory_usage
+                                            is not None
+                                            else None
                                         ),
                                     )
                                     for k, size in (
@@ -442,7 +442,7 @@ class DefaultScheduler(Scheduler):
                             size=disk.size,
                             paths={path},
                             bind=loc_storage.bind,
-                            in_memory=loc_storage.in_memory,
+                            inmemory_usage=loc_storage.inmemory_usage,
                         )
                 current_hw = Hardware(
                     cores=hardware_requirement.cores,
@@ -529,11 +529,16 @@ class DefaultScheduler(Scheduler):
             )
             for target in targets
         ]
-        # Capture finished tasks and call result() to check for exceptions
-        finished, _ = await asyncio.wait(
-            wait_tasks, return_when=asyncio.FIRST_COMPLETED
-        )
-        for task in finished:
-            if task.cancelled():
-                continue
-            task.result()
+        try:
+            # Capture finished tasks and call result() to check for exceptions
+            finished, _ = await asyncio.wait(
+                wait_tasks, return_when=asyncio.FIRST_COMPLETED
+            )
+            for task in finished:
+                if task.cancelled():
+                    continue
+                task.result()
+        finally:
+            for task in wait_tasks:
+                if not task.done():
+                    task.cancel()

--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -429,11 +429,13 @@ class DefaultScheduler(Scheduler):
                         mount_point = await utils.get_mount_point(
                             self.context, location, path
                         )
+                        loc_storage = location.hardware.get_storage(mount_point)
                         storage[key] = Storage(
                             mount_point=mount_point,
                             size=disk.size,
                             paths={path},
-                            bind=location.hardware.get_storage(mount_point).bind,
+                            bind=loc_storage.bind,
+                            in_memory=loc_storage.in_memory,
                         )
                 current_hw = Hardware(
                     cores=hardware_requirement.cores,

--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -139,38 +139,35 @@ class DefaultScheduler(Scheduler):
             for loc in locations:
                 if loc.name in self.hardware_locations.keys():
                     try:
-                        storage_usage = Hardware(
+                        storage_usage = await remotepath.get_storage_usages(
+                            self.context, loc, job_hardware
+                        )
+                        hardware_usage = Hardware(
+                            memory=sum(
+                                size / 2**20
+                                for k, size in storage_usage.items()
+                                if job_hardware.storage[k].in_memory
+                            ),
                             storage=(
                                 {
                                     k: Storage(
                                         mount_point=job_hardware.storage[k].mount_point,
                                         size=size / 2**20,
-                                        memory_usage=(
-                                            size / 2**20
-                                            if job_hardware.storage[k].memory_usage
-                                            is not None
-                                            else None
-                                        ),
+                                        in_memory=job_hardware.storage[k].in_memory,
                                     )
-                                    for k, size in (
-                                        await remotepath.get_storage_usages(
-                                            self.context,
-                                            loc,
-                                            job_hardware,
-                                        )
-                                    ).items()
+                                    for k, size in storage_usage.items()
                                 }
-                            )
+                            ),
                         )
                     except WorkflowExecutionException as err:
                         logger.warning(
                             f"Impossible to retrieve the actual storage usage in "
                             f"the {job_allocation.job} job working directories: {err}"
                         )
-                        storage_usage = Hardware()
+                        hardware_usage = Hardware()
                     self.hardware_locations[loc.name] = (
                         self.hardware_locations[loc.name] - job_hardware
-                    ) + storage_usage
+                    ) + hardware_usage
             if locations := [loc.wraps for loc in locations if loc.stacked]:
                 conn = cast(ConnectorWrapper, conn).connector
                 for execution_loc in locations:
@@ -348,7 +345,9 @@ class DefaultScheduler(Scheduler):
                             if key not in hardware_requirements:
                                 hardware_requirements[key] = hardware
                             else:
-                                hardware_requirements[key] |= hardware
+                                # Two stacked locations can have the same location below.
+                                # Thus, the underline location must have enough resources for both.
+                                hardware_requirements[key] += hardware
                     valid_locations = {
                         k: loc
                         for k, loc in available_locations.items()
@@ -441,11 +440,12 @@ class DefaultScheduler(Scheduler):
                             size=disk.size,
                             paths={path},
                             bind=loc_storage.bind,
-                            memory_usage=loc_storage.memory_usage,
+                            in_memory=loc_storage.in_memory,
                         )
                 current_hw = Hardware(
                     cores=hardware_requirement.cores,
-                    memory=hardware_requirement.memory,
+                    memory=hardware_requirement.memory
+                    + sum(s.size for s in storage.values() if s.in_memory),
                     storage=storage,
                 )
             # Otherwise, simply add the requirement as is

--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -139,16 +139,15 @@ class DefaultScheduler(Scheduler):
             for loc in locations:
                 if loc.name in self.hardware_locations.keys():
                     try:
-                        job_norm_hw = Hardware() + job_hardware
                         storage_usage = Hardware(
                             storage=(
                                 {
                                     k: Storage(
-                                        mount_point=job_norm_hw.storage[k].mount_point,
+                                        mount_point=job_hardware.storage[k].mount_point,
                                         size=size / 2**20,
-                                        inmemory_usage=(
+                                        memory_usage=(
                                             size / 2**20
-                                            if job_norm_hw.storage[k].inmemory_usage
+                                            if job_hardware.storage[k].memory_usage
                                             is not None
                                             else None
                                         ),
@@ -157,7 +156,7 @@ class DefaultScheduler(Scheduler):
                                         await remotepath.get_storage_usages(
                                             self.context,
                                             loc,
-                                            job_norm_hw,
+                                            job_hardware,
                                         )
                                     ).items()
                                 }
@@ -442,7 +441,7 @@ class DefaultScheduler(Scheduler):
                             size=disk.size,
                             paths={path},
                             bind=loc_storage.bind,
-                            inmemory_usage=loc_storage.inmemory_usage,
+                            memory_usage=loc_storage.memory_usage,
                         )
                 current_hw = Hardware(
                     cores=hardware_requirement.cores,
@@ -529,16 +528,11 @@ class DefaultScheduler(Scheduler):
             )
             for target in targets
         ]
-        try:
-            # Capture finished tasks and call result() to check for exceptions
-            finished, _ = await asyncio.wait(
-                wait_tasks, return_when=asyncio.FIRST_COMPLETED
-            )
-            for task in finished:
-                if task.cancelled():
-                    continue
-                task.result()
-        finally:
-            for task in wait_tasks:
-                if not task.done():
-                    task.cancel()
+        # Capture finished tasks and call result() to check for exceptions
+        finished, _ = await asyncio.wait(
+            wait_tasks, return_when=asyncio.FIRST_COMPLETED
+        )
+        for task in finished:
+            if task.cancelled():
+                continue
+            task.result()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -370,7 +370,6 @@ async def test_binding_filter(
         context.scheduler.get_allocation(job.name).target.deployment.name
         == docker_config.name
     )
-
     # Job changes status to RUNNING
     await _notify_status_and_test(context, job, Status.RUNNING)
     # Job changes status to COMPLETED
@@ -880,8 +879,7 @@ async def test_shared_stacked_locations(context: StreamFlowContext) -> None:
                 match=f"Could not retrieve allocation for job {jobs[1].name}",
             ):
                 context.scheduler.get_allocation(jobs[1].name)
-            fst_job = jobs[0]
-            snd_job = jobs[1]
+            fst_job, snd_job = jobs[0], jobs[1]
         except WorkflowExecutionException:
             assert (
                 context.scheduler.get_allocation(jobs[1].name).status == Status.FIREABLE
@@ -891,8 +889,7 @@ async def test_shared_stacked_locations(context: StreamFlowContext) -> None:
                 match=f"Could not retrieve allocation for job {jobs[0].name}",
             ):
                 context.scheduler.get_allocation(jobs[0].name)
-            fst_job = jobs[1]
-            snd_job = jobs[0]
+            fst_job, snd_job = jobs[1], jobs[0]
 
         # First job changes status to RUNNING and continue to keep all resources
         # Testing that second job is not scheduled (timeout parameter necessary)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -132,6 +132,7 @@ async def _setup_hardware_test(
     storage: float,
     job_dirs: MutableSequence[tuple[str | None, str | None, str | None]] | None = None,
     inmemory: bool = False,
+    cores: float | None = None,
 ) -> _HardwareTestContext:
     with InjectPlugin(plugin_name="parameterizable-hardware"):
         config = get_parameterizable_hardware_deployment_config(name=random_name())
@@ -140,12 +141,12 @@ async def _setup_hardware_test(
             ParameterizableHardwareConnector,
             context.deployment_manager.get_connector(config.name),
         )
-        disk = Storage(
-            mount_point=os.sep, size=storage, memory_usage=0.0 if inmemory else None
-        )
+        # The allocated in-memory storage must be smaller than the total available memory
+        assert not inmemory or storage < memory
+        disk = Storage(mount_point=os.sep, size=storage, in_memory=inmemory)
         conn.set_hardware(
             hardware=Hardware(
-                cores=float(requirement.cores),
+                cores=cores if cores is not None else float(requirement.cores),
                 memory=memory,
                 storage={os.sep: disk},
             )
@@ -940,11 +941,11 @@ async def test_shared_stacked_locations(context: StreamFlowContext) -> None:
 @pytest.mark.asyncio
 async def test_parallel_in_memory(context: StreamFlowContext) -> None:
     """
-    Verify that in-memory storage prevents parallel job scheduling.
+    Verify that the scheduler accounts for the memory usage of parallel jobs when using in-memory storage.
 
-    Two jobs each need 300 MB effective (100 memory + 200 in_memory storage).
-    With 350 MB total, only one fits at a time. The first job runs, completes,
-    and the second can be scheduled.
+    The location is configured with 4 cores, 500 MB of total memory, and a 400 MB in-memory storage limit.
+    There are two jobs that each require 100 MB of standard memory and 200 MB of in-memory storage.
+    Due to the location's overall memory constraints, only one job can be executed at a time.
     """
     num_jobs = 2
     requirement = CWLHardwareRequirement(
@@ -955,12 +956,13 @@ async def test_parallel_in_memory(context: StreamFlowContext) -> None:
         outdir=100,
     )
     inmemory_ctx = await _setup_hardware_test(
-        context,
-        num_jobs,
-        requirement,
-        memory=350.0,
-        storage=600.0,
+        context=context,
+        num_jobs=num_jobs,
+        requirement=requirement,
+        memory=500.0,
+        storage=400.0,
         inmemory=True,
+        cores=4.0,
     )
     path = None
     try:
@@ -981,8 +983,17 @@ async def test_parallel_in_memory(context: StreamFlowContext) -> None:
         first_job = _get_scheduled_job(context=context, jobs=inmemory_ctx.jobs)
         assert first_job is not None
         second_job = next(j for j in inmemory_ctx.jobs if j is not first_job)
+        # Second job must be blocked (insufficient memory)
+        with pytest.raises(WorkflowExecutionException):
+            context.scheduler.get_allocation(second_job.name)
 
         await context.scheduler.notify_status(first_job.name, Status.RUNNING)
+        _, pending = await asyncio.wait(pending, timeout=2)
+        assert len(pending) == 1
+        # Second job must stay blocked while first runs
+        with pytest.raises(WorkflowExecutionException):
+            context.scheduler.get_allocation(second_job.name)
+
         path = StreamFlowPath(
             first_job.output_directory,
             "persistent.dat",

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -140,7 +140,9 @@ async def _setup_hardware_test(
             ParameterizableHardwareConnector,
             context.deployment_manager.get_connector(config.name),
         )
-        disk = Storage(mount_point=os.sep, size=storage,  inmemory_usage=0.0 if inmemory else None)
+        disk = Storage(
+            mount_point=os.sep, size=storage, memory_usage=0.0 if inmemory else None
+        )
         conn.set_hardware(
             hardware=Hardware(
                 cores=float(requirement.cores),
@@ -933,6 +935,144 @@ async def test_shared_stacked_locations(context: StreamFlowContext) -> None:
             )
         )
         await context.deployment_manager.undeploy(param_config.name)
+
+
+@pytest.mark.asyncio
+async def test_parallel_in_memory(context: StreamFlowContext) -> None:
+    """
+    Verify that in-memory storage prevents parallel job scheduling.
+
+    Two jobs each need 300 MB effective (100 memory + 200 in_memory storage).
+    With 350 MB total, only one fits at a time. The first job runs, completes,
+    and the second can be scheduled.
+    """
+    num_jobs = 2
+    requirement = CWLHardwareRequirement(
+        cwl_version=CWL_VERSION,
+        cores=1,
+        memory=100,
+        tmpdir=100,
+        outdir=100,
+    )
+    inmemory_ctx = await _setup_hardware_test(
+        context,
+        num_jobs,
+        requirement,
+        memory=350.0,
+        storage=600.0,
+        inmemory=True,
+    )
+    path = None
+    try:
+        tasks = [
+            asyncio.create_task(
+                context.scheduler.schedule(
+                    job, inmemory_ctx.binding_config, inmemory_ctx.requirement
+                )
+            )
+            for job in inmemory_ctx.jobs
+        ]
+        done, pending = await asyncio.wait(
+            tasks, return_when=asyncio.FIRST_COMPLETED, timeout=60
+        )
+        assert len(done) == 1
+        for t in done:
+            assert t.result() is None
+        first_job = _get_scheduled_job(context=context, jobs=inmemory_ctx.jobs)
+        assert first_job is not None
+        second_job = next(j for j in inmemory_ctx.jobs if j is not first_job)
+
+        await context.scheduler.notify_status(first_job.name, Status.RUNNING)
+        path = StreamFlowPath(
+            first_job.output_directory,
+            "persistent.dat",
+            context=context,
+            location=inmemory_ctx.exec_location,
+        )
+        await path.write_text("\0" * (10 * 1024 * 1024))
+        await context.scheduler.notify_status(first_job.name, Status.COMPLETED)
+
+        done, _ = await asyncio.wait(pending, timeout=60)
+        assert len(done) == 1
+        assert (
+            context.scheduler.get_allocation(second_job.name).status == Status.FIREABLE
+        )
+    finally:
+        await _cleanup_hardware_test(
+            context=context,
+            deployment_name=inmemory_ctx.deployment_name,
+            jobs=inmemory_ctx.jobs,
+            paths=[path],
+        )
+
+
+@pytest.mark.asyncio
+async def test_residual_in_memory(context: StreamFlowContext) -> None:
+    """
+    Verify that residual in-memory files leak memory.
+
+    A job with in_memory storage writes a 50 MB file and completes.
+    The file persists on disk, consuming memory. A subsequent job needing
+    330 MB of memory should be blocked (only 300 MB free).
+    """
+    requirement = CWLHardwareRequirement(
+        cwl_version=CWL_VERSION,
+        cores=1,
+        memory=100,
+        tmpdir=50,
+        outdir=50,
+    )
+    inmemory_ctx = await _setup_hardware_test(
+        context,
+        2,
+        requirement,
+        memory=350.0,
+        storage=200.0,
+        inmemory=True,
+    )
+    path = None
+    try:
+        await context.scheduler.schedule(
+            inmemory_ctx.jobs[0], inmemory_ctx.binding_config, inmemory_ctx.requirement
+        )
+        first_job = _get_scheduled_job(context=context, jobs=inmemory_ctx.jobs[:1])
+        assert first_job is not None
+
+        await context.scheduler.notify_status(first_job.name, Status.RUNNING)
+        path = StreamFlowPath(
+            first_job.output_directory,
+            "persistent.dat",
+            context=context,
+            location=inmemory_ctx.exec_location,
+        )
+        await path.write_text("\0" * (50 * 1024 * 1024))
+        await context.scheduler.notify_status(first_job.name, Status.COMPLETED)
+
+        snd_hardware = CWLHardwareRequirement(
+            cwl_version=CWL_VERSION,
+            cores=1,
+            memory=330,
+            tmpdir=0,
+            outdir=0,
+        )
+        snd_job = inmemory_ctx.jobs[1]
+        snd_task = asyncio.create_task(
+            context.scheduler.schedule(
+                snd_job, inmemory_ctx.binding_config, snd_hardware
+            )
+        )
+        done, _ = await asyncio.wait([snd_task], timeout=5)
+        assert len(done) == 0
+        snd_task.cancel()
+        with pytest.raises(WorkflowExecutionException):
+            context.scheduler.get_allocation(snd_job.name)
+    finally:
+        await _cleanup_hardware_test(
+            context=context,
+            deployment_name=inmemory_ctx.deployment_name,
+            jobs=inmemory_ctx.jobs,
+            paths=[path],
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -131,6 +131,7 @@ async def _setup_hardware_test(
     memory: float,
     storage: float,
     job_dirs: MutableSequence[tuple[str | None, str | None, str | None]] | None = None,
+    inmemory: bool = False,
 ) -> _HardwareTestContext:
     with InjectPlugin(plugin_name="parameterizable-hardware"):
         config = get_parameterizable_hardware_deployment_config(name=random_name())
@@ -139,7 +140,7 @@ async def _setup_hardware_test(
             ParameterizableHardwareConnector,
             context.deployment_manager.get_connector(config.name),
         )
-        disk = Storage(mount_point=os.sep, size=storage)
+        disk = Storage(mount_point=os.sep, size=storage,  inmemory_usage=0.0 if inmemory else None)
         conn.set_hardware(
             hardware=Hardware(
                 cores=float(requirement.cores),


### PR DESCRIPTION
This commit explicitly handles in-memory FS mounts by considering them both as memory requirements and disk requirements. This improvement resolves issues due to StreamFlow skipping `tmpfs` and `ramfs` mounts, leading to unsatisfied requirements.