### PR TITLE
Fix `expand_glob` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `expand_glob` function ([#1136](https://github.com/alpha-unito/streamflow/pull/1136))
 - Fix double-counting of occupied disk space ([#1103](https://github.com/alpha-unito/streamflow/pull/1103))
 - Fix NodeJS retrieval when Docker is unavailable ([#1054](https://github.com/alpha-unito/streamflow/pull/1054))
 - Fix permission propagation when transferring files between locations ([#1085](https://github.com/alpha-unito/streamflow/pull/1085))

--- a/streamflow/cwl/processor.py
+++ b/streamflow/cwl/processor.py
@@ -523,7 +523,9 @@ class CWLCommandOutputProcessor(CommandOutputProcessor):
                     else glob
                 )
                 globpaths.extend(
-                    globpath if isinstance(globpath, MutableSequence) else [globpath]
+                    (str(g) for g in globpath)
+                    if isinstance(globpath, MutableSequence)
+                    else (str(globpath),)
                 )
             # Resolve glob
             location_globpaths: MutableMapping[str, list[MutableMapping[str, Any]]] = {}

--- a/streamflow/cwl/utils.py
+++ b/streamflow/cwl/utils.py
@@ -765,10 +765,16 @@ async def expand_glob(
     tmp_directory: str,
     path: str,
 ) -> MutableSequence[tuple[str, str]]:
-    outdir = StreamFlowPath(
-        output_directory, context=workflow.context, location=location
+    paths = sorted(
+        [
+            p
+            async for p in StreamFlowPath(
+                os.path.dirname(path) if os.path.isabs(path) else output_directory,
+                context=workflow.context,
+                location=location,
+            ).glob(os.path.basename(path) if os.path.isabs(path) else path)
+        ]
     )
-    paths = sorted([p async for p in outdir.glob(path)])
     effective_paths = await asyncio.gather(
         *(asyncio.create_task(p.resolve()) for p in paths)
     )

--- a/streamflow/data/remotepath.py
+++ b/streamflow/data/remotepath.py
@@ -366,6 +366,14 @@ class LocalStreamFlowPath(
     async def glob(
         self, pattern: str, *, case_sensitive: bool | None = None
     ) -> AsyncIterator[LocalStreamFlowPath]:
+        if not pattern:
+            raise WorkflowExecutionException(
+                f"Path `{self}`: Unacceptable pattern {pattern!r}"
+            )
+        if (ppattern := PurePath(pattern)).drive or ppattern.root:
+            raise WorkflowExecutionException(
+                f"Path `{self}`: Non-relative pattern {pattern!r} is unsupported"
+            )
         for path in glob.glob(str(self / pattern)):
             yield self.with_segments(path)
 
@@ -656,7 +664,13 @@ class RemoteStreamFlowPath(
                 )
         else:
             if not pattern:
-                raise ValueError(f"Unacceptable pattern: {pattern!r}")
+                raise WorkflowExecutionException(
+                    f"Path `{self}`: Unacceptable pattern {pattern!r}"
+                )
+            if (ppattern := PurePath(pattern)).drive or ppattern.root:
+                raise WorkflowExecutionException(
+                    f"Path `{self}`: Non-relative pattern {pattern!r} is unsupported"
+                )
             command = [
                 "set",
                 "--",

--- a/tests/test_remotepath.py
+++ b/tests/test_remotepath.py
@@ -172,6 +172,17 @@ async def test_glob(
         result = [p async for p in path.glob("*/*.txt")]
         assert len(result) == 1
         assert path / "dir1" / "file1.txt" in result
+        # Test empty pattern argument
+        with pytest.raises(WorkflowExecutionException):
+            _ = [p async for p in path.glob("")]
+        # Test full path as pattern argument
+        with pytest.raises(WorkflowExecutionException):
+            _ = [
+                p
+                async for p in path.glob(
+                    tempfile.gettempdir() if location.local else "/tmp"
+                )
+            ]
     finally:
         await path.rmtree()
 


### PR DESCRIPTION
This commit fixes the `expand_glob` function and `glob` methods of `StreamFlowPath` subclasses.

Before this commit, the `glob` method accepted a full path as the `pattern` argument, but concatenating two full paths caused incorrect behavior, in particular during remote execution.

Now, a check verifies whether the `pattern` is a full path inside the `glob` methods, raising an error message if so. Additionally, the case where a full path is passed to `expand_glob` is handled before calling the `StreamFlowPath.glob` method.

Finally, the `globpath` variable inside the `_process_command_output` method could contain non-string values; these elements are now cast to strings.