### PR TITLE
Fix double-counting of occupied disk space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix double-counting of occupied disk space ([#1103](https://github.com/alpha-unito/streamflow/pull/1103))
 - Fix NodeJS retrieval when Docker is unavailable ([#1054](https://github.com/alpha-unito/streamflow/pull/1054))
 - Fix permission propagation when transferring files between locations ([#1085](https://github.com/alpha-unito/streamflow/pull/1085))
 - Fix provenance of empty unbound inputs ([#968](https://github.com/alpha-unito/streamflow/pull/968))

--- a/streamflow/core/scheduling.py
+++ b/streamflow/core/scheduling.py
@@ -46,6 +46,8 @@ def _reduce_storages(
 
 
 class Hardware:
+    __slots__ = ("cores", "memory", "storage")
+
     def __init__(
         self,
         cores: float = 0.0,
@@ -147,10 +149,11 @@ class Hardware:
     def is_normalized(self) -> bool:
         return all(key == disk.mount_point for key, disk in self.storage.items())
 
-    def normalize(self) -> Self:
-        """Normalize the Hardware instance in-place."""
-        self.storage = self._normalize_storage()
-        return self
+    def normalized(self) -> Hardware:
+        """Get normalized Hardware instance."""
+        return Hardware(
+            cores=self.cores, memory=self.memory, storage=self._normalize_storage()
+        )
 
     def satisfies(self, other: Any) -> bool:
         """Check if this hardware has enough resources to satisfy the requirement."""

--- a/streamflow/core/scheduling.py
+++ b/streamflow/core/scheduling.py
@@ -74,24 +74,6 @@ class Hardware:
             os.sep: Storage(os.sep, 0.0)
         }
 
-    def _normalize_storage(self) -> MutableMapping[str, Storage]:
-        return _reduce_storages(self.storage.values(), Storage.__add__.__call__)
-
-    def get_mount_point(self, path: str) -> str:
-        return self.get_storage(path).mount_point
-
-    def get_mount_points(self) -> MutableSequence[str]:
-        return list({storage.mount_point for storage in self.storage.values()})
-
-    def get_size(self, path: str) -> float:
-        return self.get_storage(path).size
-
-    def get_storage(self, path: str) -> Storage:
-        for disk in self.storage.values():
-            if path == disk.mount_point or path in disk.paths:
-                return disk
-        raise KeyError(path)
-
     def __repr__(self) -> str:
         return f"Hardware(cores={self.cores}, memory={self.memory}, storage={self.storage})"
 
@@ -143,6 +125,32 @@ class Hardware:
                 Storage.__sub__.__call__,
             ),
         )
+
+    def _normalize_storage(self) -> MutableMapping[str, Storage]:
+        return _reduce_storages(self.storage.values(), Storage.__add__.__call__)
+
+    def get_mount_point(self, path: str) -> str:
+        return self.get_storage(path).mount_point
+
+    def get_mount_points(self) -> MutableSequence[str]:
+        return list({storage.mount_point for storage in self.storage.values()})
+
+    def get_size(self, path: str) -> float:
+        return self.get_storage(path).size
+
+    def get_storage(self, path: str) -> Storage:
+        for disk in self.storage.values():
+            if path == disk.mount_point or path in disk.paths:
+                return disk
+        raise KeyError(path)
+
+    def is_normalized(self) -> bool:
+        return all(key == disk.mount_point for key, disk in self.storage.items())
+
+    def normalize(self) -> Self:
+        """Normalize the Hardware instance in-place."""
+        self.storage = self._normalize_storage()
+        return self
 
     def satisfies(self, other: Any) -> bool:
         """Check if this hardware has enough resources to satisfy the requirement."""

--- a/streamflow/core/scheduling.py
+++ b/streamflow/core/scheduling.py
@@ -39,6 +39,7 @@ def _reduce_storages(
             storage[disk.mount_point] = Storage(
                 mount_point=disk.mount_point,
                 size=disk.size,
+                paths=disk.paths,
                 bind=disk.bind,
             )
     return storage

--- a/streamflow/data/utils.py
+++ b/streamflow/data/utils.py
@@ -26,14 +26,14 @@ async def bind_mount_point(
     :param context: the `StreamFlowContext` object with global application status.
     :param location: the `AvailableLocation` object of the location information
     :param hardware: the `Hardware` object with eventual binds to resolve
-    :return: a new `Hardware` object with the eventual bind in the storages resolved
+    :return: a new normalized `Hardware` object with the eventual bind in the storages resolved
     """
     path_processor = get_path_processor(location.location)
-    storage: dict[str, Storage] = {}
-    for key, disk in hardware.storage.items():
+    storages: dict[str, Storage] = {}
+    for disk in hardware.storage.values():
         if disk.bind is not None:
             mount_point = await get_mount_point(context, location, disk.bind)
-            storage[key] = Storage(
+            storage = Storage(
                 mount_point=mount_point,
                 size=disk.size,
                 paths={
@@ -46,7 +46,11 @@ async def bind_mount_point(
                     for p in disk.paths
                 },
             )
-    return Hardware(cores=hardware.cores, memory=hardware.memory, storage=storage)
+            if mount_point in storages:
+                storages[mount_point] += storage
+            else:
+                storages[mount_point] = storage
+    return Hardware(cores=hardware.cores, memory=hardware.memory, storage=storages)
 
 
 async def get_mount_point(

--- a/streamflow/data/utils.py
+++ b/streamflow/data/utils.py
@@ -30,23 +30,22 @@ async def bind_mount_point(
     """
     path_processor = get_path_processor(location.location)
     storage: dict[str, Storage] = {}
-    for disk in hardware.storage.values():
+    for key, disk in hardware.storage.items():
         if disk.bind is not None:
             mount_point = await get_mount_point(context, location, disk.bind)
-            if mount_point not in storage.keys():
-                storage[mount_point] = Storage(
-                    mount_point=mount_point,
-                    size=disk.size,
-                    paths={
-                        path_processor.normpath(
-                            path_processor.join(
-                                disk.bind,
-                                path_processor.relpath(p, disk.mount_point),
-                            )
+            storage[key] = Storage(
+                mount_point=mount_point,
+                size=disk.size,
+                paths={
+                    path_processor.normpath(
+                        path_processor.join(
+                            disk.bind,
+                            path_processor.relpath(p, disk.mount_point),
                         )
-                        for p in disk.paths
-                    },
-                )
+                    )
+                    for p in disk.paths
+                },
+            )
     return Hardware(cores=hardware.cores, memory=hardware.memory, storage=storage)
 
 

--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -137,18 +137,19 @@ class DefaultScheduler(Scheduler):
             for loc in locations:
                 if loc.name in self.hardware_locations.keys():
                     try:
+                        job_norm_hw = Hardware() + job_hardware
                         storage_usage = Hardware(
                             storage=(
                                 {
                                     k: Storage(
-                                        mount_point=job_hardware.storage[k].mount_point,
+                                        mount_point=job_norm_hw.storage[k].mount_point,
                                         size=size / 2**20,
                                     )
                                     for k, size in (
                                         await remotepath.get_storage_usages(
                                             self.context,
                                             loc,
-                                            job_hardware,
+                                            job_norm_hw,
                                         )
                                     ).items()
                                 }

--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -123,7 +123,7 @@ class DefaultScheduler(Scheduler):
                         self.hardware_locations[loc.name] += hardware[key]
                     else:
                         # Normalized hardware for the hardware location
-                        self.hardware_locations[loc.name] = hardware[key].normalize()
+                        self.hardware_locations[loc.name] = hardware[key].normalized()
                 if loc := loc.wraps if loc.stacked else None:
                     conn = cast(ConnectorWrapper, conn).connector
 
@@ -135,7 +135,7 @@ class DefaultScheduler(Scheduler):
         job_hardware = job_allocation.hardware
         while locations:
             if not job_hardware.is_normalized():
-                job_hardware.normalize()
+                job_hardware = job_hardware.normalized()
             for loc in locations:
                 if loc.name in self.hardware_locations.keys():
                     try:

--- a/streamflow/scheduling/scheduler.py
+++ b/streamflow/scheduling/scheduler.py
@@ -122,8 +122,8 @@ class DefaultScheduler(Scheduler):
                     if loc.name in self.hardware_locations.keys():
                         self.hardware_locations[loc.name] += hardware[key]
                     else:
-                        # Get normalized hardware for the hardware location
-                        self.hardware_locations[loc.name] = Hardware() + hardware[key]
+                        # Normalized hardware for the hardware location
+                        self.hardware_locations[loc.name] = hardware[key].normalize()
                 if loc := loc.wraps if loc.stacked else None:
                     conn = cast(ConnectorWrapper, conn).connector
 
@@ -134,22 +134,23 @@ class DefaultScheduler(Scheduler):
         locations = job_allocation.locations
         job_hardware = job_allocation.hardware
         while locations:
+            if not job_hardware.is_normalized():
+                job_hardware.normalize()
             for loc in locations:
                 if loc.name in self.hardware_locations.keys():
                     try:
-                        job_norm_hw = Hardware() + job_hardware
                         storage_usage = Hardware(
                             storage=(
                                 {
                                     k: Storage(
-                                        mount_point=job_norm_hw.storage[k].mount_point,
+                                        mount_point=job_hardware.storage[k].mount_point,
                                         size=size / 2**20,
                                     )
                                     for k, size in (
                                         await remotepath.get_storage_usages(
                                             self.context,
                                             loc,
-                                            job_norm_hw,
+                                            job_hardware,
                                         )
                                     ).items()
                                 }

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -290,34 +290,38 @@ async def test_bind_volumes(
     mount_point = await utils.get_mount_point(
         context, container_location, container_path
     )
-    container_hardware = await utils.bind_mount_point(
-        context,
-        local_location,
-        Hardware(
-            cores=float(1),
-            memory=float(100),
-            storage={
-                key: Storage(
-                    mount_point=mount_point,
-                    size=float(100),
-                    paths={container_path},
-                    bind=container_location.hardware.get_storage(mount_point).bind,
-                )
-                for key in ["tmpdir", "workdir"]
-            },
-        ),
+    container_hardware = Hardware(
+        cores=float(1),
+        memory=float(100),
+        storage={
+            key: Storage(
+                mount_point=mount_point,
+                size=float(100),
+                paths={container_path},
+                bind=container_location.hardware.get_storage(mount_point).bind,
+            )
+            for key in ["tmpdir", "workdir"]
+        },
     )
-    # The target paths are all mounted to the same host path. So they collapse to the same mount point
+    assert (
+        len(container_hardware.storage) == 2 and not container_hardware.is_normalized()
+    )
+    container_hardware.normalize()
+    assert len(container_hardware.storage) == 1 and container_hardware.is_normalized()
+    bound_hardware = await utils.bind_mount_point(
+        context, local_location, container_hardware
+    )
+    # The target paths are all mounted to the same host path
     assert (
         local_deployment.workdir is not None
-        and len(container_hardware.storage) == 1
-        and next(iter(container_hardware.storage.values())).mount_point
+        and len(bound_hardware.storage) == 1
+        and next(iter(bound_hardware.storage.values())).mount_point
         == await utils.get_mount_point(
             context, local_location, local_deployment.workdir
         )
     )
     assert local_location.hardware is not None and local_location.hardware.satisfies(
-        container_hardware
+        bound_hardware
     )
 
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -40,10 +40,10 @@ from tests.utils.workflow import CWL_VERSION, random_job_name
 
 class _HardwareTestContext(NamedTuple):
     binding_config: BindingConfig
-    requirement: CWLHardwareRequirement
-    jobs: MutableSequence[Job]
+    deployment_name: str
     exec_location: ExecutionLocation
-    config_name: str
+    jobs: MutableSequence[Job]
+    requirement: CWLHardwareRequirement
 
 
 async def _cleanup_hardware_test(
@@ -132,13 +132,12 @@ async def _setup_hardware_test(
     storage: float,
     job_dirs: MutableSequence[tuple[str | None, str | None, str | None]] | None = None,
 ) -> _HardwareTestContext:
-    config_name = random_name()
     with InjectPlugin(plugin_name="parameterizable-hardware"):
-        config = get_parameterizable_hardware_deployment_config(name=config_name)
+        config = get_parameterizable_hardware_deployment_config(name=random_name())
         await context.deployment_manager.deploy(config)
         conn = cast(
             ParameterizableHardwareConnector,
-            context.deployment_manager.get_connector(config_name),
+            context.deployment_manager.get_connector(config.name),
         )
         disk = Storage(mount_point=os.sep, size=storage)
         conn.set_hardware(
@@ -148,7 +147,7 @@ async def _setup_hardware_test(
                 storage={os.sep: disk},
             )
         )
-    param_config = get_parameterizable_hardware_deployment_config(name=config_name)
+    param_config = get_parameterizable_hardware_deployment_config(name=config.name)
     target = Target(
         deployment=param_config,
         service=get_service(context, param_config.type),
@@ -200,10 +199,10 @@ async def _setup_hardware_test(
         )
     return _HardwareTestContext(
         binding_config=BindingConfig(targets=[target]),
-        requirement=requirement,
-        jobs=jobs,
+        deployment_name=config.name,
         exec_location=exec_location,
-        config_name=config.name,
+        jobs=jobs,
+        requirement=requirement,
     )
 
 
@@ -234,10 +233,11 @@ async def test_bind_volumes(
     local_deployment = get_local_deployment_config()
     service = get_service(context, local_deployment.type)
     local_connector = context.deployment_manager.get_connector(local_deployment.name)
-    assert local_connector is not None
+    assert local_connector is not None and local_deployment.workdir is not None
     local_location = next(
         iter((await local_connector.get_available_locations(service=service)).values())
     )
+    assert local_location.hardware is not None
 
     # Get container deployment
     container_paths = {
@@ -290,7 +290,7 @@ async def test_bind_volumes(
     mount_point = await utils.get_mount_point(
         context, container_location, container_path
     )
-    container_hardware = Hardware(
+    fake_hardware = Hardware(
         cores=float(1),
         memory=float(100),
         storage={
@@ -303,26 +303,24 @@ async def test_bind_volumes(
             for key in ["tmpdir", "workdir"]
         },
     )
-    assert (
-        len(container_hardware.storage) == 2 and not container_hardware.is_normalized()
+    assert not fake_hardware.is_normalized()
+    container_hardware = await utils.bind_mount_point(
+        context, local_location, fake_hardware
     )
-    container_hardware.normalize()
-    assert len(container_hardware.storage) == 1 and container_hardware.is_normalized()
-    bound_hardware = await utils.bind_mount_point(
-        context, local_location, container_hardware
+    assert (
+        container_hardware.is_normalized()
+        and len(container_hardware.storage) == 1
+        and len(fake_hardware.storage) == 2
+        and next(iter(container_hardware.storage.values())).size
+        == sum(s.size for s in fake_hardware.storage.values())
     )
     # The target paths are all mounted to the same host path
-    assert (
-        local_deployment.workdir is not None
-        and len(bound_hardware.storage) == 1
-        and next(iter(bound_hardware.storage.values())).mount_point
-        == await utils.get_mount_point(
-            context, local_location, local_deployment.workdir
-        )
+    assert next(
+        iter(container_hardware.storage.values())
+    ).mount_point == await utils.get_mount_point(
+        context, local_location, local_deployment.workdir
     )
-    assert local_location.hardware is not None and local_location.hardware.satisfies(
-        bound_hardware
-    )
+    assert local_location.hardware.satisfies(container_hardware)
 
 
 @pytest.mark.asyncio
@@ -400,6 +398,7 @@ def test_hardware() -> None:
             ),
         },
     )
+    assert not main_hardware.is_normalized()
     extra_hardware = Hardware(
         cores=float(5),
         storage={
@@ -407,6 +406,7 @@ def test_hardware() -> None:
         },
     )
     secondary_hardware = main_hardware + extra_hardware
+    assert secondary_hardware.is_normalized()
     assert secondary_hardware.cores == main_hardware.cores + extra_hardware.cores
     assert secondary_hardware.memory == main_hardware.memory
     # Secondary hardware after the sum operation has the storage keys in the normalized form
@@ -1008,7 +1008,7 @@ async def test_disk_usage(context: StreamFlowContext) -> None:
     finally:
         await _cleanup_hardware_test(
             context=context,
-            deployment_name=hw_ctx.config_name,
+            deployment_name=hw_ctx.deployment_name,
             jobs=hw_ctx.jobs,
             paths=[out_file, out_file2],
         )

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import os
 from collections.abc import Callable, MutableSequence
-from typing import cast
+from typing import NamedTuple, cast
 
 import pytest
 import pytest_asyncio
@@ -12,6 +12,7 @@ from streamflow.core.config import BindingConfig
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.deployment import (
     DeploymentConfig,
+    ExecutionLocation,
     FilterConfig,
     LocalTarget,
     Target,
@@ -19,9 +20,11 @@ from streamflow.core.deployment import (
 )
 from streamflow.core.exception import WorkflowExecutionException
 from streamflow.core.scheduling import Hardware, Storage
+from streamflow.core.utils import get_job_step_name, random_name
 from streamflow.core.workflow import Job, Status
 from streamflow.cwl.hardware import CWLHardwareRequirement
 from streamflow.data import utils
+from streamflow.data.remotepath import StreamFlowPath
 from streamflow.deployment.connector import DockerConnector, SingularityConnector
 from tests.utils.connector import ParameterizableHardwareConnector
 from tests.utils.deployment import (
@@ -33,6 +36,45 @@ from tests.utils.deployment import (
 )
 from tests.utils.utils import InjectPlugin
 from tests.utils.workflow import CWL_VERSION, random_job_name
+
+
+class _HardwareTestContext(NamedTuple):
+    binding_config: BindingConfig
+    requirement: CWLHardwareRequirement
+    jobs: MutableSequence[Job]
+    exec_location: ExecutionLocation
+    config_name: str
+
+
+async def _cleanup_hardware_test(
+    context: StreamFlowContext,
+    deployment_name: str,
+    jobs: MutableSequence[Job],
+    paths: MutableSequence[StreamFlowPath | None] | None = None,
+) -> None:
+    for j in jobs:
+        try:
+            if context.scheduler.get_allocation(j.name).status != Status.COMPLETED:
+                await context.scheduler.notify_status(j.name, Status.COMPLETED)
+        except WorkflowExecutionException:
+            pass
+    await context.scheduler.context.deployment_manager.undeploy(deployment_name)
+    if paths is not None:
+        await asyncio.gather(
+            *(asyncio.create_task(path.rmtree()) for path in paths if path is not None)
+        )
+
+
+def _get_scheduled_job(
+    context: StreamFlowContext, jobs: MutableSequence[Job]
+) -> Job | None:
+    for job in jobs:
+        try:
+            context.scheduler.get_allocation(job.name)
+            return job
+        except WorkflowExecutionException:
+            continue
+    return None
 
 
 async def _notify_status_and_test(
@@ -47,6 +89,7 @@ async def _notify_status_and_test(
 
 def _prepare_connector(
     context: StreamFlowContext,
+    deployment_name: str,
     location_memory: Callable[[float], float] | None = None,
     num_jobs: int = 1,
 ) -> tuple[CWLHardwareRequirement, Target]:
@@ -54,12 +97,12 @@ def _prepare_connector(
     hardware_requirement = CWLHardwareRequirement(cwl_version=CWL_VERSION)
     conn = cast(
         ParameterizableHardwareConnector,
-        context.deployment_manager.get_connector("custom-hardware"),
+        context.deployment_manager.get_connector(deployment_name),
     )
     conn.set_hardware(
         hardware=Hardware(
-            cores=hardware_requirement.cores * num_jobs,
-            memory=(
+            cores=float(hardware_requirement.cores * num_jobs),
+            memory=float(
                 location_memory(hardware_requirement.memory)
                 if location_memory
                 else hardware_requirement.memory * num_jobs
@@ -67,17 +110,100 @@ def _prepare_connector(
             storage={
                 os.sep: Storage(
                     os.sep,
-                    hardware_requirement.tmpdir * num_jobs
-                    + hardware_requirement.outdir * num_jobs,
+                    float(hardware_requirement.tmpdir * num_jobs)
+                    + float(hardware_requirement.outdir * num_jobs),
                 )
             },
         )
     )
-    param_config = get_parameterizable_hardware_deployment_config()
+    param_config = get_parameterizable_hardware_deployment_config(name=deployment_name)
     return hardware_requirement, Target(
         deployment=param_config,
         service=get_service(context, param_config.type),
         workdir=param_config.workdir,
+    )
+
+
+async def _setup_hardware_test(
+    context: StreamFlowContext,
+    num_jobs: int,
+    requirement: CWLHardwareRequirement,
+    memory: float,
+    storage: float,
+    job_dirs: MutableSequence[tuple[str | None, str | None, str | None]] | None = None,
+) -> _HardwareTestContext:
+    config_name = random_name()
+    with InjectPlugin(plugin_name="parameterizable-hardware"):
+        config = get_parameterizable_hardware_deployment_config(name=config_name)
+        await context.deployment_manager.deploy(config)
+        conn = cast(
+            ParameterizableHardwareConnector,
+            context.deployment_manager.get_connector(config_name),
+        )
+        disk = Storage(mount_point=os.sep, size=storage)
+        conn.set_hardware(
+            hardware=Hardware(
+                cores=float(requirement.cores),
+                memory=memory,
+                storage={os.sep: disk},
+            )
+        )
+    param_config = get_parameterizable_hardware_deployment_config(name=config_name)
+    target = Target(
+        deployment=param_config,
+        service=get_service(context, param_config.type),
+        workdir=param_config.workdir,
+    )
+    exec_location = next(
+        iter(
+            (
+                await conn.get_available_locations(
+                    service=get_service(context, param_config.type)
+                )
+            ).values()
+        )
+    ).location
+    jobs = []
+    for i in range(num_jobs):
+        job_name = random_job_name()
+        if job_dirs is not None and i < len(job_dirs):
+            in_dir, out_dir, tmp_dir = job_dirs[i]
+        else:
+            for d in ("input", "output", "tmp"):
+                await StreamFlowPath(
+                    param_config.workdir,
+                    f"{get_job_step_name(job_name).lstrip(os.sep)}-{d}-{i}",
+                    context=context,
+                    location=exec_location,
+                ).mkdir(parents=True, exist_ok=True)
+            in_dir = os.path.join(
+                param_config.workdir,
+                f"{get_job_step_name(job_name).lstrip(os.sep)}-input-{i}",
+            )
+            out_dir = os.path.join(
+                param_config.workdir,
+                f"{get_job_step_name(job_name).lstrip(os.sep)}-output-{i}",
+            )
+            tmp_dir = os.path.join(
+                param_config.workdir,
+                f"{get_job_step_name(job_name).lstrip(os.sep)}-tmp-{i}",
+            )
+        jobs.append(
+            Job(
+                name=job_name,
+                workflow_id=0,
+                inputs={},
+                input_directory=in_dir,
+                output_directory=out_dir,
+                tmp_directory=tmp_dir,
+            )
+        )
+    return _HardwareTestContext(
+        binding_config=BindingConfig(targets=[target]),
+        requirement=requirement,
+        jobs=jobs,
+        exec_location=exec_location,
+        config_name=config.name,
     )
 
 
@@ -108,6 +234,7 @@ async def test_bind_volumes(
     local_deployment = get_local_deployment_config()
     service = get_service(context, local_deployment.type)
     local_connector = context.deployment_manager.get_connector(local_deployment.name)
+    assert local_connector is not None
     local_location = next(
         iter((await local_connector.get_available_locations(service=service)).values())
     )
@@ -125,9 +252,11 @@ async def test_bind_volumes(
         context, container_deployment_name
     )
     service = get_service(context, container_deployment.type)
-    container_connector = context.deployment_manager.get_connector(
-        container_deployment.name
-    )
+    assert (
+        container_connector := context.deployment_manager.get_connector(
+            container_deployment.name
+        )
+    ) is not None
     container_location = next(
         iter(
             (
@@ -153,8 +282,11 @@ async def test_bind_volumes(
             )
         )
 
-    assert not container_paths - container_location.hardware.storage.keys()
-    container_path = container_deployment.workdir
+    assert (
+        container_location.hardware is not None
+        and not container_paths - container_location.hardware.storage.keys()
+    )
+    assert (container_path := container_deployment.workdir) is not None
     mount_point = await utils.get_mount_point(
         context, container_location, container_path
     )
@@ -176,12 +308,17 @@ async def test_bind_volumes(
         ),
     )
     # The target paths are all mounted to the same host path. So they collapse to the same mount point
-    assert len(container_hardware.storage) == 1 and next(
-        iter(container_hardware.storage.values())
-    ).mount_point == await utils.get_mount_point(
-        context, local_location, local_deployment.workdir
+    assert (
+        local_deployment.workdir is not None
+        and len(container_hardware.storage) == 1
+        and next(iter(container_hardware.storage.values())).mount_point
+        == await utils.get_mount_point(
+            context, local_location, local_deployment.workdir
+        )
     )
-    assert local_location.hardware.satisfies(container_hardware)
+    assert local_location.hardware is not None and local_location.hardware.satisfies(
+        container_hardware
+    )
 
 
 @pytest.mark.asyncio
@@ -207,7 +344,6 @@ async def test_binding_filter(
         service=get_service(context, docker_config.type),
         workdir=docker_config.workdir,
     )
-
     filter_config = FilterConfig(name="reverse-filter", type="reverse", config={})
     binding_config = BindingConfig(
         targets=[local_target, docker_target], filters=[filter_config]
@@ -317,9 +453,11 @@ async def test_multi_env(
         if deployment not in chosen_deployment_types:
             pytest.skip(f"Deployment {deployment} was not activated")
     with InjectPlugin(plugin_name="parameterizable-hardware"):
-        config = await get_deployment_config(context, "parameterizable-hardware")
+        config = get_parameterizable_hardware_deployment_config(name=random_name())
         await context.deployment_manager.deploy(config)
-        hardware_requirement, target = _prepare_connector(context)
+        hardware_requirement, target = _prepare_connector(
+            context=context, deployment_name=config.name
+        )
     docker_config = get_docker_deployment_config()
     docker_target = Target(
         deployment=docker_config,
@@ -372,9 +510,11 @@ async def test_multi_targets_one_job(
         if deployment not in chosen_deployment_types:
             pytest.skip(f"Deployment {deployment} was not activated")
     with InjectPlugin(plugin_name="parameterizable-hardware"):
-        config = await get_deployment_config(context, "parameterizable-hardware")
+        config = get_parameterizable_hardware_deployment_config(name=random_name())
         await context.deployment_manager.deploy(config)
-        hardware_requirement, target = _prepare_connector(context)
+        hardware_requirement, target = _prepare_connector(
+            context=context, deployment_name=config.name
+        )
     # Create fake job with two targets and schedule it
     job = Job(
         name=random_job_name(),
@@ -432,9 +572,11 @@ async def test_multi_targets_two_jobs(
         if deployment not in chosen_deployment_types:
             pytest.skip(f"Deployment {deployment} was not activated")
     with InjectPlugin(plugin_name="parameterizable-hardware"):
-        config = await get_deployment_config(context, "parameterizable-hardware")
+        config = get_parameterizable_hardware_deployment_config(name=random_name())
         await context.deployment_manager.deploy(config)
-        hardware_requirement, target = _prepare_connector(context)
+        hardware_requirement, target = _prepare_connector(
+            context=context, deployment_name=config.name
+        )
     # Create fake jobs with two same targets and schedule them
     jobs = [
         Job(
@@ -516,9 +658,11 @@ async def test_single_env_enough_resources(context: StreamFlowContext) -> None:
     """Test scheduling two jobs on a single environment with resources for all jobs together."""
     num_jobs = 2
     with InjectPlugin(plugin_name="parameterizable-hardware"):
-        config = await get_deployment_config(context, "parameterizable-hardware")
+        config = get_parameterizable_hardware_deployment_config(name=random_name())
         await context.deployment_manager.deploy(config)
-        hardware_requirement, target = _prepare_connector(context, num_jobs=num_jobs)
+        hardware_requirement, target = _prepare_connector(
+            context=context, deployment_name=config.name, num_jobs=num_jobs
+        )
     # Create fake jobs and schedule them
     jobs = [
         Job(
@@ -574,10 +718,12 @@ async def test_single_env_few_resources(context: StreamFlowContext) -> None:
     """Test scheduling two jobs on single environment but with resources for one job at a time."""
     num_jobs = 2
     with InjectPlugin(plugin_name="parameterizable-hardware"):
-        config = await get_deployment_config(context, "parameterizable-hardware")
+        config = get_parameterizable_hardware_deployment_config(name=random_name())
         await context.deployment_manager.deploy(config)
         hardware_requirement, target = _prepare_connector(
-            context, location_memory=lambda x: x * num_jobs * 3
+            context=context,
+            deployment_name=config.name,
+            location_memory=lambda x: x * num_jobs * 3,
         )
     # Create fake jobs and schedule them
     jobs = [
@@ -662,9 +808,13 @@ async def test_shared_stacked_locations(context: StreamFlowContext) -> None:
     """
     num_jobs = 2
     with InjectPlugin(plugin_name="parameterizable-hardware"):
-        param_config = await get_deployment_config(context, "parameterizable-hardware")
+        param_config = get_parameterizable_hardware_deployment_config(
+            name=random_name()
+        )
         await context.deployment_manager.deploy(param_config)
-        _prepare_connector(context, num_jobs=1)
+        _prepare_connector(
+            context=context, deployment_name=param_config.name, num_jobs=1
+        )
     hardware_requirement = CWLHardwareRequirement(cwl_version=CWL_VERSION)
 
     targets = []
@@ -781,3 +931,80 @@ async def test_shared_stacked_locations(context: StreamFlowContext) -> None:
             )
         )
         await context.deployment_manager.undeploy(param_config.name)
+
+
+@pytest.mark.asyncio
+async def test_disk_usage(context: StreamFlowContext) -> None:
+    """
+    Verify that the scheduler correctly tracks disk usage across multiple jobs.
+    Jobs fill available storage until the last one is left pending because no space remains.
+    """
+    requirement = CWLHardwareRequirement(
+        cwl_version=CWL_VERSION,
+        cores=1,
+        memory=100,
+        tmpdir=25,
+        outdir=25,
+    )
+    hw_ctx = await _setup_hardware_test(
+        context,
+        num_jobs=3,
+        requirement=requirement,
+        memory=1000.0,
+        storage=100.0,
+        job_dirs=[(None, None, None)],
+    )
+    out_file, out_file2 = None, None
+    try:
+        await context.scheduler.schedule(
+            hw_ctx.jobs[0], hw_ctx.binding_config, hw_ctx.requirement
+        )
+        first_job = _get_scheduled_job(context=context, jobs=hw_ctx.jobs[:1])
+        assert first_job is not None
+        await context.scheduler.notify_status(first_job.name, Status.RUNNING)
+        out_file = StreamFlowPath(
+            hw_ctx.binding_config.targets[0].workdir,
+            "out.dat",
+            context=context,
+            location=hw_ctx.exec_location,
+        )
+        await out_file.write_text("\0" * (30 * 1024 * 1024))
+        await context.scheduler.notify_status(first_job.name, Status.COMPLETED)
+
+        task = asyncio.create_task(
+            context.scheduler.schedule(
+                hw_ctx.jobs[1], hw_ctx.binding_config, hw_ctx.requirement
+            )
+        )
+        done, _ = await asyncio.wait([task], timeout=5)
+        assert len(done) == 1
+        task.cancel()
+        second_job = _get_scheduled_job(context=context, jobs=hw_ctx.jobs[1:2])
+        assert second_job is not None
+        await context.scheduler.notify_status(second_job.name, Status.RUNNING)
+        out_file2 = StreamFlowPath(
+            second_job.output_directory,
+            "out.dat",
+            context=context,
+            location=hw_ctx.exec_location,
+        )
+        await out_file2.write_text("\0" * (70 * 1024 * 1024))
+        await context.scheduler.notify_status(second_job.name, Status.COMPLETED)
+
+        task = asyncio.create_task(
+            context.scheduler.schedule(
+                hw_ctx.jobs[2], hw_ctx.binding_config, hw_ctx.requirement
+            )
+        )
+        done, _ = await asyncio.wait([task], timeout=5)
+        assert len(done) == 0
+        task.cancel()
+        with pytest.raises(WorkflowExecutionException):
+            context.scheduler.get_allocation(hw_ctx.jobs[2].name)
+    finally:
+        await _cleanup_hardware_test(
+            context=context,
+            deployment_name=hw_ctx.config_name,
+            jobs=hw_ctx.jobs,
+            paths=[out_file, out_file2],
+        )

--- a/tests/utils/connector.py
+++ b/tests/utils/connector.py
@@ -308,11 +308,12 @@ class ParameterizableHardwareConnector(LocalConnector):
         self, service: str | None = None
     ) -> MutableMapping[str, AvailableLocation]:
         return {
-            "custom-hardware": AvailableLocation(
-                name="custom-hardware",
+            self.deployment_name: AvailableLocation(
+                name=self.deployment_name,
                 deployment=self.deployment_name,
                 service=service,
                 hostname="localhost",
+                local=True,
                 slots=1,
                 hardware=self.hardware,
             )

--- a/tests/utils/deployment.py
+++ b/tests/utils/deployment.py
@@ -241,13 +241,15 @@ async def get_location(
     return next(iter(locations.values())).location
 
 
-def get_parameterizable_hardware_deployment_config() -> DeploymentConfig:
+def get_parameterizable_hardware_deployment_config(
+    name: str = "custom-hardware",
+) -> DeploymentConfig:
     workdir = os.path.join(
         os.path.realpath(tempfile.gettempdir()), "streamflow-test", random_name()
     )
     os.makedirs(workdir, exist_ok=True)
     return DeploymentConfig(
-        name="custom-hardware",
+        name=name,
         type="parameterizable-hardware",
         config={},
         external=True,


### PR DESCRIPTION
This commit fixes the double-counting of occupied disk space when a job releases its resources. The issue arises when the `Job` instance uses the same directory for its output and tmp directories. In the current implementation, this can happen when the `Job` instance has no explicit values in its `input`, `output`, or `tmp` directory attributes, and the `target` workdir is used for all of them. Added new test.

Additionally, this commit fixes the behavior of the `bind_mount_point` method, which was collapsing `Storage` without following the correct logic, leading to missing `Storage` info. Improved `test_bind_volumes`.